### PR TITLE
Reset connection on return to pool

### DIFF
--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -61,7 +61,7 @@ namespace MySql.Data.MySqlClient
 				if (session.PoolGeneration == m_generation)
 					m_sessions.Enqueue(session);
 				else
-					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).ConfigureAwait(false);
+					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 			}
 			finally
 			{

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -33,11 +33,6 @@ namespace MySql.Data.MySqlClient
 					}
 					else
 					{
-						// session is valid, reset if supported
-						if (m_connectionSettings.ConnectionReset)
-						{
-							await session.ResetConnectionAsync(m_connectionSettings, ioBehavior, cancellationToken).ConfigureAwait(false);
-						}
 						// pooled session is ready to be used; return it
 						return session;
 					}
@@ -58,7 +53,23 @@ namespace MySql.Data.MySqlClient
 		{
 			try
 			{
+				var success = false;
+
 				if (session.PoolGeneration == m_generation)
+				{
+					try
+					{
+						// reset the connection upon returning it to the pool
+						if (m_connectionSettings.ConnectionReset)
+							session.ResetConnectionAsync(m_connectionSettings, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
+						success = true;
+					}
+					catch (MySqlException)
+					{
+					}
+				}
+
+				if (success)
 					m_sessions.Enqueue(session);
 				else
 					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();

--- a/tests/SideBySide.New/ConnectionPool.cs
+++ b/tests/SideBySide.New/ConnectionPool.cs
@@ -137,6 +137,7 @@ namespace SideBySide
 			csb.Pooling = true;
 			csb.MinimumPoolSize = 0;
 			csb.MaximumPoolSize = 1;
+			csb.ConnectionReset = false;
 			int serverThread;
 
 			using (var connection = new MySqlConnection(csb.ConnectionString))


### PR DESCRIPTION
Issue #178 suggests that the connection be reset when it's returned to the pool, so that it's ready immediately when a new `MySqlConnection` is opened (and reuses a pooled connection).

In the current PR, the connection is reset synchronously when the session is closed; this may not be sufficient to increase performance since the caller will still be blocked (albeit at the end of the connection lifetime, not at the beginning). It may be necessary to offload the work of resetting the connection to a background thread.