### PR TITLE
Implement Keepalive

### DIFF
--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -148,6 +148,13 @@ These are the other options that MySqlConnector supports.  They are set to sensi
     <td>True to have MySqlDataReader.GetValue() and MySqlDataReader.GetDateTime() return DateTime.MinValue for date or datetime columns that have disallowed values.</td>
   </tr>
   <tr>
+    <td>Keep Alive, Keepalive</td>
+    <td>0</td>
+    <td>TCP Keepalive idle time.  A value of 0 indicates that the OS Default keepalive settings are used.
+    On Windows, a value greater than 0 is the idle connection time, measured in seconds, before the first keepalive packet is sent.
+    Due to limitations in .NET Core, Unix-based Operating Systems will always use the OS Default keepalive settings.</td>
+  </tr>
+  <tr>
     <td>Old Guids, OldGuids</td>
     <td>false</td>
     <td> The backend representation of a GUID type was changed from BINARY(16) to CHAR(36). This was done to allow developers to use the server function UUID() to populate a GUID table - UUID() generates a 36-character string. Developers of older applications can add 'Old Guids=true' to the connection string to use a GUID of data type BINARY(16).</td>

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -122,6 +122,12 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.ForceSynchronous.SetValue(this, value); }
 		}
 
+		public uint Keepalive
+		{
+			get { return MySqlConnectionStringOption.Keepalive.GetValue(this); }
+			set { MySqlConnectionStringOption.Keepalive.SetValue(this, value); }
+		}
+
 		public bool OldGuids
 		{
 			get { return MySqlConnectionStringOption.OldGuids.GetValue(this); }
@@ -215,6 +221,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<uint> ConnectionTimeout;
 		public static readonly MySqlConnectionStringOption<bool> ConvertZeroDateTime;
 		public static readonly MySqlConnectionStringOption<bool> ForceSynchronous;
+		public static readonly MySqlConnectionStringOption<uint> Keepalive;
 		public static readonly MySqlConnectionStringOption<bool> OldGuids;
 		public static readonly MySqlConnectionStringOption<bool> PersistSecurityInfo;
 		public static readonly MySqlConnectionStringOption<bool> UseAffectedRows;
@@ -325,6 +332,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(ForceSynchronous = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "ForceSynchronous" },
 				defaultValue: false));
+
+			AddOption(Keepalive = new MySqlConnectionStringOption<uint>(
+				keys: new[] { "Keep Alive", "Keepalive" },
+				defaultValue: 0u));
 
 			AddOption(OldGuids = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Old Guids", "OldGuids" },

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -48,6 +48,7 @@ namespace MySql.Data.Serialization
 			ConnectionTimeout = (int)csb.ConnectionTimeout;
 			ConvertZeroDateTime = csb.ConvertZeroDateTime;
 			ForceSynchronous = csb.ForceSynchronous;
+			Keepalive = csb.Keepalive;
 			OldGuids = csb.OldGuids;
 			PersistSecurityInfo = csb.PersistSecurityInfo;
 			UseAffectedRows = csb.UseAffectedRows;
@@ -84,6 +85,7 @@ namespace MySql.Data.Serialization
 			ConnectionTimeout = other.ConnectionTimeout;
 			ConvertZeroDateTime = other.ConvertZeroDateTime;
 			ForceSynchronous = other.ForceSynchronous;
+			Keepalive = other.Keepalive;
 			OldGuids = other.OldGuids;
 			PersistSecurityInfo = other.PersistSecurityInfo;
 			UseAffectedRows = other.UseAffectedRows;
@@ -116,6 +118,7 @@ namespace MySql.Data.Serialization
 		internal readonly int ConnectionTimeout;
 		internal readonly bool ConvertZeroDateTime;
 		internal readonly bool ForceSynchronous;
+		internal readonly uint Keepalive;
 		internal readonly bool OldGuids;
 		internal readonly bool PersistSecurityInfo;
 		internal readonly bool UseAffectedRows;

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -252,7 +252,7 @@ namespace MySql.Data.Serialization
 					m_tcpClient = tcpClient;
 					m_socket = m_tcpClient.Client;
 					m_networkStream = m_tcpClient.GetStream();
-
+					SerializationUtility.SetKeepalive(m_socket, cs.Keepalive);
 					m_state = State.Connected;
 					return true;
 				}

--- a/tests/SideBySide.New/ConnectAsync.cs
+++ b/tests/SideBySide.New/ConnectAsync.cs
@@ -101,6 +101,19 @@ namespace SideBySide
 			}
 		}
 
+		[Fact]
+		public async Task ConnectKeepAlive()
+		{
+			// the goal of this test is to ensure that no exceptions are thrown
+			var csb = AppConfig.CreateConnectionStringBuilder();
+			csb.Keepalive = 1;
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+				await connection.OpenAsync();
+				await Task.Delay(3000);
+			}
+		}
+
 		readonly DatabaseFixture m_database;
 	}
 }


### PR DESCRIPTION
- Fixes #132 
- A value of 0 indicates that the OS Default keepalive settings are used
- On Windows, a value greater than 0 is the idle connection time, measured in seconds, before the first keepalive packet is sent.
- Unix-based Operating Systems will always use the OS Default keepalive settings.