### PR TITLE
Bump Dependencies to 4.3.0

### DIFF
--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -1,0 +1,8 @@
+{
+    "Data": {
+      "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;Use Affected Rows=true",
+      "PasswordlessUser": "no_password",
+      "SupportsCachedProcedures": true,
+      "SupportsJson": true
+    }
+}

--- a/.ci/docker-run.sh
+++ b/.ci/docker-run.sh
@@ -8,7 +8,7 @@ docker pull mysql:5.7
 docker run -d \
 	-v $(pwd)/mysqld:/var/run/mysqld \
 	-v $(pwd)/server:/etc/mysql/conf.d \
-	-p 3306:3306 \
+	-p 3307:3306 \
 	--name mysql \
 	-e MYSQL_ROOT_PASSWORD='test' \
 	mysql:5.7

--- a/.ci/use-config.sh
+++ b/.ci/use-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+cd $(dirname $0)/config
+
+display_usage() {
+    echo -e "\nUsage:\n$0 [config.json script] [port]\n"
+}
+
+# check whether user had supplied -h or --help . If yes display usage
+if [[ ( $# == "--help") ||  $# == "-h" ]]
+then
+    display_usage
+    exit 0
+fi
+
+# check number of arguments
+if [ $# -le 1 ]
+then
+    display_usage
+    exit 1
+fi
+
+# check that directory exists
+if [ ! -f $1 ]
+then
+    echo -e "Config file does not exist: $1"
+    exit 1
+fi
+
+cp $1 ../../tests/SideBySide.New/config.json
+sed -i "s/3306/$2/g" ../../tests/SideBySide.New/config.json
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ script:
   - dotnet restore
   - dotnet test tests/MySqlConnector.Tests --configuration Release
   - dotnet build tests/SideBySide.New --configuration Release
-  - echo 'Executing tests with No Compression, No SSL' && cp tests/SideBySide.New/config.json.example tests/SideBySide.New/config.json && time dotnet test tests/SideBySide.New --configuration Release
-  - echo 'Executing tests with Compression, No SSL' && cp .ci/config/config.compression.json tests/SideBySide.New/config.json && time dotnet test tests/SideBySide.New --configuration Release
-  - echo 'Executing tests with No Compression, SSL' && cp .ci/config/config.ssl.json tests/SideBySide.New/config.json && time dotnet test tests/SideBySide.New --configuration Release
-  - echo 'Executing tests with Compression, SSL' && cp .ci/config/config.compression+ssl.json tests/SideBySide.New/config.json && time dotnet test tests/SideBySide.New --configuration Release
-  - echo 'Executing tests with Unix Domain Socket, No Compression, No SSL' && cp .ci/config/config.uds.json tests/SideBySide.New/config.json && time dotnet test tests/SideBySide.New --configuration Release
+  - echo 'Executing tests with No Compression, No SSL' && ./.ci/use-config.sh config.json 3307 && time dotnet test tests/SideBySide.New --configuration Release
+  - echo 'Executing tests with Compression, No SSL' && ./.ci/use-config.sh config.compression.json 3307 && time dotnet test tests/SideBySide.New --configuration Release
+  - echo 'Executing tests with No Compression, SSL' && ./.ci/use-config.sh config.ssl.json 3307 && time dotnet test tests/SideBySide.New --configuration Release
+  - echo 'Executing tests with Compression, SSL' && ./.ci/use-config.sh config.compression+ssl.json 3307 && time dotnet test tests/SideBySide.New --configuration Release
+  - echo 'Executing tests with Unix Domain Socket, No Compression, No SSL' && ./.ci/use-config.sh config.uds.json 3307 && time dotnet test tests/SideBySide.New --configuration Release
 
 after_script:
   - chmod +x .ci/build-docs.sh && ./.ci/build-docs.sh


### PR DESCRIPTION
The .NET Dependencies have been updated to 4.3.0 across the board, and we should upgrade!

I've also changed the `System.Threading` dependency to `System.Threading.Tasks`.  The former is not compatible with UWP but the latter is.