### PR TITLE
fix connection string tests to run against MySql.Data

### DIFF
--- a/.ci/test.ps1
+++ b/.ci/test.ps1
@@ -12,6 +12,7 @@ if ($LASTEXITCODE -ne 0){
     exit $LASTEXITCODE;
 }
 
+echo "Executing connection string tests"
 dotnet test tests\MySqlConnector.Tests\MySqlConnector.Tests.csproj -c Release
 if ($LASTEXITCODE -ne 0){
     exit $LASTEXITCODE;
@@ -27,6 +28,13 @@ if ($LASTEXITCODE -ne 0){
 echo "Executing tests with Compression, No SSL"
 Copy-Item -Force .ci\config\config.compression.json tests\SideBySide\config.json
 dotnet test tests\SideBySide\SideBySide.csproj -c Release
+if ($LASTEXITCODE -ne 0){
+    exit $LASTEXITCODE;
+}
+
+echo "Executing baseline connection string tests"
+dotnet restore tests\MySqlConnector.Tests\MySqlConnector.Tests.csproj /p:Configuration=Baseline
+dotnet test tests\MySqlConnector.Tests\MySqlConnector.Tests.csproj -c Baseline
 if ($LASTEXITCODE -ne 0){
     exit $LASTEXITCODE;
 }

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -1,8 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup Condition=" '$(Configuration)' != 'Baseline' ">
+    <TargetFrameworks>netcoreapp1.1.1</TargetFrameworks>
+  </PropertyGroup>
+
+ <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">
+    <TargetFrameworks>net462</TargetFrameworks>
+    <DefineConstants>BASELINE</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <TargetFramework>netcoreapp1.1.1</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MySqlConnector.Tests</AssemblyName>
     <PackageId>MySqlConnector.Tests</PackageId>
@@ -10,15 +18,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-*" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0-*" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' != 'Baseline' ">
+    <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' == 'Baseline' ">
+    <PackageReference Include="MySql.Data" Version="6.9.8" />
+    <Compile Remove="NormalizeTests.cs;TypeMapperTests.cs;Utf8Tests.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Allows `MySqlConnectionStringBuilderTests.cs` to run against `MySql.Data`
- Ignores MySqlConnector-specific tests (presently `NormalizeTests.cs`, `TypeMapperTests.cs`, and `Utf8Tests.cs`) when running with `BASELINE=true`
- Adds Baseline Connection String tests to AppVeyor