### PR TITLE
Implement reader cancellation

### DIFF
--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -50,26 +50,34 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 		public virtual async Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection,
 			CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			m_command.Connection.Session.StartQuerying(m_command);
-			m_command.LastInsertedId = -1;
-			var statementPreparerOptions = StatementPreparerOptions.None;
-			if (m_command.Connection.AllowUserVariables || m_command.CommandType == CommandType.StoredProcedure)
-				statementPreparerOptions |= StatementPreparerOptions.AllowUserVariables;
-			if (m_command.Connection.OldGuids)
-				statementPreparerOptions |= StatementPreparerOptions.OldGuids;
-			var preparer = new MySqlStatementPreparer(commandText, parameterCollection, statementPreparerOptions);
-			var payload = new PayloadData(preparer.ParseAndBindParameters());
-			try
+			cancellationToken.ThrowIfCancellationRequested();
+			using (cancellationToken.Register(m_command.Cancel))
 			{
-				await m_command.Connection.Session.SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
-				return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
-			}
-			catch (Exception ex) when (payload.ArraySegment.Count > 4_194_304 && (ex is SocketException || ex is IOException || ex is MySqlProtocolException))
-			{
-				// the default MySQL Server value for max_allowed_packet (in MySQL 5.7) is 4MiB: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet
-				// use "decimal megabytes" (to round up) when creating the exception message
-				int megabytes = payload.ArraySegment.Count / 1_000_000;
-				throw new MySqlException("Error submitting {0}MB packet; ensure 'max_allowed_packet' is greater than {0}MB.".FormatInvariant(megabytes), ex);
+				m_command.Connection.Session.StartQuerying(m_command);
+				m_command.LastInsertedId = -1;
+				var statementPreparerOptions = StatementPreparerOptions.None;
+				if (m_command.Connection.AllowUserVariables || m_command.CommandType == CommandType.StoredProcedure)
+					statementPreparerOptions |= StatementPreparerOptions.AllowUserVariables;
+				if (m_command.Connection.OldGuids)
+					statementPreparerOptions |= StatementPreparerOptions.OldGuids;
+				var preparer = new MySqlStatementPreparer(commandText, parameterCollection, statementPreparerOptions);
+				var payload = new PayloadData(preparer.ParseAndBindParameters());
+				try
+				{
+					await m_command.Connection.Session.SendAsync(payload, ioBehavior, CancellationToken.None).ConfigureAwait(false);
+					return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, CancellationToken.None).ConfigureAwait(false);
+				}
+				catch (MySqlException ex) when (ex.Number == (int) MySqlErrorCode.QueryInterrupted && cancellationToken.IsCancellationRequested)
+				{
+					throw new OperationCanceledException(cancellationToken);
+				}
+				catch (Exception ex) when (payload.ArraySegment.Count > 4_194_304 && (ex is SocketException || ex is IOException || ex is MySqlProtocolException))
+				{
+					// the default MySQL Server value for max_allowed_packet (in MySQL 5.7) is 4MiB: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet
+					// use "decimal megabytes" (to round up) when creating the exception message
+					int megabytes = payload.ArraySegment.Count / 1_000_000;
+					throw new MySqlException("Error submitting {0}MB packet; ensure 'max_allowed_packet' is greater than {0}MB.".FormatInvariant(megabytes), ex);
+				}
 			}
 		}
 

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -50,6 +50,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 		public virtual async Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection,
 			CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
+			m_command.Connection.Session.StartQuerying();
 			m_command.LastInsertedId = -1;
 			var statementPreparerOptions = StatementPreparerOptions.None;
 			if (m_command.Connection.AllowUserVariables || m_command.CommandType == CommandType.StoredProcedure)

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -65,7 +65,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 				try
 				{
 					await m_command.Connection.Session.SendAsync(payload, ioBehavior, CancellationToken.None).ConfigureAwait(false);
-					return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior, CancellationToken.None).ConfigureAwait(false);
+					return await MySqlDataReader.CreateAsync(m_command, behavior, ioBehavior).ConfigureAwait(false);
 				}
 				catch (MySqlException ex) when (ex.Number == (int) MySqlErrorCode.QueryInterrupted && cancellationToken.IsCancellationRequested)
 				{

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -50,7 +50,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 		public virtual async Task<DbDataReader> ExecuteReaderAsync(string commandText, MySqlParameterCollection parameterCollection,
 			CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			m_command.Connection.Session.StartQuerying();
+			m_command.Connection.Session.StartQuerying(m_command);
 			m_command.LastInsertedId = -1;
 			var statementPreparerOptions = StatementPreparerOptions.None;
 			if (m_command.Connection.AllowUserVariables || m_command.CommandType == CommandType.StoredProcedure)

--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -48,11 +48,7 @@ namespace MySql.Data.MySqlClient
 			}
 		}
 
-		public override void Cancel()
-		{
-			// documentation says this shouldn't throw (but just fail silently), but for now make it explicit that this doesn't work
-			throw new NotSupportedException("Use the Async overloads with a CancellationToken.");
-		}
+		public override void Cancel() => Connection.Cancel(this);
 
 		public override int ExecuteNonQuery() =>
 			ExecuteNonQueryAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();

--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -177,8 +177,6 @@ namespace MySql.Data.MySqlClient
 				throw new InvalidOperationException("The transaction associated with this command is not the connection's active transaction.");
 			if (string.IsNullOrWhiteSpace(CommandText))
 				throw new InvalidOperationException("CommandText must be specified");
-			if (Connection.ActiveReader != null)
-				throw new MySqlException("There is already an open DataReader associated with this Connection which must be closed first.");
 		}
 
 		internal void ReaderClosed() => (m_commandExecutor as StoredProcedureCommandExecutor)?.SetParams();

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -230,7 +230,7 @@ namespace MySql.Data.MySqlClient
 		}
 
 		internal MySqlTransaction CurrentTransaction { get; set; }
-		internal MySqlDataReader ActiveReader { get; set; }
+		internal MySqlDataReader ActiveReader => m_session.ActiveReader;
 		internal bool AllowUserVariables => m_connectionSettings.AllowUserVariables;
 		internal bool BufferResultSets => m_connectionSettings.BufferResultSets;
 		internal bool ConvertZeroDateTime => m_connectionSettings.ConvertZeroDateTime;
@@ -309,11 +309,8 @@ namespace MySql.Data.MySqlClient
 		private void CloseDatabase()
 		{
 			m_cachedProcedures = null;
-			if (ActiveReader != null)
-			{
-				ActiveReader.Dispose();
-				ActiveReader = null;
-			}
+			if (Session.ActiveReader != null)
+				Session.ActiveReader.Dispose();
 			if (CurrentTransaction != null && m_session.IsConnected)
 			{
 				CurrentTransaction.Dispose();

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -257,9 +257,17 @@ namespace MySql.Data.MySqlClient
 		{
 			if (Command != null)
 			{
-				while (NextResult())
+				try
 				{
+					while (NextResult())
+					{
+					}
 				}
+				catch (MySqlException ex) when (ex.Number == (int) MySqlErrorCode.QueryInterrupted)
+				{
+					// ignore "Query execution was interrupted" exceptions when closing a data reader
+				}
+
 				m_resultSet = null;
 				m_resultSetBuffered = null;
 				m_nextResultSetBuffer.Clear();

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -112,7 +112,7 @@ namespace MySql.Data.MySqlClient
 			{
 				try
 				{
-					m_resultSetBuffered = await resultSet.ReadResultSetHeaderAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
+					m_resultSetBuffered = await resultSet.ReadResultSetHeaderAsync(ioBehavior).ConfigureAwait(false);
 					return m_resultSetBuffered;
 				}
 				catch (MySqlException ex) when (ex.Number == (int) MySqlErrorCode.QueryInterrupted)
@@ -224,17 +224,17 @@ namespace MySql.Data.MySqlClient
 		internal MySqlConnection Connection => Command?.Connection;
 		internal MySqlSession Session => Command?.Connection.Session;
 
-		internal static async Task<MySqlDataReader> CreateAsync(MySqlCommand command, CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		internal static async Task<MySqlDataReader> CreateAsync(MySqlCommand command, CommandBehavior behavior, IOBehavior ioBehavior)
 		{
 			var dataReader = new MySqlDataReader(command, behavior);
 			command.Connection.Session.SetActiveReader(dataReader);
 
 			try
 			{
-				await dataReader.ReadFirstResultSetAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+				await dataReader.ReadFirstResultSetAsync(ioBehavior).ConfigureAwait(false);
 				if (command.Connection.BufferResultSets)
 				{
-					while (await dataReader.BufferNextResultAsync(ioBehavior, cancellationToken).ConfigureAwait(false) != null)
+					while (await dataReader.BufferNextResultAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false) != null)
 					{
 					}
 				}
@@ -252,9 +252,9 @@ namespace MySql.Data.MySqlClient
 			}
 		}
 
-		internal async Task ReadFirstResultSetAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		internal async Task ReadFirstResultSetAsync(IOBehavior ioBehavior)
 		{
-			m_resultSet = await new ResultSet(this).ReadResultSetHeaderAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+			m_resultSet = await new ResultSet(this).ReadResultSetHeaderAsync(ioBehavior).ConfigureAwait(false);
 			ActivateResultSet(m_resultSet);
 			m_resultSetBuffered = m_resultSet;
 		}

--- a/src/MySqlConnector/MySqlClient/MySqlErrorCode.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlErrorCode.cs
@@ -1,0 +1,13 @@
+namespace MySql.Data.MySqlClient
+{
+	/// <summary>
+	/// MySQL Server error codes. Taken from <a href="https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html">Server Error Codes and Messages</a>.
+	/// </summary>
+	public enum MySqlErrorCode
+	{
+		/// <summary>
+		/// You have an error in your SQL syntax (ER_PARSE_ERROR).
+		/// </summary>
+		ParseError = 1064,
+	}
+}

--- a/src/MySqlConnector/MySqlClient/MySqlErrorCode.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlErrorCode.cs
@@ -9,5 +9,10 @@ namespace MySql.Data.MySqlClient
 		/// You have an error in your SQL syntax (ER_PARSE_ERROR).
 		/// </summary>
 		ParseError = 1064,
+
+		/// <summary>
+		/// Query execution was interrupted (ER_QUERY_INTERRUPTED).
+		/// </summary>
+		QueryInterrupted = 1317,
 	}
 }

--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -16,7 +16,7 @@ namespace MySql.Data.MySqlClient.Results
 			DataReader = dataReader;
 		}
 
-		public async Task<ResultSet> ReadResultSetHeaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		public async Task<ResultSet> ReadResultSetHeaderAsync(IOBehavior ioBehavior)
 		{
 			// ResultSet can be re-used, so initialize everything
 			BufferState = ResultSetState.None;
@@ -34,7 +34,7 @@ namespace MySql.Data.MySqlClient.Results
 			{
 				while (true)
 				{
-					var payload = await Session.ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+					var payload = await Session.ReceiveReplyAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 
 					var firstByte = payload.HeaderByte;
 					if (firstByte == OkPayload.Signature)
@@ -63,7 +63,7 @@ namespace MySql.Data.MySqlClient.Results
 								while ((byteCount = await stream.ReadAsync(readBuffer, 0, readBuffer.Length).ConfigureAwait(false)) > 0)
 								{
 									payload = new PayloadData(new ArraySegment<byte>(readBuffer, 0, byteCount));
-									await Session.SendReplyAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
+									await Session.SendReplyAsync(payload, ioBehavior, CancellationToken.None).ConfigureAwait(false);
 								}
 							}
 						}
@@ -73,7 +73,7 @@ namespace MySql.Data.MySqlClient.Results
 							ReadResultSetHeaderException = new MySqlException("Error during LOAD DATA LOCAL INFILE", ex);
 						}
 
-						await Session.SendReplyAsync(EmptyPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
+						await Session.SendReplyAsync(EmptyPayload.Create(), ioBehavior, CancellationToken.None).ConfigureAwait(false);
 					}
 					else
 					{
@@ -85,11 +85,11 @@ namespace MySql.Data.MySqlClient.Results
 
 						for (var column = 0; column < ColumnDefinitions.Length; column++)
 						{
-							payload = await Session.ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+							payload = await Session.ReceiveReplyAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 							ColumnDefinitions[column] = ColumnDefinitionPayload.Create(payload);
 						}
 
-						payload = await Session.ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+						payload = await Session.ReceiveReplyAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 						EofPayload.Create(payload);
 
 						LastInsertId = -1;

--- a/tests/SideBySide/CancelFixture.cs
+++ b/tests/SideBySide/CancelFixture.cs
@@ -1,0 +1,15 @@
+﻿using Dapper;
+
+namespace SideBySide
+{
+	public class CancelFixture : DatabaseFixture
+	{
+		public CancelFixture()
+		{
+			Connection.Open();
+			Connection.Execute(@"drop table if exists integers;
+				create table integers(value int not null primary key);
+				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);");
+		}
+	}
+}

--- a/tests/SideBySide/CancelTests.cs
+++ b/tests/SideBySide/CancelTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace SideBySide
+{
+	public class CancelTests : IClassFixture<DatabaseFixture>, IDisposable
+	{
+		public CancelTests(DatabaseFixture database)
+		{
+			m_database = database;
+			m_database.Connection.Open();
+		}
+
+		public void Dispose()
+		{
+			m_database.Connection.Close();
+		}
+
+		[Fact]
+		public void NoCancel()
+		{
+			using (var cmd = new MySqlCommand("SELECT SLEEP(0.25)", m_database.Connection))
+			{
+				var stopwatch = Stopwatch.StartNew();
+				var result = (long) cmd.ExecuteScalar();
+				Assert.Equal(0L, result);
+				Assert.InRange(stopwatch.ElapsedMilliseconds, 100, 1000);
+			}
+		}
+
+		[Fact]
+		public void CancelCommand()
+		{
+			using (var cmd = new MySqlCommand("SELECT SLEEP(5)", m_database.Connection))
+			{
+				var task = Task.Run(async () =>
+				{
+					await Task.Delay(TimeSpan.FromSeconds(0.5));
+					cmd.Cancel();
+				});
+
+				var stopwatch = Stopwatch.StartNew();
+				var result = (long) cmd.ExecuteScalar();
+				Assert.Equal(1L, result);
+				Assert.InRange(stopwatch.ElapsedMilliseconds, 250, 2500);
+
+				task.Wait(); // shouldn't throw
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public void CancelReaderAsynchronously()
+		{
+			using (var cmd = new MySqlCommand(@"drop table if exists integers;
+				create table integers(value int not null primary key);
+				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
+			{
+				cmd.ExecuteNonQuery();
+			}
+
+			using (var barrier = new Barrier(2))
+			using (var cmd = new MySqlCommand("select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			{
+				var task = Task.Run(() =>
+				{
+					barrier.SignalAndWait();
+					cmd.Cancel();
+				});
+
+				int rows = 0;
+				using (var reader = cmd.ExecuteReader())
+				{
+					Assert.True(reader.Read());
+
+					barrier.SignalAndWait();
+					try
+					{
+						while (reader.Read())
+							rows++;
+					}
+					catch (MySqlException ex)
+					{
+						Assert.Equal((int) MySqlErrorCode.QueryInterrupted, ex.Number);
+					}
+
+					// query returns 25 billion rows; we shouldn't have read many of them
+					Assert.InRange(rows, 0, 10000000);
+				}
+
+				task.Wait(); // shouldn't throw
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public void CancelCommandBeforeRead()
+		{
+			using (var cmd = new MySqlCommand(@"drop table if exists integers;
+				create table integers(value int not null primary key);
+				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
+			{
+				cmd.ExecuteNonQuery();
+			}
+
+			using (var cmd = new MySqlCommand("select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			{
+				using (var reader = cmd.ExecuteReader())
+				{
+					cmd.Cancel();
+
+					var stopwatch = Stopwatch.StartNew();
+					int rows = 0;
+					try
+					{
+						while (reader.Read())
+							rows++;
+					}
+					catch (MySqlException ex)
+					{
+						Assert.Equal((int) MySqlErrorCode.QueryInterrupted, ex.Number);
+					}
+					Assert.False(reader.NextResult());
+					Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 1000);
+					Assert.InRange(rows, 0, 10000000);
+				}
+			}
+		}
+
+		[UnbufferedResultSetsFact
+#if BASELINE
+			(Skip = "Hangs in NextResult")
+#endif
+		]
+		public void CancelMultiStatementReader()
+		{
+			using (var cmd = new MySqlCommand(@"drop table if exists integers;
+				create table integers(value int not null primary key);
+				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
+			{
+				cmd.ExecuteNonQuery();
+			}
+
+			using (var barrier = new Barrier(2))
+			using (var cmd = new MySqlCommand(@"select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;
+				select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;
+				select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			{
+				var task = Task.Run(() =>
+				{
+					barrier.SignalAndWait();
+					cmd.Cancel();
+				});
+
+				int rows = 0;
+				using (var reader = cmd.ExecuteReader())
+				{
+					Assert.True(reader.Read());
+
+					barrier.SignalAndWait();
+					try
+					{
+						while (reader.Read())
+							rows++;
+					}
+					catch (MySqlException ex)
+					{
+						Assert.Equal((int) MySqlErrorCode.QueryInterrupted, ex.Number);
+					}
+
+					// query returns 25 billion rows; we shouldn't have read many of them
+					Assert.InRange(rows, 0, 10000000);
+
+					Assert.False(reader.NextResult());
+				}
+
+				task.Wait(); // shouldn't throw
+			}
+
+			// should be able to reuse the same connection for another query
+			using (var cmd = new MySqlCommand(@"select sum(value) from integers;", m_database.Connection))
+			using (var reader = cmd.ExecuteReader())
+			{
+				Assert.True(reader.Read());
+				Assert.Equal(210, reader.GetInt32(0));
+				Assert.False(reader.Read());
+				Assert.False(reader.NextResult());
+			}
+		}
+
+		readonly DatabaseFixture m_database;
+	}
+}

--- a/tests/SideBySide/CancelTests.cs
+++ b/tests/SideBySide/CancelTests.cs
@@ -1,23 +1,26 @@
 using System;
+using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Dapper;
 using MySql.Data.MySqlClient;
 using Xunit;
 
 namespace SideBySide
 {
-	public class CancelTests : IClassFixture<DatabaseFixture>, IDisposable
+	public class CancelTests : IClassFixture<CancelFixture>, IDisposable
 	{
-		public CancelTests(DatabaseFixture database)
-		{
-			m_database = database;
-			m_database.Connection.Open();
-		}
+		public CancelTests(CancelFixture database) => m_database = database;
 
 		public void Dispose()
 		{
-			m_database.Connection.Close();
+			// after cancelling, the connection should still be usable
+			Assert.Equal(ConnectionState.Open, m_database.Connection.State);
+			using (var cmd = new MySqlCommand(@"select sum(value) from integers;", m_database.Connection))
+				Assert.Equal(210m, cmd.ExecuteScalar());
 		}
 
 		[Fact]
@@ -55,15 +58,8 @@ namespace SideBySide
 		[UnbufferedResultSetsFact]
 		public void CancelReaderAsynchronously()
 		{
-			using (var cmd = new MySqlCommand(@"drop table if exists integers;
-				create table integers(value int not null primary key);
-				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
-			{
-				cmd.ExecuteNonQuery();
-			}
-
 			using (var barrier = new Barrier(2))
-			using (var cmd = new MySqlCommand("select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			using (var cmd = new MySqlCommand(c_hugeQuery, m_database.Connection))
 			{
 				var task = Task.Run(() =>
 				{
@@ -98,14 +94,7 @@ namespace SideBySide
 		[UnbufferedResultSetsFact]
 		public void CancelCommandBeforeRead()
 		{
-			using (var cmd = new MySqlCommand(@"drop table if exists integers;
-				create table integers(value int not null primary key);
-				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
-			{
-				cmd.ExecuteNonQuery();
-			}
-
-			using (var cmd = new MySqlCommand("select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			using (var cmd = new MySqlCommand(c_hugeQuery, m_database.Connection))
 			{
 				using (var reader = cmd.ExecuteReader())
 				{
@@ -123,7 +112,7 @@ namespace SideBySide
 						Assert.Equal((int) MySqlErrorCode.QueryInterrupted, ex.Number);
 					}
 					Assert.False(reader.NextResult());
-					Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 1000);
+					Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 1000 * c_ciDelayFactor);
 					Assert.InRange(rows, 0, 10000000);
 				}
 			}
@@ -136,17 +125,8 @@ namespace SideBySide
 		]
 		public void CancelMultiStatementReader()
 		{
-			using (var cmd = new MySqlCommand(@"drop table if exists integers;
-				create table integers(value int not null primary key);
-				insert into integers(value) values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20);", m_database.Connection))
-			{
-				cmd.ExecuteNonQuery();
-			}
-
 			using (var barrier = new Barrier(2))
-			using (var cmd = new MySqlCommand(@"select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;
-				select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;
-				select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;", m_database.Connection))
+			using (var cmd = new MySqlCommand(c_hugeQuery + c_hugeQuery + c_hugeQuery, m_database.Connection))
 			{
 				var task = Task.Run(() =>
 				{
@@ -178,17 +158,244 @@ namespace SideBySide
 
 				task.Wait(); // shouldn't throw
 			}
+		}
 
-			// should be able to reuse the same connection for another query
-			using (var cmd = new MySqlCommand(@"select sum(value) from integers;", m_database.Connection))
-			using (var reader = cmd.ExecuteReader())
+		[UnbufferedResultSetsFact]
+		public void DapperQueryMultiple()
+		{
+			Stopwatch stopwatch;
+			using (var gridReader = m_database.Connection.QueryMultiple(@"select 1; " + c_hugeQuery))
 			{
-				Assert.True(reader.Read());
-				Assert.Equal(210, reader.GetInt32(0));
+				var first = gridReader.Read<int>().ToList();
+				Assert.Equal(1, first.Count);
+				Assert.Equal(1, first[0]);
+
+				// don't read the second result set; disposing the GridReader should Cancel the command
+				stopwatch = Stopwatch.StartNew();
+			}
+			stopwatch.Stop();
+			Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 1000 * c_ciDelayFactor);
+		}
+
+#if !BASELINE
+		[Fact]
+		public async Task CancelCommandWithTokenBeforeExecuteScalar()
+		{
+			using (var cmd = new MySqlCommand("select 1;", m_database.Connection))
+			{
+				try
+				{
+					await cmd.ExecuteScalarAsync(s_canceledToken);
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(s_canceledToken, ex.CancellationToken);
+				}
+			}
+		}
+
+		[Fact]
+		public async Task CancelCommandWithTokenBeforeExecuteNonQuery()
+		{
+			using (var cmd = new MySqlCommand("select 1;", m_database.Connection))
+			{
+				try
+				{
+					await cmd.ExecuteNonQueryAsync(s_canceledToken);
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(s_canceledToken, ex.CancellationToken);
+				}
+			}
+		}
+
+		[Fact]
+		public async Task CancelCommandWithTokenBeforeExecuteReader()
+		{
+			using (var cmd = new MySqlCommand("select 1;", m_database.Connection))
+			{
+				try
+				{
+					await cmd.ExecuteReaderAsync(s_canceledToken);
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(s_canceledToken, ex.CancellationToken);
+				}
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public async Task CancelHugeQueryWithTokenAfterExecuteReader()
+		{
+			using (var cmd = new MySqlCommand(c_hugeQuery, m_database.Connection))
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5)))
+			using (var reader = await cmd.ExecuteReaderAsync(cts.Token))
+			{
+				var rows = 0;
+				try
+				{
+					while (await reader.ReadAsync(cts.Token))
+						rows++;
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(cts.Token, ex.CancellationToken);
+					Assert.InRange(rows, 0, 10000000);
+				}
+
+				// no more result sets
 				Assert.False(reader.Read());
 				Assert.False(reader.NextResult());
 			}
 		}
+
+		[UnbufferedResultSetsFact]
+		public async Task CancelHugeQueryWithTokenInNextResult()
+		{
+			using (var cmd = new MySqlCommand(c_hugeQuery + "select 1, 2, 3;", m_database.Connection))
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5)))
+			using (var reader = await cmd.ExecuteReaderAsync(cts.Token))
+			{
+				// read first result set
+				Assert.True(await reader.ReadAsync(cts.Token));
+
+				try
+				{
+					// skip to the next result set
+					Assert.True(await reader.NextResultAsync(cts.Token));
+
+					// shouldn't get here
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(cts.Token, ex.CancellationToken);
+				}
+
+				// no more result sets
+				Assert.False(reader.Read());
+				Assert.False(reader.NextResult());
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public async Task CancelSlowQueryWithTokenAfterExecuteReader()
+		{
+			using (var cmd = new MySqlCommand(c_slowQuery, m_database.Connection))
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5)))
+			{
+				// the call to ExecuteReader should block until the token is cancelled
+				var stopwatch = Stopwatch.StartNew();
+				using (var reader = await cmd.ExecuteReaderAsync(cts.Token))
+				{
+					Assert.InRange(stopwatch.ElapsedMilliseconds, 450, 750 * c_ciDelayFactor);
+
+					var rows = 0;
+					try
+					{
+						// the OperationCanceledException is thrown later, from ReadAsync
+						while (await reader.ReadAsync(cts.Token))
+							rows++;
+						Assert.True(false);
+					}
+					catch (OperationCanceledException ex)
+					{
+						Assert.Equal(cts.Token, ex.CancellationToken);
+						Assert.InRange(rows, 0, 100);
+					}
+				}
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public async Task CancelSlowQueryWithTokenAfterNextResult()
+		{
+			using (var cmd = new MySqlCommand("SELECT 1; " + c_slowQuery, m_database.Connection))
+			using (var reader = await cmd.ExecuteReaderAsync())
+			{
+				// first resultset should be available immediately
+				Assert.True(reader.Read());
+				Assert.Equal(1, reader.GetInt32(0));
+				Assert.False(reader.Read());
+
+				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5)))
+				{
+					// the call to NextResult should block until the token is cancelled
+					var stopwatch = Stopwatch.StartNew();
+					Assert.True(await reader.NextResultAsync(cts.Token));
+					Assert.InRange(stopwatch.ElapsedMilliseconds, 450, 750 * c_ciDelayFactor);
+
+					int rows = 0;
+					try
+					{
+						// the OperationCanceledException is thrown later, from ReadAsync
+						while (await reader.ReadAsync(cts.Token))
+							rows++;
+					}
+					catch (OperationCanceledException ex)
+					{
+						Assert.Equal(cts.Token, ex.CancellationToken);
+						Assert.InRange(rows, 0, 100);
+					}
+				}
+
+				Assert.False(await reader.NextResultAsync());
+			}
+		}
+
+		[UnbufferedResultSetsFact]
+		public async Task CancelMultiStatementInRead()
+		{
+			using (var cmd = new MySqlCommand(c_hugeQuery + c_hugeQuery + c_hugeQuery, m_database.Connection))
+			using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5)))
+			using (var reader = await cmd.ExecuteReaderAsync())
+			{
+				var rows = 0;
+				try
+				{
+					while (await reader.ReadAsync(cts.Token))
+						rows++;
+
+					Assert.True(false);
+				}
+				catch (OperationCanceledException ex)
+				{
+					Assert.Equal(cts.Token, ex.CancellationToken);
+					Assert.InRange(rows, 0, 10000000);
+				}
+
+				// no more result sets; the whole command was cancelled
+				Assert.False(reader.Read());
+				Assert.False(reader.NextResult());
+			}
+		}
+
+		private static CancellationToken GetCanceledToken()
+		{
+			var cts = new CancellationTokenSource();
+			cts.Cancel();
+			return cts.Token;
+		}
+
+		static readonly CancellationToken s_canceledToken = GetCanceledToken();
+#endif
+
+		// returns billions of rows
+		const string c_hugeQuery = @"select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h;";
+
+		// takes a long time to return any rows
+		const string c_slowQuery = @"select * from integers a join integers b join integers c join integers d join integers e join integers f join integers g join integers h
+where sqrt(a.value) + sqrt(b.value) + sqrt(c.value) + sqrt(d.value) + sqrt(e.value) + sqrt(f.value) + sqrt(g.value) + sqrt(h.value) = 20;";
+
+		// tests can run extremely slowly on Appveyor (and slightly slower under Travis)
+		static readonly int c_ciDelayFactor = Environment.GetEnvironmentVariable("APPVEYOR") == "True" ? 10 :
+			Environment.GetEnvironmentVariable("TRAVIS") == "true" ? 3 : 1;
 
 		readonly DatabaseFixture m_database;
 	}

--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -84,9 +84,37 @@ create table query_invalid_sql(id integer not null primary key auto_increment);"
 			using (var cmd = m_database.Connection.CreateCommand())
 			{
 				cmd.CommandText = @"select id from query_invalid_sql limit 1 where id is not null";
-				await Assert.ThrowsAsync<MySqlException>(() => cmd.ExecuteNonQueryAsync());
-				await Assert.ThrowsAsync<MySqlException>(() => cmd.ExecuteReaderAsync());
-				await Assert.ThrowsAsync<MySqlException>(() => cmd.ExecuteScalarAsync());
+				try
+				{
+					await cmd.ExecuteNonQueryAsync();
+					Assert.True(false, "Exception should have been thrown.");
+				}
+				catch (MySqlException ex)
+				{
+					Assert.Equal((int) MySqlErrorCode.ParseError, ex.Number);
+				}
+
+				try
+				{
+					using (var reader = await cmd.ExecuteReaderAsync())
+					{
+					}
+					Assert.True(false, "Exception should have been thrown.");
+				}
+				catch (MySqlException ex)
+				{
+					Assert.Equal((int) MySqlErrorCode.ParseError, ex.Number);
+				}
+
+				try
+				{
+					await cmd.ExecuteScalarAsync();
+					Assert.True(false, "Exception should have been thrown.");
+				}
+				catch (MySqlException ex)
+				{
+					Assert.Equal((int) MySqlErrorCode.ParseError, ex.Number);
+				}
 			}
 
 			using (var cmd = m_database.Connection.CreateCommand())


### PR DESCRIPTION
Fixes #3.

Implements both `MySqlCommand.Cancel` (pre-async ADO.NET cancellation) and cancelling a `CancellationToken` passed to `ExecuteXAsync`/`ReadAsync`/`NextResultAsync`.

Cancellation is handled by opening a separate connection to the (IP address of the) current DB server and executing `KILL QUERY n` (where *n* is the `ServerThread` of the current connection). The `MySqlSession` stores the current command and reader so that calling `Cancel` on a non-active command does not incorrectly kill a different command executing on the same connection.