### PR TITLE
Unify how config.json is found and used by tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ build_script:
 - cmd: |-
     dotnet build src\MySqlConnector --configuration Release
     dotnet build tests\SideBySide.New --configuration Release
-    copy .ci\config\config.json tests\SideBySide.New\config.json
     "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" /p:Configuration=Release /t:SideBySide_Baseline MySqlConnector.sln
 before_test:
 - cmd: |-
@@ -21,7 +20,7 @@ test_script:
     dotnet test tests\MySqlConnector.Tests --configuration Release
     echo Executing tests with No Compression, No SSL && copy /y .ci\config\config.json tests\SideBySide.New\config.json && dotnet test tests/SideBySide.New --configuration Release
     echo Executing tests with Compression, No SSL && copy /y .ci\config\config.compression.json tests\SideBySide.New\config.json && dotnet test tests/SideBySide.New --configuration Release
-    packages\xunit.runner.console.2.1.0\tools\xunit.console.exe tests\SideBySide.Baseline\bin\Release\SideBySide.Baseline.dll
+    echo Executing baseline tests with No Compression, No SSL && copy .ci\config\config.json tests\SideBySide.New\config.json && packages\xunit.runner.console.2.1.0\tools\xunit.console.exe tests\SideBySide.Baseline\bin\Release\SideBySide.Baseline.dll
 notifications:
 - provider: Slack
   incoming_webhook:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ build_script:
 - cmd: |-
     dotnet build src\MySqlConnector --configuration Release
     dotnet build tests\SideBySide.New --configuration Release
-    copy tests\SideBySide.New\config.json.example tests\SideBySide.New\config.json
+    copy .ci\config\config.json tests\SideBySide.New\config.json
     "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe" /p:Configuration=Release /t:SideBySide_Baseline MySqlConnector.sln
 before_test:
 - cmd: |-
@@ -19,7 +19,7 @@ before_test:
 test_script:
 - cmd: |-
     dotnet test tests\MySqlConnector.Tests --configuration Release
-    echo Executing tests with No Compression, No SSL && copy /y tests\SideBySide.New\config.json.example tests\SideBySide.New\config.json && dotnet test tests/SideBySide.New --configuration Release
+    echo Executing tests with No Compression, No SSL && copy /y .ci\config\config.json tests\SideBySide.New\config.json && dotnet test tests/SideBySide.New --configuration Release
     echo Executing tests with Compression, No SSL && copy /y .ci\config\config.compression.json tests\SideBySide.New\config.json && dotnet test tests/SideBySide.New --configuration Release
     packages\xunit.runner.console.2.1.0\tools\xunit.console.exe tests\SideBySide.Baseline\bin\Release\SideBySide.Baseline.dll
 notifications:

--- a/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
+++ b/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
@@ -178,10 +178,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\SideBySide.New\config.json">
-      <Link>config.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/tests/SideBySide.New/Attributes.cs
+++ b/tests/SideBySide.New/Attributes.cs
@@ -2,7 +2,7 @@
 using MySql.Data.MySqlClient;
 using Xunit;
 
-namespace SideBySide.New
+namespace SideBySide
 {
 	public class CachedProcedureTheoryAttribute : TheoryAttribute
 	{

--- a/tests/SideBySide.New/ConnectAsync.cs
+++ b/tests/SideBySide.New/ConnectAsync.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
-using SideBySide.New;
 using Xunit;
 
 namespace SideBySide

--- a/tests/SideBySide.New/ConnectSync.cs
+++ b/tests/SideBySide.New/ConnectSync.cs
@@ -9,7 +9,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
-using SideBySide.New;
 using Xunit;
 
 namespace SideBySide

--- a/tests/SideBySide.New/DataTypes.cs
+++ b/tests/SideBySide.New/DataTypes.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Dapper;
 using MySql.Data.MySqlClient;
-using SideBySide.New;
 using Xunit;
 using static System.FormattableString;
 

--- a/tests/SideBySide.New/InsertTests.cs
+++ b/tests/SideBySide.New/InsertTests.cs
@@ -5,7 +5,7 @@ using Dapper;
 using Xunit;
 using System.Data;
 
-namespace SideBySide.New
+namespace SideBySide
 {
 	public class InsertTests : IClassFixture<DatabaseFixture>
 	{

--- a/tests/SideBySide.New/StoredProcedureFixture.cs
+++ b/tests/SideBySide.New/StoredProcedureFixture.cs
@@ -1,6 +1,6 @@
 ﻿using Dapper;
 
-namespace SideBySide.New
+namespace SideBySide
 {
 	public class StoredProcedureFixture : DatabaseFixture
 	{

--- a/tests/SideBySide.New/StoredProcedureTests.cs
+++ b/tests/SideBySide.New/StoredProcedureTests.cs
@@ -3,7 +3,6 @@ using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
-using SideBySide.New;
 using Xunit;
 
 namespace SideBySide


### PR DESCRIPTION
* Use the same `config.json` file for (no compression, no SSL) Appveyor and Travis tests
* Find the same file at runtime in Baseline tests, instead of copying it to the `bin` folder
* Clean up namespaces in code