### PR TITLE
Remove unnecessary netstandard1.3 dependencies.

### DIFF
--- a/src/MySqlConnector/project.json
+++ b/src/MySqlConnector/project.json
@@ -37,7 +37,6 @@
 				"System.Buffers": "4.0.0",
 				"System.Collections.Concurrent": "4.0.12",
 				"System.Data.Common": "4.1.0",
-				"System.Globalization": "4.0.11",
 				"System.IO": "4.1.0",
 				"System.IO.Compression": "4.1.0",
 				"System.IO.FileSystem": "4.0.1",
@@ -45,12 +44,9 @@
 				"System.Net.NameResolution": "4.0.0",
 				"System.Net.Security": "4.0.0",
 				"System.Net.Sockets": "4.1.0",
-				"System.Runtime": "4.1.0",
 				"System.Runtime.Extensions": "4.1.0",
 				"System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-				"System.Security.Cryptography.Algorithms": "4.2.0",
 				"System.Text.RegularExpressions": "4.1.0",
-				"System.Threading": "4.0.11",
 				"System.Threading.Tasks.Extensions": "4.0.0"
 			}
 		}


### PR DESCRIPTION
Various dependencies have accumulated during development, and it appears that not all of them are still necessary.