### PR TITLE
try/catch SendAsync in TryPingAsync

### DIFF
--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -138,9 +138,14 @@ namespace MySql.Data.Serialization
 
 		public async Task<bool> TryPingAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			await SendAsync(PingPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
+			// check if client socket is still connected
+			// http://stackoverflow.com/questions/2661764/how-to-check-if-a-socket-is-connected-disconnected-in-c
+			if (m_socket.Poll(1, SelectMode.SelectRead) && m_socket.Available == 0)
+				return false;
+			// client socket is still connected, send ping payload to verify server socket is still connected
 			try
 			{
+				await SendAsync(PingPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
 				var payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 				OkPayload.Create(payload);
 				return true;


### PR DESCRIPTION
Fixes #150.

I tried a lot of different things to recreate a broken pipe in a test case and couldn't figure out how to.  I tried making a TCP Proxy with `socat`, `netcat`, and `nc`, but they all detect `RST` packets and close the connection gracefully.