### PR TITLE
Buffer Socket Reads

### DIFF
--- a/src/MySqlConnector/Protocol/Serialization/BufferedByteReader.cs
+++ b/src/MySqlConnector/Protocol/Serialization/BufferedByteReader.cs
@@ -5,6 +5,11 @@ namespace MySql.Data.Protocol.Serialization
 {
 	internal sealed class BufferedByteReader
 	{
+		public BufferedByteReader()
+		{
+			m_buffer = new byte[16384];
+		}
+
 		public ValueTask<ArraySegment<byte>> ReadBytesAsync(IByteHandler byteHandler, int count, IOBehavior ioBehavior)
 		{
 			if (m_remainingData.Count >= count)
@@ -14,50 +19,42 @@ namespace MySql.Data.Protocol.Serialization
 				return new ValueTask<ArraySegment<byte>>(readBytes);
 			}
 
-			if (m_remainingData.Count == 0)
-				return ReadBytesAsync(byteHandler, default(ArraySegment<byte>), count, ioBehavior);
+			var buffer = count > m_buffer.Length ? new byte[count] : m_buffer;
+			if (m_remainingData.Count > 0)
+			{
+				Buffer.BlockCopy(m_remainingData.Array, m_remainingData.Offset, buffer, 0, m_remainingData.Count);
+				m_remainingData = new ArraySegment<byte>(buffer, 0, m_remainingData.Count);
+			}
 
-			// save data from m_remainingData.Array because calling ReadAsync may invalidate it
-			var buffer = new byte[Math.Max(count, 16384)];
-			Buffer.BlockCopy(m_remainingData.Array, m_remainingData.Offset, buffer, 0, m_remainingData.Count);
-			var previousReadBytes = new ArraySegment<byte>(buffer, 0, m_remainingData.Count);
-
-			return ReadBytesAsync(byteHandler, previousReadBytes, count, ioBehavior);
+			return ReadBytesAsync(byteHandler, new ArraySegment<byte>(buffer, m_remainingData.Count, buffer.Length - m_remainingData.Count), count, ioBehavior);
 		}
 
-		private ValueTask<ArraySegment<byte>> ReadBytesAsync(IByteHandler byteHandler, ArraySegment<byte> previousReadBytes, int count, IOBehavior ioBehavior)
+		private ValueTask<ArraySegment<byte>> ReadBytesAsync(IByteHandler byteHandler, ArraySegment<byte> buffer, int count, IOBehavior ioBehavior)
 		{
-			return byteHandler.ReadBytesAsync(count - previousReadBytes.Count, ioBehavior)
-				.ContinueWith(readBytes =>
+			return byteHandler.ReadBytesAsync(buffer, ioBehavior)
+				.ContinueWith(readBytesCount =>
 				{
-					if (readBytes.Count == 0)
-						return new ValueTask<ArraySegment<byte>>(previousReadBytes);
-
-					if (previousReadBytes.Array == null && readBytes.Count >= count)
+					if (readBytesCount == 0)
 					{
-						m_remainingData = readBytes.Slice(count);
-						return new ValueTask<ArraySegment<byte>>(readBytes.Slice(0, count));
+						var data = m_remainingData;
+						m_remainingData = default(ArraySegment<byte>);
+						return new ValueTask<ArraySegment<byte>>(data);
 					}
 
-					var previousReadBytesArray = previousReadBytes.Array;
-					if (previousReadBytesArray == null)
-						previousReadBytesArray = new byte[Math.Max(count, 16384)];
-					else if (previousReadBytesArray.Length < previousReadBytes.Count + readBytes.Count)
-						Array.Resize(ref previousReadBytesArray, Math.Max(previousReadBytesArray.Length * 2, previousReadBytes.Count + readBytes.Count));
-
-					Buffer.BlockCopy(readBytes.Array, readBytes.Offset, previousReadBytesArray, previousReadBytes.Offset + previousReadBytes.Count, readBytes.Count);
-					previousReadBytes = new ArraySegment<byte>(previousReadBytesArray, previousReadBytes.Offset, previousReadBytes.Count + readBytes.Count);
-
-					if (previousReadBytes.Count >= count)
+					var bufferSize = buffer.Offset + readBytesCount;
+					if (bufferSize >= count)
 					{
-						m_remainingData = previousReadBytes.Slice(count);
-						return new ValueTask<ArraySegment<byte>>(previousReadBytes.Slice(0, count));
+						var bufferBytes = new ArraySegment<byte>(buffer.Array, 0, bufferSize);
+						var requestedBytes = bufferBytes.Slice(0, count);
+						m_remainingData = bufferBytes.Slice(count);
+						return new ValueTask<ArraySegment<byte>>(requestedBytes);
 					}
 
-					return ReadBytesAsync(byteHandler, previousReadBytes, count, ioBehavior);
+					return ReadBytesAsync(byteHandler, new ArraySegment<byte>(buffer.Array, bufferSize, buffer.Array.Length - bufferSize), count, ioBehavior);
 				});
 		}
 
 		ArraySegment<byte> m_remainingData;
+		readonly byte[] m_buffer;
 	}
 }

--- a/src/MySqlConnector/Protocol/Serialization/IByteHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/IByteHandler.cs
@@ -8,13 +8,13 @@ namespace MySql.Data.Protocol.Serialization
 		/// <summary>
 		/// Reads data from this byte handler.
 		/// </summary>
-		/// <param name="count">The number of bytes to read.</param>
+		/// <param name="buffer">The buffer to read into.</param>
 		/// <param name="ioBehavior">The <see cref="IOBehavior"/> to use when reading data.</param>
-		/// <returns>An <see cref="ArraySegment{Byte}"/> containing the data that was read. This will contain at most <paramref name="count"/> bytes.
-		/// If not all the data was available, fewer than <paramref name="count"/> bytes may be returned. If reading failed, zero bytes will be returned. This
+		/// <returns>A <see cref="ValueTask{Int32}"/>. Number of bytes read.</returns>
+		/// If reading failed, zero bytes will be returned. This
 		/// <see cref="ArraySegment{Byte}"/> will be valid to read from until the next time <see cref="ReadBytesAsync"/> or
 		/// <see cref="WriteBytesAsync"/> is called.</returns>
-		ValueTask<ArraySegment<byte>> ReadBytesAsync(int count, IOBehavior ioBehavior);
+		ValueTask<int> ReadBytesAsync(ArraySegment<byte> buffer, IOBehavior ioBehavior);
 
 		/// <summary>
 		/// Writes data to this byte handler.

--- a/src/MySqlConnector/Protocol/Serialization/SocketByteHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/SocketByteHandler.cs
@@ -11,20 +11,18 @@ namespace MySql.Data.Protocol.Serialization
 			m_socket = socket;
 			var socketEventArgs = new SocketAsyncEventArgs();
 			m_socketAwaitable = new SocketAwaitable(socketEventArgs);
-			m_buffer = new byte[16384];
 		}
 
-		public ValueTask<ArraySegment<byte>> ReadBytesAsync(int count, IOBehavior ioBehavior)
+		public ValueTask<int> ReadBytesAsync(ArraySegment<byte> buffer, IOBehavior ioBehavior)
 		{
-			var buffer = count < m_buffer.Length ? m_buffer : new byte[count];
-			if (ioBehavior == IOBehavior.Asynchronous && m_socket.Available < count)
+			if (ioBehavior == IOBehavior.Asynchronous)
 			{
-				return new ValueTask<ArraySegment<byte>>(DoReadBytesAsync(buffer, 0, count));
+				return new ValueTask<int>(DoReadBytesAsync(buffer));
 			}
 			else
 			{
-				var bytesRead = m_socket.Receive(buffer, 0, count, SocketFlags.None);
-				return new ValueTask<ArraySegment<byte>>(new ArraySegment<byte>(buffer, 0, bytesRead));
+				var bytesRead = m_socket.Receive(buffer.Array, buffer.Offset, buffer.Count, SocketFlags.None);
+				return new ValueTask<int>(bytesRead);
 			}
 		}
 
@@ -41,30 +39,21 @@ namespace MySql.Data.Protocol.Serialization
 			}
 		}
 
-		private async Task<ArraySegment<byte>> DoReadBytesAsync(byte[] buffer, int offset, int count)
+		private async Task<int> DoReadBytesAsync(ArraySegment<byte> buffer)
 		{
-			m_socketAwaitable.EventArgs.SetBuffer(buffer, offset, count);
+			m_socketAwaitable.EventArgs.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
 			await m_socket.ReceiveAsync(m_socketAwaitable);
-			return new ArraySegment<byte>(buffer, 0, m_socketAwaitable.EventArgs.BytesTransferred);
+			return m_socketAwaitable.EventArgs.BytesTransferred;
 		}
 
 		private async Task<int> DoWriteBytesAsync(ArraySegment<byte> payload)
 		{
-			if (payload.Count <= m_buffer.Length)
-			{
-				Buffer.BlockCopy(payload.Array, payload.Offset, m_buffer, 0, payload.Count);
-				m_socketAwaitable.EventArgs.SetBuffer(m_buffer, 0, payload.Count);
-			}
-			else
-			{
-				m_socketAwaitable.EventArgs.SetBuffer(payload.Array, payload.Offset, payload.Count);
-			}
+			m_socketAwaitable.EventArgs.SetBuffer(payload.Array, payload.Offset, payload.Count);
 			await m_socket.SendAsync(m_socketAwaitable);
 			return 0;
 		}
 
 		readonly Socket m_socket;
 		readonly SocketAwaitable m_socketAwaitable;
-		readonly byte[] m_buffer;
 	}
 }


### PR DESCRIPTION
- Fixes #164 
- Uses `BufferedByteReader` to read up to 16384 bytes out of the OS Socket Buffer at once
- Changes `IByteHandler.ReadAsync` method to accept an `ArraySegment<byte> buffer` parameter that new data is read into
