### PR TITLE
Stored Procedures

### DIFF
--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;certificate file=.ci/server/ssl-client.pfx;use compression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;UseCompression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;certificate file=.ci/server/ssl-client.pfx;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=./.ci/mysqld/mysqld.sock;user id=ssltest;password=test;database=mysqltest;ssl mode=required;certificate file=.ci/server/ssl-client.pfx;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }

--- a/.ci/config/config.uds.json
+++ b/.ci/config/config.uds.json
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=./.ci/mysqld/mysqld.sock;user id=mysqltest;password='test;key=\"val';database=mysqltest;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }

--- a/src/MySqlConnector/MySqlClient/Caches/CachedParameter.cs
+++ b/src/MySqlConnector/MySqlClient/Caches/CachedParameter.cs
@@ -1,0 +1,40 @@
+﻿using System.Data;
+using System.Linq;
+using MySql.Data.MySqlClient.Types;
+
+namespace MySql.Data.MySqlClient.Caches
+{
+	internal class CachedParameter
+	{
+		public CachedParameter(int ordinalPosition, string mode, string name, string dataType, bool unsigned)
+		{
+			Position = ordinalPosition;
+			if (Position == 0)
+			{
+				Direction = ParameterDirection.ReturnValue;
+			}
+			else
+			{
+				switch (mode.ToLowerInvariant())
+				{
+					case "in":
+						Direction = ParameterDirection.Input;
+						break;
+					case "inout":
+						Direction = ParameterDirection.InputOutput;
+						break;
+					case "out":
+						Direction = ParameterDirection.Output;
+						break;
+				}
+			}
+			Name = name;
+			DbType = TypeMapper.Mapper.GetDbTypeMapping(dataType, unsigned).DbTypes?.First() ?? DbType.Object;
+		}
+
+		internal readonly int Position;
+		internal readonly ParameterDirection Direction;
+		internal readonly string Name;
+		internal readonly DbType DbType;
+	}
+}

--- a/src/MySqlConnector/MySqlClient/Caches/CachedProcedure.cs
+++ b/src/MySqlConnector/MySqlClient/Caches/CachedProcedure.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.Protocol.Serialization;
+
+namespace MySql.Data.MySqlClient.Caches
+{
+	internal class CachedProcedure
+	{
+		internal static async Task<CachedProcedure> FillAsync(IOBehavior ioBehavior, MySqlConnection connection, string schema, string component, CancellationToken cancellationToken)
+		{
+			var cmd = (MySqlCommand) connection.CreateCommand();
+
+			cmd.CommandText = @"SELECT ORDINAL_POSITION, PARAMETER_MODE, PARAMETER_NAME, DATA_TYPE, DTD_IDENTIFIER
+				FROM information_schema.parameters
+				WHERE SPECIFIC_SCHEMA = @schema AND SPECIFIC_NAME = @component
+				ORDER BY ORDINAL_POSITION";
+			cmd.Parameters.Add(new MySqlParameter
+			{
+				ParameterName = "@schema",
+				DbType = DbType.String,
+				Value = schema
+			});
+			cmd.Parameters.Add(new MySqlParameter
+			{
+				ParameterName = "@component",
+				DbType = DbType.String,
+				Value = component
+			});
+
+			var parameters = new List<CachedParameter>();
+			using (var reader = (MySqlDataReader) await cmd.ExecuteReaderAsync(CommandBehavior.Default, ioBehavior, cancellationToken).ConfigureAwait(false))
+			{
+				while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+				{
+					parameters.Add(new CachedParameter(
+						reader.GetInt32(0),
+						!reader.IsDBNull(1) ? reader.GetString(1) : null,
+						!reader.IsDBNull(2) ? reader.GetString(2) : null,
+						reader.GetString(3),
+						reader.GetString(4).IndexOf("unsigned", StringComparison.OrdinalIgnoreCase) != -1
+					));
+				}
+			}
+
+			return new CachedProcedure(schema, component, parameters.AsReadOnly());
+		}
+
+		protected CachedProcedure(string schema, string component, ReadOnlyCollection<CachedParameter> parameters)
+		{
+			m_schema = schema;
+			m_component = component;
+			m_parameters = parameters;
+		}
+
+		internal MySqlParameterCollection AlignParamsWithDb(MySqlParameterCollection parameterCollection)
+		{
+			var alignedParams = new MySqlParameterCollection();
+			var returnParam = parameterCollection.FirstOrDefault(x => x.Direction == ParameterDirection.ReturnValue);
+
+			foreach (var cachedParam in m_parameters)
+			{
+				MySqlParameter alignParam;
+				if (cachedParam.Direction == ParameterDirection.ReturnValue)
+				{
+					if (returnParam == null)
+						throw new InvalidOperationException($"Attempt to call stored function {FullyQualified} without specifying a return parameter");
+					alignParam = returnParam;
+				}
+				else
+				{
+					var index = parameterCollection.NormalizedIndexOf(cachedParam.Name);
+					if (index == -1)
+						throw new ArgumentException($"Parameter '{cachedParam.Name}' not found in the collection.");
+					alignParam = parameterCollection[index];
+				}
+
+				if (alignParam.Direction == default(ParameterDirection))
+					alignParam.Direction = cachedParam.Direction;
+				if (alignParam.DbType == default(DbType))
+					alignParam.DbType = cachedParam.DbType;
+
+				// cached parameters are oredered by ordinal position
+				alignedParams.Add(alignParam);
+			}
+
+			return alignedParams;
+		}
+
+		private string FullyQualified => $"`{m_schema}`.`{m_component}`";
+
+		readonly string m_schema;
+		readonly string m_component;
+		readonly ReadOnlyCollection<CachedParameter> m_parameters;
+	}
+}

--- a/src/MySqlConnector/MySqlClient/Caches/NormalizedSchema.cs
+++ b/src/MySqlConnector/MySqlClient/Caches/NormalizedSchema.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace MySql.Data.MySqlClient.Caches
+{
+	internal class NormalizedSchema
+	{
+		private const string ReQuoted = @"`((?:[^`]|``)+)`";
+		private const string ReUnQuoted = @"([^\.`]+)";
+		private static readonly string ReEither = $@"(?:{ReQuoted}|{ReUnQuoted})";
+
+		private static readonly Regex NameRe = new Regex(
+			$@"^\s*{ReEither}\s*(?:\.\s*{ReEither}\s*)?$",
+			RegexOptions.Compiled);
+
+		internal static NormalizedSchema MustNormalize(string name, string defaultSchema = null)
+		{
+			var normalized = new NormalizedSchema(name, defaultSchema);
+			if (normalized.Component == null)
+				throw new ArgumentException("Could not determine function/procedure name", name);
+			if (normalized.Component == null)
+				throw new ArgumentException("Could not determine schema", name);
+			return normalized;
+		}
+
+		public NormalizedSchema(string name, string defaultSchema=null)
+		{
+			var match = NameRe.Match(name);
+			if (match.Success)
+			{
+				if (match.Groups[3].Success)
+					Component = match.Groups[3].Value.Trim();
+				else if (match.Groups[4].Success)
+					Component = match.Groups[4].Value.Trim();
+
+				string firstGroup = "";
+				if (match.Groups[1].Success)
+					firstGroup = match.Groups[1].Value.Trim();
+				else if (match.Groups[2].Success)
+					firstGroup = match.Groups[2].Value.Trim();
+				if (Component == null)
+					Component = firstGroup.Trim();
+				else
+					Schema = firstGroup.Trim();
+
+				if (Schema == null)
+					Schema = defaultSchema;
+			}
+		}
+
+		internal readonly string Schema;
+		internal readonly string Component;
+
+		internal string FullyQualified => $"`{Schema}`.`{Component}`";
+	}
+}

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/ICommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/ICommandExecutor.cs
@@ -1,0 +1,17 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.Protocol.Serialization;
+
+namespace MySql.Data.MySqlClient.CommandExecutors
+{
+	internal interface ICommandExecutor
+	{
+		Task<int> ExecuteNonQueryAsync(string commandText, MySqlParameterCollection parameterCollection, IOBehavior ioBehavior, CancellationToken cancellationToken);
+
+		Task<object> ExecuteScalarAsync(string commandText, MySqlParameterCollection parameterCollection, IOBehavior ioBehavior, CancellationToken cancellationToken);
+
+		Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken);
+	}
+}

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient.Types;
+using MySql.Data.Protocol.Serialization;
+
+namespace MySql.Data.MySqlClient.CommandExecutors
+{
+	internal class StoredProcedureCommandExecutor : TextCommandExecutor
+	{
+
+		internal StoredProcedureCommandExecutor(MySqlCommand command)
+			: base(command)
+		{
+			m_command = command;
+		}
+
+		public override async Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection,
+			CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			var cachedProcedure = await m_command.Connection.GetCachedProcedure(ioBehavior, commandText, cancellationToken).ConfigureAwait(false);
+			if (cachedProcedure != null)
+				parameterCollection = cachedProcedure.AlignParamsWithDb(parameterCollection);
+
+			MySqlParameter returnParam = null;
+			m_outParams = new MySqlParameterCollection();
+			m_outParamNames = new List<string>();
+			var inParams = new MySqlParameterCollection();
+			var argParamNames = new List<string>();
+			var inOutSetParams = "";
+			for (var i = 0; i < parameterCollection.Count; i++)
+			{
+				var param = parameterCollection[i];
+				var inName = "@inParam" + i;
+				var outName = "@outParam" + i;
+				switch (param.Direction)
+				{
+					case 0:
+					case ParameterDirection.Input:
+					case ParameterDirection.InputOutput:
+						var inParam = param.WithParameterName(inName);
+						inParams.Add(inParam);
+						if (param.Direction == ParameterDirection.InputOutput)
+						{
+							inOutSetParams += $"SET {outName}={inName}; ";
+							goto case ParameterDirection.Output;
+						}
+						argParamNames.Add(inName);
+						break;
+					case ParameterDirection.Output:
+						m_outParams.Add(param);
+						m_outParamNames.Add(outName);
+						argParamNames.Add(outName);
+						break;
+					case ParameterDirection.ReturnValue:
+						returnParam = param;
+						break;
+				}
+			}
+
+			// if a return param is set, assume it is a funciton.  otherwise, assume stored procedure
+			commandText += "(" + string.Join(", ", argParamNames) +")";
+			if (returnParam == null)
+			{
+				commandText = inOutSetParams + "CALL " + commandText;
+				if (m_outParams.Count > 0)
+				{
+					m_setParamsFlags = true;
+					m_cancellationToken = cancellationToken;
+				}
+			}
+			else
+			{
+				commandText = "SELECT " + commandText;
+			}
+
+			var reader = (MySqlDataReader) await base.ExecuteReaderAsync(commandText, inParams, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
+			if (returnParam != null && await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
+				returnParam.Value = reader.GetValue(0);
+			
+			return reader;
+		}
+
+		internal void SetParams()
+		{
+			if (!m_setParamsFlags)
+				return;
+			m_setParamsFlags = false;
+			var commandText = "SELECT " + string.Join(", ", m_outParamNames);
+			using (var reader = (MySqlDataReader) base.ExecuteReaderAsync(commandText, new MySqlParameterCollection(), CommandBehavior.Default, IOBehavior.Synchronous, m_cancellationToken).GetAwaiter().GetResult())
+			{
+				reader.Read();
+				for (var i = 0; i < m_outParams.Count; i++)
+				{
+					var param = m_outParams[i];
+					if (param.DbType != default(DbType))
+					{
+						var dbTypeMapping = TypeMapper.Mapper.GetDbTypeMapping(param.DbType);
+						if (dbTypeMapping != null)
+						{
+							param.Value = dbTypeMapping.DoConversion(reader.GetValue(i));
+							continue;
+						}
+					}
+					param.Value = reader.GetValue(i);
+				}
+			}
+		}
+
+		readonly MySqlCommand m_command;
+		bool m_setParamsFlags;
+		MySqlParameterCollection m_outParams;
+		List<string> m_outParamNames;
+		private CancellationToken m_cancellationToken;
+	}
+}

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -1,0 +1,81 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.Protocol.Serialization;
+using MySql.Data.Serialization;
+
+namespace MySql.Data.MySqlClient.CommandExecutors
+{
+	internal class TextCommandExecutor : ICommandExecutor
+	{
+		internal TextCommandExecutor(MySqlCommand command)
+		{
+			m_command = command;
+		}
+
+		public virtual async Task<int> ExecuteNonQueryAsync(string commandText, MySqlParameterCollection parameterCollection,
+			IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			using (var reader = (MySqlDataReader) await ExecuteReaderAsync(commandText, parameterCollection, CommandBehavior.Default, ioBehavior, cancellationToken).ConfigureAwait(false))
+			{
+				do
+				{
+					while (await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
+					{
+					}
+				} while (await reader.NextResultAsync(ioBehavior, cancellationToken).ConfigureAwait(false));
+				return reader.RecordsAffected;
+			}
+		}
+
+		public virtual async Task<object> ExecuteScalarAsync(string commandText, MySqlParameterCollection parameterCollection,
+			IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			object result = null;
+			using (var reader = (MySqlDataReader) await ExecuteReaderAsync(commandText, parameterCollection, CommandBehavior.SingleResult | CommandBehavior.SingleRow, ioBehavior, cancellationToken).ConfigureAwait(false))
+			{
+				do
+				{
+					if (await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
+						result = reader.GetValue(0);
+				} while (await reader.NextResultAsync(ioBehavior, cancellationToken).ConfigureAwait(false));
+			}
+			return result;
+		}
+
+		public virtual async Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection,
+			CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			m_command.VerifyValid();
+			var connection = m_command.Connection;
+			connection.HasActiveReader = true;
+
+			MySqlDataReader reader = null;
+			try
+			{
+				m_command.LastInsertedId = -1;
+				var statementPreparerOptions = StatementPreparerOptions.None;
+				if (connection.AllowUserVariables || m_command.CommandType == CommandType.StoredProcedure)
+					statementPreparerOptions |= StatementPreparerOptions.AllowUserVariables;
+				if (connection.OldGuids)
+					statementPreparerOptions |= StatementPreparerOptions.OldGuids;
+				var preparer = new MySqlStatementPreparer(commandText, parameterCollection, statementPreparerOptions);
+				var payload = new PayloadData(preparer.ParseAndBindParameters());
+				await connection.Session.SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
+				reader = await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
+				return reader;
+			}
+			finally
+			{
+				if (reader == null)
+				{
+					// received an error from MySQL and never created an active reader
+					connection.HasActiveReader = false;
+				}
+			}
+		}
+
+		readonly MySqlCommand m_command;
+	}
+}

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -641,6 +641,7 @@ namespace MySql.Data.MySqlClient
 
 				var connection = m_command.Connection;
 				connection.HasActiveReader = false;
+				m_command.ReaderClosed();
 				if (m_behavior.HasFlag(CommandBehavior.CloseConnection))
 				{
 					m_command.Dispose();

--- a/src/MySqlConnector/MySqlClient/MySqlParameterCollection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlParameterCollection.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace MySql.Data.MySqlClient
 {
-	public sealed class MySqlParameterCollection : DbParameterCollection
+	public sealed class MySqlParameterCollection : DbParameterCollection, IEnumerable<MySqlParameter>
 	{
 		internal MySqlParameterCollection()
 		{
@@ -64,6 +64,11 @@ namespace MySql.Data.MySqlClient
 			return m_parameters.GetEnumerator();
 		}
 
+		IEnumerator<MySqlParameter> IEnumerable<MySqlParameter>.GetEnumerator()
+		{
+			return m_parameters.GetEnumerator();
+		}
+
 		protected override DbParameter GetParameter(int index)
 		{
 			return m_parameters[index];
@@ -84,11 +89,18 @@ namespace MySql.Data.MySqlClient
 
 		public override int IndexOf(string parameterName)
 		{
+			var index = NormalizedIndexOf(parameterName);
+			if (index == -1)
+				return -1;
+			return string.Equals(parameterName, m_parameters[index].ParameterName, StringComparison.OrdinalIgnoreCase) ? index : -1;
+		}
+
+		internal int NormalizedIndexOf(string parameterName)
+		{
 			if (parameterName == null)
 				throw new ArgumentNullException(nameof(parameterName));
 			int index;
-			return m_nameToIndex.TryGetValue(MySqlParameter.NormalizeParameterName(parameterName), out index) &&
-				string.Equals(parameterName, m_parameters[index].ParameterName, StringComparison.OrdinalIgnoreCase) ? index : -1;
+			return m_nameToIndex.TryGetValue(MySqlParameter.NormalizeParameterName(parameterName), out index) ? index : -1;
 		}
 
 		public override void Insert(int index, object value)

--- a/src/MySqlConnector/MySqlClient/ServerVersions.cs
+++ b/src/MySqlConnector/MySqlClient/ServerVersions.cs
@@ -4,6 +4,10 @@ namespace MySql.Data.MySqlClient
 {
 	internal static class ServerVersions
 	{
+		// https://dev.mysql.com/doc/refman/5.7/en/mysql-reset-connection.html
 		public static readonly Version SupportsResetConnection = new Version(5, 7, 3);
+
+		// http://dev.mysql.com/doc/refman/5.5/en/parameters-table.html
+		public static readonly Version SupportsProcedureCache = new Version(5, 5, 3);
 	}
 }

--- a/src/MySqlConnector/MySqlClient/Types/ColumnTypeMapping.cs
+++ b/src/MySqlConnector/MySqlClient/Types/ColumnTypeMapping.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using MySql.Data.Serialization;
+
+namespace MySql.Data.MySqlClient.Types
+{
+	internal class ColumnTypeMapping
+	{
+		internal static string CreateLookupKey(string columnTypeName, bool unsigned, int length)
+		{
+			return columnTypeName.Trim().ToLowerInvariant()
+			       + "|" + (unsigned ? "u" : "s")
+			       + "|" + length;
+		}
+
+		public ColumnTypeMapping(string columnTypeName, DbTypeMapping dbTypeMapping, IEnumerable<ColumnType> columnTypes,
+			bool unsigned=false,
+			bool binary=false,
+			int length=0
+		)
+		{
+			ColumnTypeName = columnTypeName;
+			DbTypeMapping = dbTypeMapping;
+			Unsigned = unsigned;
+			Binary = binary;
+			Length = length;
+		}
+
+		internal readonly string ColumnTypeName;
+		internal readonly DbTypeMapping DbTypeMapping;
+		internal readonly IEnumerable<ColumnType> ColumnTypes;
+		internal readonly bool Binary;
+		internal readonly bool Unsigned;
+		internal readonly int Length;
+
+		internal string LookupKey => CreateLookupKey(ColumnTypeName, Unsigned, Length);
+	}
+}

--- a/src/MySqlConnector/MySqlClient/Types/DbTypeMapping.cs
+++ b/src/MySqlConnector/MySqlClient/Types/DbTypeMapping.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace MySql.Data.MySqlClient.Types
+{
+	internal class DbTypeMapping
+	{
+		public DbTypeMapping(Type clrType, IEnumerable<DbType> dbTypes,
+			Func<object, object> convert = null)
+		{
+			ClrType = clrType;
+			DbTypes = dbTypes;
+			m_convert = convert;
+		}
+
+		internal readonly Type ClrType;
+		internal readonly IEnumerable<DbType> DbTypes;
+
+		internal object DoConversion(object obj)
+		{
+			if (obj.GetType() == ClrType)
+				return obj;
+			return m_convert == null ? Convert.ChangeType(obj, ClrType) : m_convert(obj);
+		}
+
+		readonly Func<object, object> m_convert;
+	}
+}

--- a/src/MySqlConnector/MySqlClient/Types/TypeMapper.cs
+++ b/src/MySqlConnector/MySqlClient/Types/TypeMapper.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using MySql.Data.Serialization;
+
+namespace MySql.Data.MySqlClient.Types
+{
+	internal class TypeMapper
+	{
+		internal static TypeMapper Mapper = new TypeMapper();
+
+		private TypeMapper()
+		{
+			// boolean
+			var typeBoolean = AddDbTypeMapping(new DbTypeMapping(typeof(bool), new []{DbType.Boolean}, convert: o => Convert.ToBoolean(o)));
+			AddColumnTypeMapping(new ColumnTypeMapping("bit",     typeBoolean, new []{ColumnType.Bit}));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinyint", typeBoolean, new []{ColumnType.Tiny}, unsigned: false, length: 1));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinyint", typeBoolean, new []{ColumnType.Tiny}, unsigned: true, length: 1));
+
+			// integers
+			var typeSbyte    = AddDbTypeMapping(new DbTypeMapping(typeof(sbyte),  new []{DbType.SByte},  convert: o => Convert.ToSByte(o)));
+			var typeByte     = AddDbTypeMapping(new DbTypeMapping(typeof(byte),   new []{DbType.Byte},   convert: o => Convert.ToByte(o)));
+			var typeShort    = AddDbTypeMapping(new DbTypeMapping(typeof(short),  new []{DbType.Int16},  convert: o => Convert.ToInt16(o)));
+			var typeUshort   = AddDbTypeMapping(new DbTypeMapping(typeof(ushort), new []{DbType.UInt16}, convert: o => Convert.ToUInt16(o)));
+			var typeInt      = AddDbTypeMapping(new DbTypeMapping(typeof(int),    new []{DbType.Int32},  convert: o => Convert.ToInt32(o)));
+			var typeUint     = AddDbTypeMapping(new DbTypeMapping(typeof(uint),   new []{DbType.UInt32}, convert: o => Convert.ToUInt32(o)));
+			var typeLong     = AddDbTypeMapping(new DbTypeMapping(typeof(long),   new []{DbType.Int64},  convert: o => Convert.ToInt64(o)));
+			var typeUlong    = AddDbTypeMapping(new DbTypeMapping(typeof(ulong),  new []{DbType.UInt64}, convert: o => Convert.ToUInt64(o)));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinyint",    typeSbyte,	  new []{ColumnType.Tiny},     unsigned: false));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinyint",    typeByte,    new []{ColumnType.Tiny},     unsigned: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("smallint",   typeShort,   new []{ColumnType.Short},    unsigned: false));
+			AddColumnTypeMapping(new ColumnTypeMapping("smallint",   typeUshort,  new []{ColumnType.Short},    unsigned: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("mediumint",  typeInt,     new []{ColumnType.Int24},    unsigned: false));
+			AddColumnTypeMapping(new ColumnTypeMapping("mediumint",  typeUint,    new []{ColumnType.Int24},    unsigned: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("int",        typeInt,     new []{ColumnType.Long},     unsigned: false));
+			AddColumnTypeMapping(new ColumnTypeMapping("int",        typeUint,    new []{ColumnType.Long},     unsigned: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("bigint",     typeLong,    new []{ColumnType.Longlong}, unsigned: false));
+			AddColumnTypeMapping(new ColumnTypeMapping("bigint",     typeUlong,   new []{ColumnType.Longlong}, unsigned: true));
+
+			// decimals
+			var typeDecimal    = AddDbTypeMapping(new DbTypeMapping(typeof(decimal), new []{DbType.Decimal}, convert: o => Convert.ToDecimal(o)));
+			var typeDouble     = AddDbTypeMapping(new DbTypeMapping(typeof(double),  new []{DbType.Double},  convert: o => Convert.ToDouble(o)));
+			var typeFloat      = AddDbTypeMapping(new DbTypeMapping(typeof(float),   new []{DbType.Single},  convert: o => Convert.ToSingle(o)));
+			AddColumnTypeMapping(new ColumnTypeMapping("decimal",  typeDecimal, new []{ColumnType.Decimal, ColumnType.NewDecimal}));
+			AddColumnTypeMapping(new ColumnTypeMapping("double",   typeDouble,  new []{ColumnType.Double}));
+			AddColumnTypeMapping(new ColumnTypeMapping("float",    typeFloat,   new []{ColumnType.Float}));
+
+			// string
+			var typeString          = AddDbTypeMapping(new DbTypeMapping(typeof(string), new []{DbType.String, DbType.StringFixedLength, DbType.AnsiString, DbType.AnsiStringFixedLength}, convert: o => Convert.ToString(o)));
+			AddColumnTypeMapping(new ColumnTypeMapping("char",       typeString, new []{ColumnType.String}));
+			AddColumnTypeMapping(new ColumnTypeMapping("varchar",    typeString, new []{ColumnType.VarChar, ColumnType.VarString}));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinytext",   typeString, new []{ColumnType.TinyBlob}));
+			AddColumnTypeMapping(new ColumnTypeMapping("text",       typeString, new []{ColumnType.Blob}));
+			AddColumnTypeMapping(new ColumnTypeMapping("mediumtext", typeString, new []{ColumnType.MediumBlob}));
+			AddColumnTypeMapping(new ColumnTypeMapping("longtext",   typeString, new []{ColumnType.LongBlob}));
+			AddColumnTypeMapping(new ColumnTypeMapping("enum",       typeString, new []{ColumnType.Enum}));
+			AddColumnTypeMapping(new ColumnTypeMapping("set",        typeString, new []{ColumnType.Set}));
+			AddColumnTypeMapping(new ColumnTypeMapping("json",       typeString, new []{ColumnType.Json}));
+
+			// binary
+			var typeBinary = AddDbTypeMapping(new DbTypeMapping(typeof(byte[]), new []{DbType.Binary}));
+			AddColumnTypeMapping(new ColumnTypeMapping("binary",     typeBinary, new []{ColumnType.String},     binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("varbinary",  typeBinary, new []{ColumnType.VarString},  binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("tinyblob",   typeBinary, new []{ColumnType.TinyBlob},   binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("blob",       typeBinary, new []{ColumnType.Blob},       binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("mediumblob", typeBinary, new []{ColumnType.MediumBlob}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("longblob",   typeBinary, new []{ColumnType.LongBlob},   binary: true));
+
+			// spatial
+			AddColumnTypeMapping(new ColumnTypeMapping("point",              typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("linestring",         typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("polygon",            typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("geometry",           typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("multipoint",         typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("multilinestring",    typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("multipolygon",       typeBinary, new []{ColumnType.Geometry}, binary: true));
+			AddColumnTypeMapping(new ColumnTypeMapping("geometrycollection", typeBinary, new []{ColumnType.Geometry}, binary: true));
+
+			// date/time
+			var typeDateTime       = AddDbTypeMapping(new DbTypeMapping(typeof(DateTime), new []{DbType.DateTime, DbType.Date, DbType.DateTime2}));
+			var typeTime           = AddDbTypeMapping(new DbTypeMapping(typeof(TimeSpan), new []{DbType.Time}));
+			var typeDateTimeOffset = AddDbTypeMapping(new DbTypeMapping(typeof(DateTimeOffset), new []{DbType.DateTimeOffset}));
+			AddColumnTypeMapping(new ColumnTypeMapping("datetime",  typeDateTime,       new []{ColumnType.DateTime}));
+			AddColumnTypeMapping(new ColumnTypeMapping("date",      typeDateTime,       new []{ColumnType.Date}));
+			AddColumnTypeMapping(new ColumnTypeMapping("time",      typeTime,           new []{ColumnType.Time}));
+			AddColumnTypeMapping(new ColumnTypeMapping("timestamp", typeDateTimeOffset, new []{ColumnType.Timestamp}));
+			AddColumnTypeMapping(new ColumnTypeMapping("year",      typeInt,            new []{ColumnType.Year}));
+
+			// guid
+			AddDbTypeMapping(new DbTypeMapping(typeof(Guid), new[]{DbType.Guid}, convert: o => Guid.Parse(Convert.ToString(o))));
+		}
+
+		private DbTypeMapping AddDbTypeMapping(DbTypeMapping dbTypeMapping)
+		{
+			m_dbTypeMappingsByClrType[dbTypeMapping.ClrType] = dbTypeMapping;
+
+			if (dbTypeMapping.DbTypes != null)
+				foreach (var dbType in dbTypeMapping.DbTypes)
+					m_dbTypeMappingsByDbType[dbType] = dbTypeMapping;
+
+			return dbTypeMapping;
+		}
+
+		private void AddColumnTypeMapping(ColumnTypeMapping columnTypeMapping)
+		{
+			m_columnTypeMappingLookup[columnTypeMapping.LookupKey] = columnTypeMapping;
+		}
+
+		internal DbTypeMapping GetDbTypeMapping(Type clrType)
+		{
+			DbTypeMapping dbTypeMapping;
+			m_dbTypeMappingsByClrType.TryGetValue(clrType, out dbTypeMapping);
+			return dbTypeMapping;
+		}
+
+		internal DbTypeMapping GetDbTypeMapping(DbType dbType)
+		{
+			DbTypeMapping dbTypeMapping;
+			m_dbTypeMappingsByDbType.TryGetValue(dbType, out dbTypeMapping);
+			return dbTypeMapping;
+		}
+
+		internal DbTypeMapping GetDbTypeMapping(string columnTypeName, bool unsigned=false, int length=0)
+		{
+			return GetColumnTypeMapping(columnTypeName, unsigned, length)?.DbTypeMapping;
+		}
+
+		internal ColumnTypeMapping GetColumnTypeMapping(string columnTypeName, bool unsigned=false, int length=0)
+		{
+			ColumnTypeMapping columnTypeMapping;
+			if (!m_columnTypeMappingLookup.TryGetValue(ColumnTypeMapping.CreateLookupKey(columnTypeName, unsigned, length), out columnTypeMapping) && length != 0)
+				m_columnTypeMappingLookup.TryGetValue(ColumnTypeMapping.CreateLookupKey(columnTypeName, unsigned, 0), out columnTypeMapping);
+			return columnTypeMapping;
+		}
+
+		private Dictionary<Type, DbTypeMapping> m_dbTypeMappingsByClrType = new Dictionary<Type, DbTypeMapping>();
+		private Dictionary<DbType, DbTypeMapping> m_dbTypeMappingsByDbType = new Dictionary<DbType, DbTypeMapping>();
+		private Dictionary<string, ColumnTypeMapping> m_columnTypeMappingLookup = new Dictionary<string, ColumnTypeMapping>();
+	}
+}

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using MySql.Data.MySqlClient;
@@ -12,7 +13,7 @@ namespace MySql.Data.Serialization
 			ConnectionString = csb.ConnectionString;
 
 			// Base Options
-			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (csb.Server.StartsWith("/") || csb.Server.StartsWith("./")))
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (csb.Server.StartsWith("/", StringComparison.Ordinal) || csb.Server.StartsWith("./", StringComparison.Ordinal)))
 			{
 				if (!File.Exists(csb.Server))
 					throw new MySqlException("Cannot find Unix Socket at " + csb.Server);

--- a/src/MySqlConnector/project.json
+++ b/src/MySqlConnector/project.json
@@ -49,6 +49,7 @@
 				"System.Runtime.Extensions": "4.1.0",
 				"System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
 				"System.Security.Cryptography.Algorithms": "4.2.0",
+                "System.Text.RegularExpressions": "4.1.0",
 				"System.Threading": "4.0.11",
 				"System.Threading.Tasks.Extensions": "4.0.0"
 			}

--- a/tests/MySqlConnector.Tests/NormalizeTests.cs
+++ b/tests/MySqlConnector.Tests/NormalizeTests.cs
@@ -1,0 +1,48 @@
+﻿using MySql.Data.MySqlClient;
+using MySql.Data.MySqlClient.Caches;
+using Xunit;
+
+namespace MySql.Data.Tests
+{
+	public class NormalizeTests
+	{
+		[Theory]
+		[InlineData("`mysql`.`data`", "mysql", "data")]
+		[InlineData(" `mysql` . `data` ", "mysql", "data")]
+		[InlineData("mysql.data", "mysql", "data")]
+		[InlineData(" mysql . data ", "mysql", "data")]
+		[InlineData("`mysql`.data", "mysql", "data")]
+		[InlineData("mysql.`data`", "mysql", "data")]
+		[InlineData("`my``sql`.`da``ta`", "my``sql", "da``ta")]
+		[InlineData("`mysql.data`", null, "mysql.data")]
+		[InlineData("mysqldata", null, "mysqldata")]
+		[InlineData("my`sql.data", null, null)]
+		[InlineData("mysql.da`ta", null, null)]
+		public void NormalizeSchema(string input, string expectedSchema, string expectedComponent)
+		{
+			var normalized = new NormalizedSchema(input);
+			Assert.Equal(expectedSchema, normalized.Schema);
+			Assert.Equal(expectedComponent, normalized.Component);
+		}
+
+		[Theory]
+		[InlineData("param1", "param1")]
+		[InlineData("@param1", "param1")]
+		[InlineData("?param1", "param1")]
+		[InlineData("@`param1`", "param1")]
+		[InlineData("?`param1`", "param1")]
+		[InlineData("@`param``1`", "param`1")]
+		[InlineData("@'param1'", "param1")]
+		[InlineData("?'param1'", "param1")]
+		[InlineData("@'param''1'", "param'1")]
+		[InlineData("@\"param1\"", "param1")]
+		[InlineData("?\"param1\"", "param1")]
+		[InlineData("@\"param\"\"1\"", "param\"1")]
+		[InlineData(" @PaRaM1 ", "PaRaM1")]
+		public void NormalizeParameterName(string input, string expectedName)
+		{
+			var normalized = MySqlParameter.NormalizeParameterName(input);
+			Assert.Equal(expectedName, normalized);
+		}
+	}
+}

--- a/tests/MySqlConnector.Tests/TypeMapperTests.cs
+++ b/tests/MySqlConnector.Tests/TypeMapperTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+using MySql.Data.MySqlClient.Types;
+using Xunit;
+
+namespace MySql.Data.Tests
+{
+	public class TypeMapperTests
+	{
+		[Theory]
+		[InlineData(typeof(bool), DbType.Boolean)]
+		[InlineData(typeof(sbyte), DbType.SByte)]
+		[InlineData(typeof(byte), DbType.Byte)]
+		[InlineData(typeof(short), DbType.Int16)]
+		[InlineData(typeof(ushort), DbType.UInt16)]
+		[InlineData(typeof(int), DbType.Int32)]
+		[InlineData(typeof(uint), DbType.UInt32)]
+		[InlineData(typeof(long), DbType.Int64)]
+		[InlineData(typeof(ulong), DbType.UInt64)]
+		[InlineData(typeof(decimal), DbType.Decimal)]
+		[InlineData(typeof(double), DbType.Double)]
+		[InlineData(typeof(float), DbType.Single)]
+		[InlineData(typeof(string), DbType.String)]
+		[InlineData(typeof(string), DbType.StringFixedLength)]
+		[InlineData(typeof(string), DbType.AnsiString)]
+		[InlineData(typeof(string), DbType.AnsiStringFixedLength)]
+		[InlineData(typeof(byte[]), DbType.Binary)]
+		[InlineData(typeof(DateTime), DbType.Date)]
+		[InlineData(typeof(DateTime), DbType.DateTime)]
+		[InlineData(typeof(DateTime), DbType.DateTime2)]
+		[InlineData(typeof(TimeSpan), DbType.Time)]
+		[InlineData(typeof(DateTimeOffset), DbType.DateTimeOffset)]
+		[InlineData(typeof(Guid), DbType.Guid)]
+		public void DbTypeMappingTest(Type clrType, DbType dbType)
+		{
+			Assert.Equal(clrType, TypeMapper.Mapper.GetDbTypeMapping(dbType).ClrType);
+			Assert.Contains(dbType, TypeMapper.Mapper.GetDbTypeMapping(clrType).DbTypes);
+		}
+
+		[Theory]
+		[InlineData(1, DbType.Boolean, true)]
+		[InlineData(true, DbType.SByte, (sbyte)1)]
+		[InlineData((sbyte)1, DbType.Byte, (byte)1)]
+		[InlineData((byte)1, DbType.Int16, (short)1)]
+		[InlineData((short)1, DbType.UInt16, (ushort)1)]
+		[InlineData((ushort)1, DbType.Int32, 1)]
+		[InlineData(1, DbType.UInt32, (uint)1)]
+		[InlineData((uint)1, DbType.Int64, (long)1)]
+		[InlineData((long)1, DbType.UInt64, (ulong)1)]
+		[InlineData((ulong)1, DbType.String, "1")]
+		[InlineData((ulong)1, DbType.StringFixedLength, "1")]
+		[InlineData((ulong)1, DbType.AnsiString, "1")]
+		[InlineData((ulong)1, DbType.AnsiStringFixedLength, "1")]
+		public void ConversionTest(object original, DbType dbType, object expected)
+		{
+			Assert.Equal(expected, TypeMapper.Mapper.GetDbTypeMapping(dbType).DoConversion(original));
+		}
+
+		[Theory]
+		[InlineData("bit", false, 0, DbType.Boolean)]
+		[InlineData("tinyint", false, 1, DbType.Boolean)]
+		[InlineData("tinyint", true, 1, DbType.Boolean)]
+		[InlineData("tinyint", false, 0, DbType.SByte)]
+		[InlineData("tinyint", true, 0, DbType.Byte)]
+		[InlineData("smallint", false, 0, DbType.Int16)]
+		[InlineData("smallint", true, 0, DbType.UInt16)]
+		[InlineData("mediumint", false, 0, DbType.Int32)]
+		[InlineData("mediumint", true, 0, DbType.UInt32)]
+		[InlineData("int", false, 0, DbType.Int32)]
+		[InlineData("int", true, 0, DbType.UInt32)]
+		[InlineData("bigint", false, 0, DbType.Int64)]
+		[InlineData("bigint", true, 0, DbType.UInt64)]
+		[InlineData("decimal", false, 0, DbType.Decimal)]
+		[InlineData("double", false, 0, DbType.Double)]
+		[InlineData("float", false, 0, DbType.Single)]
+		[InlineData("char", false, 0, DbType.String)]
+		[InlineData("varchar", false, 0, DbType.String)]
+		[InlineData("tinytext", false, 0, DbType.String)]
+		[InlineData("text", false, 0, DbType.String)]
+		[InlineData("mediumtext", false, 0, DbType.String)]
+		[InlineData("longtext", false, 0, DbType.String)]
+		[InlineData("enum", false, 0, DbType.String)]
+		[InlineData("set", false, 0, DbType.String)]
+		[InlineData("json", false, 0, DbType.String)]
+		[InlineData("binary", false, 0, DbType.Binary)]
+		[InlineData("varbinary", false, 0, DbType.Binary)]
+		[InlineData("tinyblob", false, 0, DbType.Binary)]
+		[InlineData("blob", false, 0, DbType.Binary)]
+		[InlineData("mediumblob", false, 0, DbType.Binary)]
+		[InlineData("longblob", false, 0, DbType.Binary)]
+		[InlineData("point", false, 0, DbType.Binary)]
+		[InlineData("linestring", false, 0, DbType.Binary)]
+		[InlineData("polygon", false, 0, DbType.Binary)]
+		[InlineData("geometry", false, 0, DbType.Binary)]
+		[InlineData("multipoint", false, 0, DbType.Binary)]
+		[InlineData("multilinestring", false, 0, DbType.Binary)]
+		[InlineData("multipolygon", false, 0, DbType.Binary)]
+		[InlineData("datetime", false, 0, DbType.DateTime)]
+		[InlineData("date", false, 0, DbType.DateTime)] // todo: this should be DbType.Date
+		[InlineData("time", false, 0, DbType.Time)]
+		[InlineData("timestamp", false, 0, DbType.DateTimeOffset)]
+		[InlineData("year", false, 0, DbType.Int32)]
+		public void ColumnTypeMappingTest(string columnTypeName, bool unsigned, int length, DbType dbType)
+		{
+			Assert.Equal(dbType, TypeMapper.Mapper.GetDbTypeMapping(columnTypeName, unsigned, length).DbTypes.FirstOrDefault());
+			Assert.Equal(dbType, TypeMapper.Mapper.GetDbTypeMapping(columnTypeName.ToUpperInvariant(), unsigned, length).DbTypes.FirstOrDefault());
+		}
+	}
+}

--- a/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
+++ b/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
@@ -157,6 +157,12 @@
     <Compile Include="..\SideBySide.New\QueryTests.cs">
       <Link>QueryTests.cs</Link>
     </Compile>
+    <Compile Include="..\SideBySide.New\StoredProcedureFixture.cs">
+      <Link>StoredProcedureFixture.cs</Link>
+    </Compile>
+    <Compile Include="..\SideBySide.New\StoredProcedureTests.cs">
+      <Link>StoredProcedureTests.cs</Link>
+    </Compile>
     <Compile Include="..\SideBySide.New\TestUtilities.cs">
       <Link>TestUtilities.cs</Link>
     </Compile>

--- a/tests/SideBySide.New/AppConfig.cs
+++ b/tests/SideBySide.New/AppConfig.cs
@@ -14,6 +14,7 @@ namespace SideBySide
 			new Dictionary<string, string>
 			{
 				["Data:NoPasswordUser"] = "",
+				["Data:SupportsCachedProcedures"] = "false",
 				["Data:SupportsJson"] = "false",
 			};
 
@@ -39,6 +40,8 @@ namespace SideBySide
 		public static string ConnectionString => Config.GetValue<string>("Data:ConnectionString");
 
 		public static string PasswordlessUser => Config.GetValue<string>("Data:PasswordlessUser");
+
+		public static bool SupportsCachedProcedures => Config.GetValue<bool>("Data:SupportsCachedProcedures");
 
 		public static bool SupportsJson => Config.GetValue<bool>("Data:SupportsJson");
 

--- a/tests/SideBySide.New/Attributes.cs
+++ b/tests/SideBySide.New/Attributes.cs
@@ -1,37 +1,43 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace SideBySide.New
 {
-	public class JsonTheoryAttribute : TheoryAttribute {
+	public class CachedProcedureTheoryAttribute : TheoryAttribute
+	{
+		public CachedProcedureTheoryAttribute()
+		{
+			if(!AppConfig.SupportsCachedProcedures)
+				Skip = "No Cached Procedure Support";
+		}
+	}
 
-		public JsonTheoryAttribute() {
-			if(!AppConfig.SupportsJson) {
+	public class JsonTheoryAttribute : TheoryAttribute
+	{
+		public JsonTheoryAttribute()
+		{
+			if(!AppConfig.SupportsJson)
 				Skip = "No JSON Support";
-			}
 		}
-
 	}
 
-	public class PasswordlessUserFactAttribute : FactAttribute {
-
-		public PasswordlessUserFactAttribute() {
-			if(string.IsNullOrWhiteSpace(AppConfig.PasswordlessUser)) {
+	public class PasswordlessUserFactAttribute : FactAttribute
+	{
+		public PasswordlessUserFactAttribute()
+		{
+			if(string.IsNullOrWhiteSpace(AppConfig.PasswordlessUser))
 				Skip = "No passwordless user";
-			}
 		}
 
 	}
 
-	public class TcpConnectionFactAttribute : FactAttribute {
-
+	public class TcpConnectionFactAttribute : FactAttribute
+	{
 		public TcpConnectionFactAttribute()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
-			if(csb.Server.StartsWith("/") || csb.Server.StartsWith("./")) {
+			if(csb.Server.StartsWith("/", StringComparison.Ordinal) || csb.Server.StartsWith("./", StringComparison.Ordinal))
 				Skip = "Not a TCP Connection";
-			}
 		}
-
 	}
-
 }

--- a/tests/SideBySide.New/StoredProcedureFixture.cs
+++ b/tests/SideBySide.New/StoredProcedureFixture.cs
@@ -1,0 +1,79 @@
+﻿using Dapper;
+
+namespace SideBySide.New
+{
+	public class StoredProcedureFixture : DatabaseFixture
+	{
+		public StoredProcedureFixture()
+		{
+			Connection.Open();
+			Connection.Execute(@"DROP FUNCTION IF EXISTS echof;
+				CREATE FUNCTION echof(
+					name VARCHAR(63)
+				) RETURNS VARCHAR(63)
+				BEGIN
+					RETURN name;
+				END");
+			Connection.Execute(@"DROP PROCEDURE IF EXISTS echop;
+				CREATE PROCEDURE echop(
+					IN name VARCHAR(63)
+				)
+				BEGIN
+					SELECT name;
+				END");
+			Connection.Execute(@"DROP PROCEDURE IF EXISTS circle;
+				CREATE PROCEDURE circle(
+					IN radius DOUBLE,
+					IN height DOUBLE,
+					IN name VARCHAR(63),
+					OUT diameter DOUBLE,
+					OUT circumference DOUBLE,
+					OUT area DOUBLE,
+					OUT volume DOUBLE,
+					OUT shape VARCHAR(63)
+				)
+				BEGIN
+					SELECT radius * 2 INTO diameter;
+					SELECT diameter * PI() INTO circumference;
+					SELECT PI() * POW(radius, 2) INTO area;
+					SELECT area * height INTO volume;
+					SELECT 'circle' INTO shape;
+					SELECT CONCAT(name, shape);
+				END");
+			Connection.Execute(@"drop table if exists sproc_multiple_rows;
+				create table sproc_multiple_rows (
+					value integer not null primary key auto_increment,
+					name text not null
+				);
+				insert into sproc_multiple_rows values
+				(1, 'one'),
+				(2, 'two'),
+				(3, 'three'),
+				(4, 'four'),
+				(5, 'five'),
+				(6, 'six'),
+				(7, 'seven'),
+				(8, 'eight');");
+			Connection.Execute(@"drop procedure if exists number_multiples;
+				create procedure number_multiples (in factor int)
+				begin
+					select name from sproc_multiple_rows
+					where mod(value, factor) = 0
+					order by name;
+				end;");
+			Connection.Execute(@"drop procedure if exists number_lister;
+				create procedure number_lister (inout high int)
+				begin
+					DECLARE i int;
+					SET i = 1;
+					WHILE (i <= high) DO
+						select value, name from sproc_multiple_rows
+						where value <= high
+						order by value;
+						SET i = i + 1;
+					END WHILE;
+					SET high = high + 1;
+				end;");
+		}
+	}
+}

--- a/tests/SideBySide.New/StoredProcedureTests.cs
+++ b/tests/SideBySide.New/StoredProcedureTests.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using SideBySide.New;
+using Xunit;
+
+namespace SideBySide
+{
+	public class StoredProcedureTests : IClassFixture<StoredProcedureFixture>
+	{
+		public StoredProcedureTests(StoredProcedureFixture database)
+		{
+			m_database = database;
+		}
+
+		[Theory]
+		[InlineData("FUNCTION", "NonQuery")]
+		[InlineData("FUNCTION", "Scalar")]
+		[InlineData("FUNCTION", "Reader")]
+		[InlineData("PROCEDURE", "NonQuery")]
+		[InlineData("PROCEDURE", "Scalar")]
+		[InlineData("PROCEDURE", "Reader")]
+		public async Task StoredProcedureEcho(string procedureType, string executorType)
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "echo" + (procedureType == "FUNCTION" ? "f" : "p");
+				cmd.CommandType = CommandType.StoredProcedure;
+
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@name",
+					DbType = DbType.String,
+					Direction = ParameterDirection.Input,
+					Value = "hello",
+				});
+
+				// we make the assumption that Stored Procedures with ParameterDirection.ReturnValue are functions
+				if (procedureType == "FUNCTION")
+				{
+					cmd.Parameters.Add(new MySqlParameter
+					{
+						ParameterName = "@result",
+						DbType = DbType.String,
+						Direction = ParameterDirection.ReturnValue,
+					});
+				}
+
+				var result = await ExecuteCommandAsync(cmd, executorType);
+				if (procedureType == "PROCEDURE" && executorType != "NonQuery")
+					Assert.Equal(cmd.Parameters["@name"].Value, result);
+				if (procedureType == "FUNCTION")
+					Assert.Equal(cmd.Parameters["@name"].Value, cmd.Parameters["@result"].Value);
+			}
+		}
+
+		[CachedProcedureTheory]
+		[InlineData("FUNCTION")]
+		[InlineData("PROCEDURE")]
+		public async Task StoredProcedureEchoException(string procedureType)
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "echo" + (procedureType == "FUNCTION" ? "f" : "p");
+				cmd.CommandType = CommandType.StoredProcedure;
+
+				if (procedureType == "FUNCTION")
+					await Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await cmd.ExecuteNonQueryAsync());
+				else
+					await Assert.ThrowsAsync(typeof(ArgumentException), async () => await cmd.ExecuteNonQueryAsync());
+			}
+		}
+
+		[Theory]
+		[InlineData("NonQuery")]
+		[InlineData("Scalar")]
+		[InlineData("Reader")]
+		public async Task StoredProcedureCircle(string executorType)
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "circle";
+				cmd.CommandType = CommandType.StoredProcedure;
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@radius",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Input,
+					Value = 1.0,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@height",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Input,
+					Value = 2.0,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@name",
+					DbType = DbType.String,
+					Direction = ParameterDirection.Input,
+					Value = "awesome",
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@diameter",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Output,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@circumference",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Output,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@area",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Output,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@volume",
+					DbType = DbType.Double,
+					Direction = ParameterDirection.Output,
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@shape",
+					DbType = DbType.String,
+					Direction = ParameterDirection.Output,
+				});
+
+				await CircleAssertions(cmd, executorType);
+			}
+		}
+
+		[CachedProcedureTheory]
+		[InlineData("NonQuery")]
+		[InlineData("Scalar")]
+		[InlineData("Reader")]
+		public async Task StoredProcedureCircleCached(string executorType)
+		{
+			// reorder parameters
+			// remove return types
+			// remove directions (MySqlConnector only, MySql.Data does not fix these up)
+			// CachedProcedure class should fix everything up based on parameter names
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "circle";
+				cmd.CommandType = CommandType.StoredProcedure;
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@name",
+					Value = "awesome",
+#if BASELINE
+					Direction = ParameterDirection.Input,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@radius",
+					Value = 1.0,
+#if BASELINE
+					Direction = ParameterDirection.Input,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@shape",
+#if BASELINE
+					Direction = ParameterDirection.Output,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@height",
+					Value = 2.0,
+#if BASELINE
+					Direction = ParameterDirection.Input,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@diameter",
+#if BASELINE
+					Direction = ParameterDirection.Output,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@area",
+#if BASELINE
+					Direction = ParameterDirection.Output,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@volume",
+#if BASELINE
+					Direction = ParameterDirection.Output,
+#endif
+				});
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@circumference",
+#if BASELINE
+					Direction = ParameterDirection.Output,
+#endif
+				});
+
+				await CircleAssertions(cmd, executorType);
+			}
+		}
+
+		private async Task CircleAssertions(DbCommand cmd, string executorType)
+		{
+			var result = await ExecuteCommandAsync(cmd, executorType);
+			if (executorType != "NonQuery")
+				Assert.Equal((string)cmd.Parameters["@name"].Value + (string)cmd.Parameters["@shape"].Value, result);
+
+			Assert.Equal(2 * (double)cmd.Parameters["@radius"].Value, cmd.Parameters["@diameter"].Value);
+			Assert.Equal(Math.PI * (double)cmd.Parameters["@radius"].Value, cmd.Parameters["@area"].Value);
+			Assert.Equal(Math.PI * Math.Pow((double)cmd.Parameters["@radius"].Value, 2), cmd.Parameters["@area"].Value);
+			Assert.Equal((double)cmd.Parameters["@area"].Value * (double)cmd.Parameters["@height"].Value, cmd.Parameters["@volume"].Value);
+		}
+
+		private async Task<object> ExecuteCommandAsync(DbCommand cmd, string executorType)
+		{
+			switch (executorType)
+			{
+				case "NonQuery":
+					await cmd.ExecuteNonQueryAsync();
+					return null;
+				case "Scalar":
+					return await cmd.ExecuteScalarAsync();
+				default:
+					using (var reader = await cmd.ExecuteReaderAsync())
+					{
+						if (await reader.ReadAsync())
+							return reader.GetValue(0);
+						return null;
+					}
+			}
+		}
+
+		[Theory]
+		[InlineData("factor")]
+		[InlineData("@factor")]
+		[InlineData("?factor")]
+		public async Task MultipleRows(string paramaterName)
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "number_multiples";
+				cmd.CommandType = CommandType.StoredProcedure;
+				cmd.Parameters.Add(new MySqlParameter { ParameterName = paramaterName, Value = 3 });
+				using (var reader = await cmd.ExecuteReaderAsync())
+				{
+					Assert.True(await reader.ReadAsync());
+					Assert.Equal("six", reader.GetString(0));
+					Assert.True(await reader.ReadAsync());
+					Assert.Equal("three", reader.GetString(0));
+					Assert.False(await reader.ReadAsync());
+					//Assert.False(await reader.NextResultAsync()); // <-- This passes on MySql.Data but not MySqlConnector, why?
+				}
+			}
+		}
+
+		[Fact]
+		public async Task InOut()
+		{
+			var parameter = new MySqlParameter
+			{
+				ParameterName = "high",
+				DbType = DbType.Int32,
+				Direction = ParameterDirection.InputOutput,
+				Value = 1
+			};
+			while ((int) parameter.Value < 8)
+			{
+				using (var cmd = m_database.Connection.CreateCommand())
+				{
+					var nextValue = (int) parameter.Value + 1;
+					cmd.CommandText = "number_lister";
+					cmd.CommandType = CommandType.StoredProcedure;
+					cmd.Parameters.Add(parameter);
+					cmd.Prepare();
+					using (var reader = await cmd.ExecuteReaderAsync())
+					{
+						for (var i = 0; i < (int) parameter.Value; i++)
+						{
+							Assert.True(await reader.ReadAsync());
+							Assert.Equal(i + 1, reader.GetInt32(0));
+							Assert.True(reader.GetString(1).Length > 0);
+						}
+						await reader.NextResultAsync();
+					}
+					Assert.Equal(nextValue, parameter.Value);
+				}
+			}
+		}
+
+		readonly DatabaseFixture m_database;
+	}
+}

--- a/tests/SideBySide.New/config.json.example
+++ b/tests/SideBySide.New/config.json.example
@@ -2,6 +2,7 @@
     "Data": {
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
       "SupportsJson": true
     }
 }


### PR DESCRIPTION
- Fixes #19 
- Implements Stored Procedure Cache on a per-connection basis in >= [MySql 5.5.3](http://dev.mysql.com/doc/refman/5.5/en/parameters-table.html)
  - Fixes up Parameter Order, Direction, and Data Types to match the procedure on the Server
- Works without Stored Procedure Cache on < MySql 5.5.3, but caller is responsible for matching c# param Order, Direction, and Data Types to Server params