### PR TITLE
Implement TrimPool

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -168,21 +168,24 @@ namespace MySql.Data.MySqlClient
 
 		public int ServerThread => m_session.ConnectionId;
 
-		public static void ClearPool(MySqlConnection connection) => ClearPoolAsync(connection, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
-		public static Task ClearPoolAsync(MySqlConnection connection) => ClearPoolAsync(connection, connection.AsyncIOBehavior, CancellationToken.None);
-		public static Task ClearPoolAsync(MySqlConnection connection, CancellationToken cancellationToken) => ClearPoolAsync(connection, connection.AsyncIOBehavior, cancellationToken);
-		public static void ClearAllPools() => ConnectionPool.ClearPoolsAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
-		public static Task ClearAllPoolsAsync() => ConnectionPool.ClearPoolsAsync(IOBehavior.Asynchronous, CancellationToken.None);
-		public static Task ClearAllPoolsAsync(CancellationToken cancellationToken) => ConnectionPool.ClearPoolsAsync(IOBehavior.Asynchronous, cancellationToken);
+		public static void ClearPool(MySqlConnection connection) => TrimPoolAsync(connection, IOBehavior.Synchronous, 0, CancellationToken.None).GetAwaiter().GetResult();
+		public static Task ClearPoolAsync(MySqlConnection connection) => TrimPoolAsync(connection, connection.AsyncIOBehavior, 0, CancellationToken.None);
+		public static Task ClearPoolAsync(MySqlConnection connection, CancellationToken cancellationToken) => TrimPoolAsync(connection, connection.AsyncIOBehavior, 0, cancellationToken);
+		public static void ClearAllPools() => ConnectionPool.TrimPoolsAsync(IOBehavior.Synchronous, 0, CancellationToken.None).GetAwaiter().GetResult();
+		public static Task ClearAllPoolsAsync() => ConnectionPool.TrimPoolsAsync(IOBehavior.Asynchronous, 0, CancellationToken.None);
+		public static Task ClearAllPoolsAsync(CancellationToken cancellationToken) => ConnectionPool.TrimPoolsAsync(IOBehavior.Asynchronous, 0, cancellationToken);
 
-		private static async Task ClearPoolAsync(MySqlConnection connection, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		public static Task TrimPoolAsync(MySqlConnection connection, int connectionsToKeep, CancellationToken cancellationToken) => TrimPoolAsync(connection, connection.AsyncIOBehavior, connectionsToKeep, cancellationToken);
+		public static Task TrimAllPoolsAsync(int connectionsToKeep, CancellationToken cancellationToken) => ConnectionPool.TrimPoolsAsync(IOBehavior.Asynchronous, connectionsToKeep, cancellationToken);
+
+		private static async Task TrimPoolAsync(MySqlConnection connection, IOBehavior ioBehavior, int connectionsToKeep, CancellationToken cancellationToken)
 		{
 			if (connection == null)
 				throw new ArgumentNullException(nameof(connection));
 
 			var pool = ConnectionPool.GetPool(connection.m_connectionSettings);
 			if (pool != null)
-				await pool.ClearAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+				await pool.TrimAsync(ioBehavior, connectionsToKeep, cancellationToken).ConfigureAwait(false);
 		}
 
 		protected override DbCommand CreateDbCommand() => new MySqlCommand(this, CurrentTransaction);


### PR DESCRIPTION
This is an idea to work around Connection Lifetime that should have a similar effect. Related to #211.

This patch transforms `ClearPool` into `TrimPool`, and makes `ClearPool` = TrimPool(conectionsToKeep: 0);

Then it adds a static method `MySqlConnection.TrimPool(int connectionsToKeep)` that should release only the required number of connections to keep the pool at some sane size without releasing more than required.

Ideally, it would be better to trim connections based on lifetime, but I'm not confortable changing this codebase yet to add this. If it was possible to add some method like "TrimPool(TimeSpan)" that would trim based on idle time, I could easily implement the timer on the app side calling it every 3 minutes or so.