### PR TITLE
dispose reader when disposing connection. fixes #196

### DIFF
--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -57,7 +57,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 			var payload = new PayloadData(preparer.ParseAndBindParameters());
 			await m_command.Connection.Session.SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
 			var reader = await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
-			m_command.Connection.HasActiveReader = true;
+			m_command.Connection.ActiveReader = reader;
 			return reader;
 		}
 

--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -177,7 +177,7 @@ namespace MySql.Data.MySqlClient
 				throw new InvalidOperationException("The transaction associated with this command is not the connection's active transaction.");
 			if (string.IsNullOrWhiteSpace(CommandText))
 				throw new InvalidOperationException("CommandText must be specified");
-			if (Connection.HasActiveReader)
+			if (Connection.ActiveReader != null)
 				throw new MySqlException("There is already an open DataReader associated with this Connection which must be closed first.");
 		}
 

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -224,7 +224,7 @@ namespace MySql.Data.MySqlClient
 		}
 
 		internal MySqlTransaction CurrentTransaction { get; set; }
-		internal bool HasActiveReader { get; set; }
+		internal MySqlDataReader ActiveReader { get; set; }
 		internal bool AllowUserVariables => m_connectionSettings.AllowUserVariables;
 		internal bool ConvertZeroDateTime => m_connectionSettings.ConvertZeroDateTime;
 		internal bool OldGuids => m_connectionSettings.OldGuids;
@@ -281,6 +281,10 @@ namespace MySql.Data.MySqlClient
 			if (m_connectionState != ConnectionState.Closed)
 			{
 				m_cachedProcedures = null;
+				if (ActiveReader != null){
+					ActiveReader.Dispose();
+					ActiveReader = null;
+				}
 				if (CurrentTransaction != null)
 				{
 					CurrentTransaction.Dispose();

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -250,7 +250,7 @@ namespace MySql.Data.MySqlClient
 				m_nextResultSetBuffer.Clear();
 
 				var connection = Command.Connection;
-				connection.HasActiveReader = false;
+				connection.ActiveReader = null;
 				Command.ReaderClosed();
 				if ((m_behavior & CommandBehavior.CloseConnection) != 0)
 				{


### PR DESCRIPTION
- Change `bool HasActiveReader` to `MySqlDataReader ActiveReader`
- Dispose active reader if one exists when connection is closed