### PR TITLE
Bulk Insert/Select Perf Tests

### DIFF
--- a/tests/MySqlConnector.Performance/Models/BlogPostQuery.cs
+++ b/tests/MySqlConnector.Performance/Models/BlogPostQuery.cs
@@ -14,7 +14,7 @@ namespace MySqlConnector.Performance.Models
 		{
 			Db = db;
 		}
-		
+
 		public BlogPost FindOne(int id)
 		{
 			var result = ReadAll(FindOneCmd(id).ExecuteReader());
@@ -29,12 +29,12 @@ namespace MySqlConnector.Performance.Models
 
 		public List<BlogPost> LatestPosts()
 		{
-			return ReadAll(LatestPostsCmd().ExecuteReader());
+			return ReadAll(LatestPostsCmd(10).ExecuteReader());
 		}
 
 		public async Task<List<BlogPost>> LatestPostsAsync()
 		{
-			return await ReadAllAsync(await LatestPostsCmd().ExecuteReaderAsync());
+			return await ReadAllAsync(await LatestPostsCmd(10).ExecuteReaderAsync());
 		}
 
 		public void DeleteAll()
@@ -80,10 +80,16 @@ namespace MySqlConnector.Performance.Models
 			return cmd as MySqlCommand;
 		}
 
-		private DbCommand LatestPostsCmd()
+		public DbCommand LatestPostsCmd(int limit)
 		{
 			var cmd = Db.Connection.CreateCommand();
-			cmd.CommandText = @"SELECT `Id`, `Title`, `Content` FROM `BlogPost` ORDER BY `Id` DESC LIMIT 10;";
+			cmd.CommandText = @"SELECT `Id`, `Title`, `Content` FROM `BlogPost` ORDER BY `Id` DESC LIMIT @limit;";
+			cmd.Parameters.Add(new MySqlParameter
+			{
+				ParameterName = "@limit",
+				DbType = DbType.Int32,
+				Value = limit,
+			});
 			return cmd as MySqlCommand;
 		}
 

--- a/tests/MySqlConnector.Performance/README.md
+++ b/tests/MySqlConnector.Performance/README.md
@@ -16,6 +16,10 @@ The application runs on http://localhost:5000 by default.  It drops and creates 
         "Content": "Post Content"
     }
 
+`GET  /api/async/bulkinsert/<num>` and `GET /api/sync/bulkinsert/<num>` Insert <num> blog posts serially in a transaction
+
+`GET  /api/async/bulkselect/<num>` and `GET /api/sync/bulkselect/<num>` Selects <num> blog posts and exhausts the datareader (make sure you have inserted <num> posts first with the bulkinsert endpoint)
+
 The `scripts` directory contains load testing scripts.  These scripts require that the  [Vegeta](https://github.com/tsenart/vegeta/releases) binary is installed and accessible in your PATH.  Here are examples of how to call the load testing scripts:
 
     # by default, runs 50 async queries per second for 5 seconds

--- a/tests/MySqlConnector.Performance/scripts/vegeta/targets-hello.txt
+++ b/tests/MySqlConnector.Performance/scripts/vegeta/targets-hello.txt
@@ -1,0 +1,1 @@
+GET http://localhost:5000/api/sync/hello


### PR DESCRIPTION
Should help for recreate in #164 

Seeing following results with 0.11.2:

```
"Sync: Inserted 100000 records in 00:00:11.5128270"
"Sync: Read 100000 records in 00:00:00.5506590"

"Async: Inserted 100000 records in 00:00:17.0541600"
"Async: Read 100000 records in 00:00:04.0327080"
```