### PR TITLE
Throw MySqlException for oversize packets.

### DIFF
--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -63,7 +63,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 				await m_command.Connection.Session.SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
 				return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
 			}
-			catch (Exception ex) when (payload.ArraySegment.Count > 4194304 && (ex is SocketException || ex is IOException))
+			catch (Exception ex) when (payload.ArraySegment.Count > 4194304 && (ex is SocketException || ex is IOException || ex is MySqlProtocolException))
 			{
 				// the default MySQL Server value for max_allowed_packet (in MySQL 5.7) is 4MiB: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet
 				// use "decimal megabytes" (to round up) when creating the exception message

--- a/src/MySqlConnector/MySqlClient/MySqlProtocolException.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlProtocolException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace MySql.Data.MySqlClient
+{
+	public sealed class MySqlProtocolException : InvalidOperationException
+	{
+		internal static MySqlProtocolException CreateForPacketOutOfOrder(int expectedSequenceNumber, int packetSequenceNumber)
+		{
+			return new MySqlProtocolException("Packet received out-of-order. Expected {0}; got {1}.".FormatInvariant(expectedSequenceNumber, packetSequenceNumber));
+		}
+
+		private MySqlProtocolException(string message)
+			: base(message)
+		{
+		}
+	}
+}

--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -29,7 +29,6 @@ namespace MySql.Data.MySqlClient.Results
 			m_readBuffer.Clear();
 			m_row = null;
 			m_rowBuffered = null;
-			MySqlException exception = null;
 
 			try
 			{
@@ -71,7 +70,7 @@ namespace MySql.Data.MySqlClient.Results
 						catch (Exception ex)
 						{
 							// store the exception, to be thrown after reading the response packet from the server
-							exception = new MySqlException("Error during LOAD DATA LOCAL INFILE", ex);
+							ReadResultSetHeaderException = new MySqlException("Error during LOAD DATA LOCAL INFILE", ex);
 						}
 
 						await Session.SendReplyAsync(EmptyPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
@@ -98,9 +97,6 @@ namespace MySql.Data.MySqlClient.Results
 						break;
 					}
 				}
-
-				if (exception != null)
-					throw exception;
 			}
 			catch (Exception ex)
 			{

--- a/src/MySqlConnector/Protocol/Serialization/CompressedPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/CompressedPayloadHandler.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
 using MySql.Data.Serialization;
 
 namespace MySql.Data.Protocol.Serialization
@@ -87,7 +88,7 @@ namespace MySql.Data.Protocol.Serialization
 						if (protocolErrorBehavior == ProtocolErrorBehavior.Ignore)
 							return default(ValueTask<int>);
 
-						var exception = new InvalidOperationException("Packet received out-of-order. Expected {0}; got {1}.".FormatInvariant(expectedSequenceNumber, packetSequenceNumber));
+						var exception = MySqlProtocolException.CreateForPacketOutOfOrder(expectedSequenceNumber, packetSequenceNumber);
 						return ValueTaskExtensions.FromException<int>(exception);
 					}
 

--- a/src/MySqlConnector/Protocol/Serialization/ProtocolUtility.cs
+++ b/src/MySqlConnector/Protocol/Serialization/ProtocolUtility.cs
@@ -2,6 +2,7 @@
 using System.Buffers;
 using System.IO;
 using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
 using MySql.Data.Serialization;
 
 namespace MySql.Data.Protocol.Serialization
@@ -29,7 +30,7 @@ namespace MySql.Data.Protocol.Serialization
 						if (protocolErrorBehavior == ProtocolErrorBehavior.Ignore)
 							return default(ValueTask<Packet>);
 
-						var exception = new InvalidOperationException("Packet received out-of-order. Expected {0}; got {1}.".FormatInvariant(expectedSequenceNumber.Value, packetSequenceNumber));
+						var exception = MySqlProtocolException.CreateForPacketOutOfOrder(expectedSequenceNumber.Value, packetSequenceNumber);
 						return ValueTaskExtensions.FromException<Packet>(exception);
 					}
 

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -447,7 +447,16 @@ namespace MySql.Data.Serialization
 		private ValueTask<int> TryAsync<TArg>(Func<TArg, IOBehavior, ValueTask<int>> func, TArg arg, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
 			VerifyConnected();
-			var task = func(arg, ioBehavior);
+			ValueTask<int> task;
+			try
+			{
+				task = func(arg, ioBehavior);
+			}
+			catch (Exception ex)
+			{
+				task = ValueTaskExtensions.FromException<int>(ex);
+			}
+
 			if (task.IsCompletedSuccessfully)
 				return task;
 
@@ -468,7 +477,16 @@ namespace MySql.Data.Serialization
 		private ValueTask<PayloadData> TryAsync(Func<ProtocolErrorBehavior, IOBehavior, ValueTask<ArraySegment<byte>>> func, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
 			VerifyConnected();
-			var task = func(ProtocolErrorBehavior.Throw, ioBehavior);
+			ValueTask<ArraySegment<byte>> task;
+			try
+			{
+				task = func(ProtocolErrorBehavior.Throw, ioBehavior);
+			}
+			catch (Exception ex)
+			{
+				task = ValueTaskExtensions.FromException<ArraySegment<byte>>(ex);
+			}
+
 			if (task.IsCompletedSuccessfully)
 			{
 				var payload = new PayloadData(task.Result);


### PR DESCRIPTION
When a MySQL Server receives a packet larger than `max_allowed_packet` it will reply with an error payload ("Got a packet bigger than 'max_allowed_packet' bytes") and then reset the connection.

This may manifest on the client side as an error payload with that message, or a `SocketException` (when not using SSL) or an `IOException` (when using SSL).

The connector now handles those exceptions and throws a more descriptive exception if it's likely that the underlying problem is exceeding `max_allowed_packet`.

Note that one unhandled problem is that (when this happens) the socket has been closed (and `MySqlSession` is in the failed state) but `MySqlConnection.State` will still be `Open`; reusing that connection will throw an exception from `MySqlSession`. The workaround is to close/dispose the connection and return the session to the pool (which will detect that it's broken and dispose it).