### PR TITLE
Buffer Result Sets Implementation

### DIFF
--- a/.ci/config/config.buffer.json
+++ b/.ci/config/config.buffer.json
@@ -1,0 +1,11 @@
+{
+    "Data": {
+      "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true;BufferResultSets=true",
+      "PasswordlessUser": "no_password",
+      "SecondaryDatabase": "testdb2",
+      "SupportsCachedProcedures": true,
+      "SupportsJson": true,
+      "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
+      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
 - echo 'Executing tests with No Compression, SSL' && ./.ci/use-config.sh config.ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 - echo 'Executing tests with Compression, SSL' && ./.ci/use-config.sh config.compression+ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 - echo 'Executing tests with Unix Domain Socket, No Compression, No SSL' && ./.ci/use-config.sh config.uds.json && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
+- echo 'Executing tests with Buffering, No Compression, No SSL' && ./.ci/use-config.sh config.buffer.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 
 after_script:
 - chmod +x .ci/build-docs.sh && ./.ci/build-docs.sh

--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -127,9 +127,15 @@ These are the other options that MySqlConnector supports.  They are set to sensi
     <th style="width: 70%">Descriotion</th>
   </thead>
   <tr>
-    <td>AllowUserVariables</td>
-    <td>true</td>
+    <td>AllowUserVariables, Allow User Variables</td>
+    <td>false</td>
     <td>Setting this to true indicates that the provider expects user variables in the SQL.</td>
+  </tr>
+  <tr>
+    <td>BufferResultSets, Buffer Result Sets</td>
+    <td>false</td>
+    <td>Setting this to true immediately buffers all result sets to memory upon calling ExecuteReader/ExecuteReaderAsync.  This will allow the connection
+      to execute another statement while still holding the original postion of the reader.  Do not use when result sets are bigger than available memory.</td>
   </tr>
   <tr>
     <td>Compress, Use Compression, UseCompression</td>

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -56,9 +56,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 			var preparer = new MySqlStatementPreparer(commandText, parameterCollection, statementPreparerOptions);
 			var payload = new PayloadData(preparer.ParseAndBindParameters());
 			await m_command.Connection.Session.SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
-			var reader = await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
-			m_command.Connection.ActiveReader = reader;
-			return reader;
+			return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
 		}
 
 		readonly MySqlCommand m_command;

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -226,6 +226,7 @@ namespace MySql.Data.MySqlClient
 		internal MySqlTransaction CurrentTransaction { get; set; }
 		internal MySqlDataReader ActiveReader { get; set; }
 		internal bool AllowUserVariables => m_connectionSettings.AllowUserVariables;
+		internal bool BufferResultSets => m_connectionSettings.BufferResultSets;
 		internal bool ConvertZeroDateTime => m_connectionSettings.ConvertZeroDateTime;
 		internal bool OldGuids => m_connectionSettings.OldGuids;
 		internal bool TreatTinyAsBoolean => m_connectionSettings.TreatTinyAsBoolean;

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -98,6 +98,12 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.AllowUserVariables.SetValue(this, value); }
 		}
 
+		public bool BufferResultSets
+		{
+			get { return MySqlConnectionStringOption.BufferResultSets.GetValue(this); }
+			set { MySqlConnectionStringOption.BufferResultSets.SetValue(this, value); }
+		}
+
 		public string CharacterSet
 		{
 			get { return MySqlConnectionStringOption.CharacterSet.GetValue(this); }
@@ -223,6 +229,7 @@ namespace MySql.Data.MySqlClient
 
 		// Other Options
 		public static readonly MySqlConnectionStringOption<bool> AllowUserVariables;
+		public static readonly MySqlConnectionStringOption<bool> BufferResultSets;
 		public static readonly MySqlConnectionStringOption<string> CharacterSet;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionTimeout;
 		public static readonly MySqlConnectionStringOption<bool> ConvertZeroDateTime;
@@ -322,6 +329,10 @@ namespace MySql.Data.MySqlClient
 			// Other Options
 			AddOption(AllowUserVariables = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "AllowUserVariables", "Allow User Variables" },
+				defaultValue: false));
+
+			AddOption(BufferResultSets = new MySqlConnectionStringOption<bool>(
+				keys: new[] { "BufferResultSets", "Buffer Result Sets" },
 				defaultValue: false));
 
 			AddOption(CharacterSet = new MySqlConnectionStringOption<string>(

--- a/src/MySqlConnector/MySqlClient/Results/Row.cs
+++ b/src/MySqlConnector/MySqlClient/Results/Row.cs
@@ -52,6 +52,7 @@ namespace MySql.Data.MySqlClient.Results
 				ArrayPool<int>.Shared.Return(m_dataLengths);
 				ArrayPool<int>.Shared.Return(m_dataOffsets);
 				ArrayPool<byte>.Shared.Return(m_payload);
+				m_buffered = false;
 			}
 			m_dataLengths = null;
 			m_dataOffsets = null;

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -44,6 +44,7 @@ namespace MySql.Data.Serialization
 
 			// Other Options
 			AllowUserVariables = csb.AllowUserVariables;
+			BufferResultSets = csb.BufferResultSets;
 			ConnectionTimeout = (int)csb.ConnectionTimeout;
 			ConvertZeroDateTime = csb.ConvertZeroDateTime;
 			ForceSynchronous = csb.ForceSynchronous;
@@ -82,6 +83,7 @@ namespace MySql.Data.Serialization
 
 			// Other Options
 			AllowUserVariables = other.AllowUserVariables;
+			BufferResultSets = other.BufferResultSets;
 			ConnectionTimeout = other.ConnectionTimeout;
 			ConvertZeroDateTime = other.ConvertZeroDateTime;
 			ForceSynchronous = other.ForceSynchronous;
@@ -116,6 +118,7 @@ namespace MySql.Data.Serialization
 
 		// Other Options
 		internal readonly bool AllowUserVariables;
+		internal readonly bool BufferResultSets;
 		internal readonly int ConnectionTimeout;
 		internal readonly bool ConvertZeroDateTime;
 		internal readonly bool ForceSynchronous;

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -23,6 +23,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(false, csb.ConvertZeroDateTime);
 			Assert.Equal("", csb.Database);
 #if !BASELINE
+			Assert.Equal(false, csb.BufferResultSets);
 			Assert.Equal(false, csb.ForceSynchronous);
 #endif
 			Assert.Equal(0u, csb.Keepalive);
@@ -61,6 +62,7 @@ namespace MySql.Data.Tests
 				                   "ConnectionReset=false;" +
 				                   "Convert Zero Datetime=true;" +
 #if !BASELINE
+				                   "bufferresultsets=true;" +
 				                   "forcesynchronous=true;" +
 #endif
 				                   "Keep Alive=90;" +
@@ -85,6 +87,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(true, csb.ConvertZeroDateTime);
 			Assert.Equal("schema_name", csb.Database);
 #if !BASELINE
+			Assert.Equal(true, csb.BufferResultSets);
 			Assert.Equal(true, csb.ForceSynchronous);
 #endif
 			Assert.Equal(90u, csb.Keepalive);

--- a/tests/SideBySide/Attributes.cs
+++ b/tests/SideBySide/Attributes.cs
@@ -67,6 +67,16 @@ namespace SideBySide
 		}
 	}
 
+	public class UnbufferedResultSetsFactAttribute : FactAttribute
+	{
+		public UnbufferedResultSetsFactAttribute()
+		{
+			var csb = AppConfig.CreateConnectionStringBuilder();
+			if(csb.BufferResultSets == true)
+				Skip = "Do not run when BufferResultSets are used";
+		}
+	}
+
 	public class TcpConnectionFactAttribute : FactAttribute
 	{
 		public TcpConnectionFactAttribute()

--- a/tests/SideBySide/Attributes.cs
+++ b/tests/SideBySide/Attributes.cs
@@ -69,12 +69,14 @@ namespace SideBySide
 
 	public class UnbufferedResultSetsFactAttribute : FactAttribute
 	{
+#if !BASELINE
 		public UnbufferedResultSetsFactAttribute()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
 			if(csb.BufferResultSets == true)
 				Skip = "Do not run when BufferResultSets are used";
 		}
+#endif
 	}
 
 	public class TcpConnectionFactAttribute : FactAttribute

--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -152,7 +152,9 @@ create table query_invalid_sql(id integer not null primary key auto_increment);"
 		public async Task MultipleBufferedReaders()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
+#if !BASELINE
 			csb.BufferResultSets = true;
+#endif
 
 			using (var connection = new MySqlConnection(csb.ConnectionString))
 			{


### PR DESCRIPTION
- Fixes #202 
- Changes Result Set exceptions to be thrown at the time the result set is activated
  - This allows Buffered result sets to throw exceptions at the same time as their un-buffered counterpart would
- Adds test for executing multiple readers without disposing
- Adds TravisCI test run with `BufferResultSets=true` to run all tests with buffered option