### PR TITLE
Bump Dependencies to 4.3.0

### DIFF
--- a/src/MySqlConnector/project.json
+++ b/src/MySqlConnector/project.json
@@ -25,29 +25,29 @@
 				"System.Transactions": "4.0.0.0"
 			},
 			"dependencies": {
-				"System.Buffers": "4.0.0",
-				"System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-				"System.Threading.Tasks.Extensions": "4.0.0"
+				"System.Buffers": "4.3.0",
+				"System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+				"System.Threading.Tasks.Extensions": "4.3.0"
 			}
 		},
 		"netstandard1.3": {
 			"frameworkAssemblies": {
 			},
 			"dependencies": {
-				"System.Buffers": "4.0.0",
-				"System.Collections.Concurrent": "4.0.12",
-				"System.Data.Common": "4.1.0",
-				"System.IO": "4.1.0",
-				"System.IO.Compression": "4.1.0",
-				"System.IO.FileSystem": "4.0.1",
-				"System.Linq": "4.1.0",
-				"System.Net.NameResolution": "4.0.0",
-				"System.Net.Security": "4.0.0",
-				"System.Net.Sockets": "4.1.0",
-				"System.Runtime.Extensions": "4.1.0",
-				"System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-				"System.Text.RegularExpressions": "4.1.0",
-				"System.Threading.Tasks.Extensions": "4.0.0"
+				"System.Buffers": "4.3.0",
+				"System.Collections.Concurrent": "4.3.0",
+				"System.Data.Common": "4.3.0",
+				"System.IO": "4.3.0",
+				"System.IO.Compression": "4.3.0",
+				"System.IO.FileSystem": "4.3.0",
+				"System.Linq": "4.3.0",
+				"System.Net.NameResolution": "4.3.0",
+				"System.Net.Security": "4.3.0",
+				"System.Net.Sockets": "4.3.0",
+				"System.Runtime.Extensions": "4.3.0",
+				"System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+				"System.Text.RegularExpressions": "4.3.0",
+				"System.Threading.Tasks.Extensions": "4.3.0"
 			}
 		}
 	}


### PR DESCRIPTION
The .NET Dependencies have been updated to 4.3.0 across the board, and we should upgrade!

I've also changed the `System.Threading` dependency to `System.Threading.Tasks`.  The former is not compatible with UWP but the latter is.