### PR TITLE
Add better exception for unsupported ParameterDirection.

### DIFF
--- a/src/MySqlConnector/MySqlClient/Caches/CachedProcedure.cs
+++ b/src/MySqlConnector/MySqlClient/Caches/CachedProcedure.cs
@@ -75,7 +75,7 @@ namespace MySql.Data.MySqlClient.Caches
 					alignParam = index >= 0 ? parameterCollection[index] : throw new ArgumentException($"Parameter '{cachedParam.Name}' not found in the collection.");
 				}
 
-				if (alignParam.Direction == default(ParameterDirection))
+				if (!alignParam.HasSetDirection)
 					alignParam.Direction = cachedParam.Direction;
 				if (alignParam.DbType == default(DbType))
 					alignParam.DbType = cachedParam.DbType;

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
@@ -37,7 +37,6 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 				var outName = "@outParam" + i;
 				switch (param.Direction)
 				{
-					case 0:
 					case ParameterDirection.Input:
 					case ParameterDirection.InputOutput:
 						var inParam = param.WithParameterName(inName);
@@ -79,7 +78,7 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 			var reader = (MySqlDataReader) await base.ExecuteReaderAsync(commandText, inParams, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
 			if (returnParam != null && await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
 				returnParam.Value = reader.GetValue(0);
-			
+
 			return reader;
 		}
 

--- a/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/TextCommandExecutor.cs
@@ -56,6 +56,8 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 				statementPreparerOptions |= StatementPreparerOptions.AllowUserVariables;
 			if (m_command.Connection.OldGuids)
 				statementPreparerOptions |= StatementPreparerOptions.OldGuids;
+			if (m_command.CommandType == CommandType.StoredProcedure)
+				statementPreparerOptions |= StatementPreparerOptions.AllowOutputParameters;
 			var preparer = new MySqlStatementPreparer(commandText, parameterCollection, statementPreparerOptions);
 			var payload = new PayloadData(preparer.ParseAndBindParameters());
 			try

--- a/src/MySqlConnector/MySqlClient/MySqlParameter.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlParameter.cs
@@ -13,7 +13,19 @@ namespace MySql.Data.MySqlClient
 
 		public override DbType DbType { get; set; }
 
-		public override ParameterDirection Direction { get; set; }
+		public override ParameterDirection Direction
+		{
+			get => m_direction.GetValueOrDefault(ParameterDirection.Input);
+			set
+			{
+				if (value != ParameterDirection.Input && value != ParameterDirection.Output &&
+					value != ParameterDirection.InputOutput && value != ParameterDirection.ReturnValue)
+				{
+					throw new ArgumentOutOfRangeException(nameof(value), "{0} is not a supported value for ParameterDirection".FormatInvariant(value));
+				}
+				m_direction = value;
+			}
+		}
 
 		public override bool IsNullable { get; set; }
 
@@ -64,7 +76,7 @@ namespace MySql.Data.MySqlClient
 		private MySqlParameter(MySqlParameter other, string parameterName)
 		{
 			DbType = other.DbType;
-			Direction = other.Direction;
+			m_direction = other.m_direction;
 			IsNullable = other.IsNullable;
 			Size = other.Size;
 			ParameterName = parameterName ?? other.ParameterName;
@@ -74,6 +86,8 @@ namespace MySql.Data.MySqlClient
 			Scale = other.Scale;
 #endif
 		}
+
+		internal bool HasSetDirection => m_direction.HasValue;
 
 		internal string NormalizedParameterName { get; private set; }
 
@@ -200,5 +214,6 @@ namespace MySql.Data.MySqlClient
 		}
 
 		string m_name;
+		ParameterDirection? m_direction;
 	}
 }

--- a/src/MySqlConnector/MySqlClient/MySqlStatementPreparer.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlStatementPreparer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.IO;
 using System.Text;
 using MySql.Data.Serialization;
@@ -67,6 +68,9 @@ namespace MySql.Data.MySqlClient
 			private void DoAppendParameter(int parameterIndex, int textIndex, int textLength)
 			{
 				AppendString(m_preparer.m_commandText, m_lastIndex, textIndex - m_lastIndex);
+				var parameter = m_preparer.m_parameters[parameterIndex];
+				if (parameter.Direction != ParameterDirection.Input && (m_preparer.m_options & StatementPreparerOptions.AllowOutputParameters) == 0)
+					throw new MySqlException("Only ParameterDirection.Input is supported when CommandType is Text (parameter name: {0})".FormatInvariant(parameter.ParameterName));
 				m_preparer.m_parameters[parameterIndex].AppendSqlString(m_writer, m_preparer.m_options);
 				m_lastIndex = textIndex + textLength;
 			}

--- a/src/MySqlConnector/MySqlClient/StatementPreparerOptions.cs
+++ b/src/MySqlConnector/MySqlClient/StatementPreparerOptions.cs
@@ -8,5 +8,6 @@ namespace MySql.Data.MySqlClient
 		None = 0,
 		AllowUserVariables = 1,
 		OldGuids = 2,
+		AllowOutputParameters = 4,
 	}
 }

--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -581,6 +581,59 @@ insert into query_null_parameter (id, value) VALUES (1, 'one'), (2, 'two'), (3, 
 			}
 		}
 
+		[Fact]
+		public void ParameterDefaults()
+		{
+			var parameter = new MySqlParameter();
+			Assert.Equal(DbType.AnsiString, parameter.DbType);
+			Assert.Equal(ParameterDirection.Input, parameter.Direction);
+			Assert.False(parameter.IsNullable);
+			Assert.Null(parameter.ParameterName);
+			Assert.Equal(0, parameter.Precision);
+			Assert.Equal(0, parameter.Scale);
+			Assert.Equal(0, parameter.Size);
+			Assert.Null(parameter.Value);
+		}
+
+		[Fact]
+		public void InputOutputParameter()
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "set @param = 1234";
+
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@param",
+					Direction = ParameterDirection.InputOutput,
+					Value = 123,
+				});
+
+				Assert.Throws<MySqlException>(() => cmd.ExecuteNonQuery());
+
+				// Issue #231: Assert.Equal(1234, cmd.Parameters["@param"].Value);
+			}
+		}
+
+		[Fact]
+		public void OutputParameter()
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = "set @param = 1234";
+
+				cmd.Parameters.Add(new MySqlParameter
+				{
+					ParameterName = "@param",
+					Direction = ParameterDirection.Output,
+				});
+
+				Assert.Throws<MySqlException>(() => cmd.ExecuteNonQuery());
+
+				// Issue #231: Assert.Equal(1234, cmd.Parameters["@param"].Value);
+			}
+		}
+
 		class BoolTest
 		{
 			public int Id { get; set; }


### PR DESCRIPTION
Throw a better exception if `MySqlParamter.ParameterDirection != ParameterDirection.Input` when executing a command of type `CommandType.Text`. MySQL Server will eventually return an error which will cause a `MySqlException` to be thrown, but there's no point in submitting it to the server if we know it will fail; additionally, we can explain to the caller *why* it's failing.

Additionally:
* Add better tracking of whether the client has explicitly set MySqlParameter.ParameterDirection, and add parameter validation.
* Verify that MySqlParameter default values match the baseline.

Fixes #234. See also [MySQL bug 75267](https://bugs.mysql.com/bug.php?id=75267).