### PR TITLE
Connection Pool Reaper

### DIFF
--- a/.ci/test.ps1
+++ b/.ci/test.ps1
@@ -24,6 +24,11 @@ dotnet test tests\SideBySide\SideBySide.csproj -c Release
 if ($LASTEXITCODE -ne 0){
     exit $LASTEXITCODE;
 }
+echo "Executing Debug Only tests"
+dotnet test tests\SideBySide\SideBySide.csproj -c Debug --filter "FullyQualifiedName~SideBySide.DebugOnlyTests"
+if ($LASTEXITCODE -ne 0){
+    exit $LASTEXITCODE;
+}
 
 echo "Executing tests with Compression, No SSL"
 Copy-Item -Force .ci\config\config.compression.json tests\SideBySide\config.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 - dotnet test tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj -c Release -f netcoreapp1.1.1
 - dotnet build tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 - echo 'Executing tests with No Compression, No SSL' && ./.ci/use-config.sh config.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
+- echo 'Executing Debug Only tests' && time dotnet test tests/SideBySide/SideBySide.csproj -c Debug -f netcoreapp1.1.1 --filter "FullyQualifiedName~SideBySide.DebugOnlyTests"
 - echo 'Executing tests with Compression, No SSL' && ./.ci/use-config.sh config.compression.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 - echo 'Executing tests with No Compression, SSL' && ./.ci/use-config.sh config.ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
 - echo 'Executing tests with Compression, SSL' && ./.ci/use-config.sh config.compression+ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1

--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -106,7 +106,7 @@ Connection pooling is enabled by default.  These options are used to configure i
   <tr>
     <td>Connection Lifetime, ConnectionLifeTime</td>
     <td>0</td>
-    <td>When a connection is returned to the pool, its creation time is compared with the current time, and the connection is destroyed if that time span (in seconds) exceeds the value specified by Connection Lifetime. This is useful in clustered configurations to force load balancing between a running server and a server just brought online. A value of zero (0) causes pooled connections to have the maximum connection timeout.</td>
+    <td>When a connection is returned to the pool, its creation time is compared with the current time, and the connection is destroyed if that time span (in seconds) exceeds the value specified by Connection Lifetime. This is useful in clustered configurations to force load balancing between a running server and a server just brought online. A value of zero (0) means pooled connections will never incur a ConnectionLifeTime timeout.</td>
   </tr>
   <tr>
     <td>Connection Reset, ConnectionReset	</td>
@@ -114,9 +114,19 @@ Connection pooling is enabled by default.  These options are used to configure i
     <td>If true, the connection state is reset when it is retrieved from the pool. The default value of false avoids making an additional server round trip when obtaining a connection, but the connection state is not reset.</td>
   </tr>
   <tr>
+    <td>Connection Idle Timeout, ConnectionIdleTimeout</td>
+    <td>180</td>
+    <td>The amount of time in seconds that a connection can remain idle in the pool. Any connection that is idle for longer is subject to being closed by a background task that runs every minute, unless there are only MinimumPoolSize connections left in the pool. A value of zero (0) means pooled connections will never incur a ConnectionIdleTimeout.</td>
+  </tr>
+  <tr>
     <td>Maximum Pool Size, Max Pool Size, MaximumPoolsize, maxpoolsize</td>
     <td>100</td>
     <td>The maximum number of connections allowed in the pool.</td>
+  </tr>
+  <tr>
+    <td>Minimum Pool Size, Min Pool Size, MinimumPoolSize, minpoolsize</td>
+    <td>0</td>
+    <td>The minimum number of connections to leave in the pool if ConnectionIdleTimeout is reached.</td>
   </tr>
 </table>
 

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -22,8 +22,17 @@ namespace MySql.Data.MySqlClient
 
 			try
 			{
-				// check for a pooled session
-				if (m_sessions.TryDequeue(out var session))
+				// check for a waiting session
+				MySqlSession session = null;
+				lock (m_sessions)
+				{
+					if (m_sessions.Count > 0)
+					{
+						session = m_sessions.First.Value;
+						m_sessions.RemoveFirst();
+					}
+				}
+				if (session != null)
 				{
 					if (session.PoolGeneration != m_generation || !await session.TryPingAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
 					{
@@ -42,6 +51,7 @@ namespace MySql.Data.MySqlClient
 					}
 				}
 
+				// create a new session
 				session = new MySqlSession(this, m_generation);
 				await session.ConnectAsync(m_connectionSettings, ioBehavior, cancellationToken).ConfigureAwait(false);
 				return session;
@@ -73,7 +83,8 @@ namespace MySql.Data.MySqlClient
 			try
 			{
 				if (SessionIsHealthy(session))
-					m_sessions.Enqueue(session);
+					lock (m_sessions)
+						m_sessions.AddFirst(session);
 				else
 					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).ConfigureAwait(false);
 			}
@@ -87,44 +98,84 @@ namespace MySql.Data.MySqlClient
 		{
 			// increment the generation of the connection pool
 			Interlocked.Increment(ref m_generation);
+			await CleanPoolAsync(ioBehavior, session => session.PoolGeneration != m_generation, false, cancellationToken).ConfigureAwait(false);
+		}
 
-			var waitTimeout = TimeSpan.FromMilliseconds(10);
-			while (true)
+		public async Task ReapAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			if (m_connectionSettings.ConnectionIdleTimeout == 0)
+				return;
+			await CleanPoolAsync(ioBehavior, session => (DateTime.UtcNow - session.LastReturnedUtc).TotalSeconds >= m_connectionSettings.ConnectionIdleTimeout, true, cancellationToken).ConfigureAwait(false);
+		}
+
+		private async Task CleanPoolAsync(IOBehavior ioBehavior, Func<MySqlSession, bool> shouldCleanFn, bool respectMinPoolSize, CancellationToken cancellationToken)
+		{
+			// synchronize access to this method as only one clean routine should be run at a time
+			if (ioBehavior == IOBehavior.Asynchronous)
+				await m_cleanSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+			else
+				m_cleanSemaphore.Wait(cancellationToken);
+
+			try
 			{
-				// try to get an open slot; if this fails, connection pool is full and sessions will be disposed when returned to pool
-				if (ioBehavior == IOBehavior.Asynchronous)
+				var waitTimeout = TimeSpan.FromMilliseconds(10);
+				while (true)
 				{
-					if (!await m_sessionSemaphore.WaitAsync(waitTimeout, cancellationToken).ConfigureAwait(false))
-						return;
-				}
-				else
-				{
-					if (!m_sessionSemaphore.Wait(waitTimeout, cancellationToken))
-						return;
-				}
+					// if respectMinPoolSize is true, return if (leased sessions + waiting sessions <= minPoolSize)
+					if (respectMinPoolSize)
+						lock (m_sessions)
+							if (m_connectionSettings.MaximumPoolSize - m_sessionSemaphore.CurrentCount + m_sessions.Count <= m_connectionSettings.MinimumPoolSize)
+								return;
 
-				try
-				{
-					if (m_sessions.TryDequeue(out var session))
+					// try to get an open slot; if this fails, connection pool is full and sessions will be disposed when returned to pool
+					if (ioBehavior == IOBehavior.Asynchronous)
 					{
-						if (session.PoolGeneration != m_generation)
+						if (!await m_sessionSemaphore.WaitAsync(waitTimeout, cancellationToken).ConfigureAwait(false))
+							return;
+					}
+					else
+					{
+						if (!m_sessionSemaphore.Wait(waitTimeout, cancellationToken))
+							return;
+					}
+
+					try
+					{
+						// check for a waiting session
+						MySqlSession session = null;
+						lock (m_sessions)
 						{
-							// session generation does not match pool generation; dispose of it and continue iterating
+							if (m_sessions.Count > 0)
+							{
+								session = m_sessions.Last.Value;
+								m_sessions.RemoveLast();
+							}
+						}
+						if (session == null)
+							return;
+
+						if (shouldCleanFn(session))
+						{
+							// session should be cleaned; dispose it and keep iterating
 							await session.DisposeAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
-							continue;
 						}
 						else
 						{
-							// session generation matches pool generation; put it back in the queue and stop iterating
-							m_sessions.Enqueue(session);
+							// session should not be cleaned; put it back in the queue and stop iterating
+							lock (m_sessions)
+								m_sessions.AddLast(session);
+							return;
 						}
 					}
-					return;
+					finally
+					{
+						m_sessionSemaphore.Release();
+					}
 				}
-				finally
-				{
-					m_sessionSemaphore.Release();
-				}
+			}
+			finally
+			{
+				m_cleanSemaphore.Release();
 			}
 		}
 
@@ -144,25 +195,47 @@ namespace MySql.Data.MySqlClient
 
 		public static async Task ClearPoolsAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			var pools = new List<ConnectionPool>(s_pools.Values);
-
-			foreach (var pool in pools)
+			foreach (var pool in s_pools.Values)
 				await pool.ClearAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+		}
+
+		public static async Task ReapPoolsAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			foreach (var pool in s_pools.Values)
+				await pool.ReapAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 		}
 
 		private ConnectionPool(ConnectionSettings cs)
 		{
 			m_connectionSettings = cs;
 			m_generation = 0;
+			m_cleanSemaphore = new SemaphoreSlim(1);
 			m_sessionSemaphore = new SemaphoreSlim(cs.MaximumPoolSize);
-			m_sessions = new ConcurrentQueue<MySqlSession>();
+			m_sessions = new LinkedList<MySqlSession>();
 		}
 
 		static readonly ConcurrentDictionary<string, ConnectionPool> s_pools = new ConcurrentDictionary<string, ConnectionPool>();
+		static readonly TimeSpan ReaperInterval = TimeSpan.FromMinutes(1);
+		static readonly Task Reaper = Task.Run(async () => {
+			while (true)
+			{
+				var task = Task.Delay(ReaperInterval);
+				try
+				{
+					await ReapPoolsAsync(IOBehavior.Asynchronous, new CancellationTokenSource(ReaperInterval).Token).ConfigureAwait(false);
+				}
+				catch
+				{
+					// do nothing; we'll try to reap again
+				}
+				await task.ConfigureAwait(false);
+			}
+		});
 
 		int m_generation;
+		readonly SemaphoreSlim m_cleanSemaphore;
 		readonly SemaphoreSlim m_sessionSemaphore;
-		readonly ConcurrentQueue<MySqlSession> m_sessions;
+		readonly LinkedList<MySqlSession> m_sessions;
 		readonly ConnectionSettings m_connectionSettings;
 	}
 }

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -215,7 +215,11 @@ namespace MySql.Data.MySqlClient
 		}
 
 		static readonly ConcurrentDictionary<string, ConnectionPool> s_pools = new ConcurrentDictionary<string, ConnectionPool>();
+#if DEBUG
+		static readonly TimeSpan ReaperInterval = TimeSpan.FromSeconds(1);
+#else
 		static readonly TimeSpan ReaperInterval = TimeSpan.FromMinutes(1);
+#endif
 		static readonly Task Reaper = Task.Run(async () => {
 			while (true)
 			{

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -85,6 +85,12 @@ namespace MySql.Data.MySqlClient
 			set => MySqlConnectionStringOption.ConnectionReset.SetValue(this, value);
 		}
 
+		public uint ConnectionIdleTimeout
+		{
+			get => MySqlConnectionStringOption.ConnectionIdleTimeout.GetValue(this);
+			set => MySqlConnectionStringOption.ConnectionIdleTimeout.SetValue(this, value);
+		}
+
 		public uint MinimumPoolSize
 		{
 			get => MySqlConnectionStringOption.MinimumPoolSize.GetValue(this);
@@ -231,6 +237,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> Pooling;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionLifeTime;
 		public static readonly MySqlConnectionStringOption<bool> ConnectionReset;
+		public static readonly MySqlConnectionStringOption<uint> ConnectionIdleTimeout;
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
 
@@ -320,6 +327,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(ConnectionReset = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Connection Reset", "ConnectionReset" },
 				defaultValue: true));
+
+			AddOption(ConnectionIdleTimeout = new MySqlConnectionStringOption<uint>(
+				keys: new[] { "Connection Idle Timeout", "ConnectionIdleTimeout" },
+				defaultValue: 180));
 
 			AddOption(MinimumPoolSize = new MySqlConnectionStringOption<uint>(
 				keys: new[] { "Minimum Pool Size", "Min Pool Size", "MinimumPoolSize", "minpoolsize" },

--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -36,6 +36,10 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DefineConstants>DEBUG</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="MySqlClient\MySqlCommand.cs">
       <SubType>Component</SubType>

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -38,6 +38,7 @@ namespace MySql.Data.Serialization
 			Pooling = csb.Pooling;
 			ConnectionLifeTime = (int)csb.ConnectionLifeTime;
 			ConnectionReset = csb.ConnectionReset;
+			ConnectionIdleTimeout = (int)csb.ConnectionIdleTimeout;
 			if (csb.MinimumPoolSize > csb.MaximumPoolSize)
 				throw new MySqlException("MaximumPoolSize must be greater than or equal to MinimumPoolSize");
 			MinimumPoolSize = (int)csb.MinimumPoolSize;
@@ -80,6 +81,7 @@ namespace MySql.Data.Serialization
 			Pooling = other.Pooling;
 			ConnectionLifeTime = other.ConnectionLifeTime;
 			ConnectionReset = other.ConnectionReset;
+			ConnectionIdleTimeout = other.ConnectionIdleTimeout;
 			MinimumPoolSize = other.MinimumPoolSize;
 			MaximumPoolSize = other.MaximumPoolSize;
 
@@ -116,6 +118,7 @@ namespace MySql.Data.Serialization
 		internal readonly bool Pooling;
 		internal readonly int ConnectionLifeTime;
 		internal readonly bool ConnectionReset;
+		internal readonly int ConnectionIdleTimeout;
 		internal readonly int MinimumPoolSize;
 		internal readonly int MaximumPoolSize;
 
@@ -134,4 +137,3 @@ namespace MySql.Data.Serialization
 	}
 
 }
-

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -34,9 +34,14 @@ namespace MySql.Data.Serialization
 		public DateTime CreatedUtc { get; }
 		public ConnectionPool Pool { get; }
 		public int PoolGeneration { get; }
+		public DateTime LastReturnedUtc { get; private set; }
 		public string DatabaseOverride { get; set; }
 
-		public void ReturnToPool() => Pool?.Return(this);
+		public void ReturnToPool()
+		{
+			LastReturnedUtc = DateTime.UtcNow;
+			Pool?.Return(this);
+		}
 
 		public bool IsConnected => m_state == State.Connected;
 

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -25,6 +25,7 @@ namespace MySql.Data.Tests
 			Assert.Equal("", csb.Database);
 #if !BASELINE
 			Assert.Equal(false, csb.BufferResultSets);
+			Assert.Equal(180u, csb.ConnectionIdleTimeout);
 			Assert.Equal(false, csb.ForceSynchronous);
 #endif
 			Assert.Equal(0u, csb.Keepalive);
@@ -64,6 +65,7 @@ namespace MySql.Data.Tests
 				                   "ConnectionReset=false;" +
 				                   "Convert Zero Datetime=true;" +
 #if !BASELINE
+				                   "connectionidletimeout=30;" +
 				                   "bufferresultsets=true;" +
 				                   "forcesynchronous=true;" +
 #endif
@@ -91,6 +93,7 @@ namespace MySql.Data.Tests
 			Assert.Equal("schema_name", csb.Database);
 #if !BASELINE
 			Assert.Equal(true, csb.BufferResultSets);
+			Assert.Equal(30u, csb.ConnectionIdleTimeout);
 			Assert.Equal(true, csb.ForceSynchronous);
 #endif
 			Assert.Equal(90u, csb.Keepalive);

--- a/tests/SideBySide/DebugOnlyTests.cs
+++ b/tests/SideBySide/DebugOnlyTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace SideBySide
+{
+	public class DebugOnlyTests : IClassFixture<DatabaseFixture>
+	{
+
+		[Theory]
+		[InlineData(1u, 3u, 0u, 5u)]
+		[InlineData(1u, 3u, 3u, 5u)]
+		public async Task ConnectionLifeTime(uint idleTimeout, uint delaySeconds, uint minPoolSize, uint maxPoolSize)
+		{
+			var csb = AppConfig.CreateConnectionStringBuilder();
+			csb.Pooling = true;
+			csb.MinimumPoolSize = minPoolSize;
+			csb.MaximumPoolSize = maxPoolSize;
+			csb.ConnectionIdleTimeout = idleTimeout;
+			HashSet<int> serverThreadIdsBegin = new HashSet<int>();
+			HashSet<int> serverThreadIdsEnd = new HashSet<int>();
+
+			async Task OpenConnections(uint numConnections, HashSet<int> serverIdSet)
+			{
+				using (var connection = new MySqlConnection(csb.ConnectionString))
+				{
+					await connection.OpenAsync();
+					serverIdSet.Add(connection.ServerThread);
+					if (--numConnections <= 0)
+						return;
+					await OpenConnections(numConnections, serverIdSet);
+				}
+			}
+
+			await OpenConnections(maxPoolSize, serverThreadIdsBegin);
+			await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
+			await OpenConnections(maxPoolSize, serverThreadIdsEnd);
+
+			serverThreadIdsEnd.IntersectWith(serverThreadIdsBegin);
+			Assert.Equal((int)minPoolSize, serverThreadIdsEnd.Count);
+		}
+
+	}
+}

--- a/tests/SideBySide/SideBySide.csproj
+++ b/tests/SideBySide/SideBySide.csproj
@@ -41,6 +41,10 @@
     <PackageReference Include="MySql.Data" Version="6.9.8" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
+    <Compile Remove="DebugOnlyTests.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
- Opening this as an initial design proposal for the Connection Pool Reaper #217
- We probably need a configurable time for the reaper via Connection String Option.  This would allow us to set a low time for testing.
- This would need to be adjusted to support `Min Pool Size` once we support that

Please provide feedback and I can update this PR to something more formal over the next few days.  Let me know if there's a "more accepted/efficient" way to create long-running jobs than just spinning up an async task.  Also open for ideas on how to better monitor this job to ensure that it doesn't hang.