### PR TITLE
Reader Functions for DateTimeOffset

### DIFF
--- a/docs/content/api/mysql-data-reader.md
+++ b/docs/content/api/mysql-data-reader.md
@@ -22,3 +22,7 @@ Additionally, MySqlDataReader provides the following public properties and metho
 
 Gets the value of the specified column as an sbyte
 ***
+`public DateTimeOffset GetDateTimeOffset(int ordinal)`
+
+Gets the value of the specified column as a DateTimeOffset with an offset of 0
+***

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -169,6 +169,8 @@ namespace MySql.Data.MySqlClient
 
 		public override DateTime GetDateTime(int ordinal) => GetResultSet().GetCurrentRow().GetDateTime(ordinal);
 
+		public DateTimeOffset GetDateTimeOffset(int ordinal) => GetResultSet().GetCurrentRow().GetDateTimeOffset(ordinal);
+
 		public override string GetString(int ordinal) => GetResultSet().GetCurrentRow().GetString(ordinal);
 
 		public override decimal GetDecimal(int ordinal) => GetResultSet().GetCurrentRow().GetDecimal(ordinal);
@@ -190,6 +192,14 @@ namespace MySql.Data.MySqlClient
 			DoClose();
 		}
 #endif
+
+		public override T GetFieldValue<T>(int ordinal)
+		{
+			if (typeof(T) == typeof(DateTimeOffset))
+				return (T) Convert.ChangeType(GetDateTimeOffset(ordinal), typeof(T));
+
+			return base.GetFieldValue<T>(ordinal);
+		}
 
 		protected override void Dispose(bool disposing)
 		{

--- a/src/MySqlConnector/MySqlClient/Results/Row.cs
+++ b/src/MySqlConnector/MySqlClient/Results/Row.cs
@@ -229,6 +229,11 @@ namespace MySql.Data.MySqlClient.Results
 			return (DateTime) GetValue(ordinal);
 		}
 
+		public DateTimeOffset GetDateTimeOffset(int ordinal)
+		{
+			return new DateTimeOffset(DateTime.SpecifyKind(GetDateTime(ordinal), DateTimeKind.Utc));
+		}
+
 		public string GetString(int ordinal)
 		{
 			return (string) GetValue(ordinal);


### PR DESCRIPTION
- Fixes #175 
- Adds public `MySqlDataReader.GetDateTimeOffset` function
- Adds overrides for `MySqlDataReader.GetFieldValue<T>` `MySqlDataReader.GetFieldValueAsync<T>`
  - Needed to convert `DateTimeOffset` if `MySqlDataReader.GetFieldValue<typeof(DateTimeOffset)>` is called
  - May be useful in the future
- Added test path for `MySqlDataReader.GetFieldValue<T>` and `MySqlDataReader.GetFieldValueAsync<T>`
