### PR TITLE
Allow passing of MySqlConnectionStringBuilder in constructor

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -22,7 +22,10 @@ namespace MySql.Data.MySqlClient
 
 		public MySqlConnection(MySqlConnectionStringBuilder connectionStringBuilder)
 		{
-			SetConnectionSettings(connectionStringBuilder);
+			if (connectionStringBuilder == null)
+				throw new ArgumentNullException(nameof(connectionStringBuilder));
+
+			SetConnectionSettings(connectionStringBuilder.Clone());
 		}
 
 		public new MySqlTransaction BeginTransaction() => (MySqlTransaction) base.BeginTransaction();

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -20,6 +20,11 @@ namespace MySql.Data.MySqlClient
 
 		public MySqlConnection(string connectionString) => ConnectionString = connectionString;
 
+		public MySqlConnection(MySqlConnectionStringBuilder connectionStringBuilder)
+		{
+			SetConnectionSettings(connectionStringBuilder);
+		}
+
 		public new MySqlTransaction BeginTransaction() => (MySqlTransaction) base.BeginTransaction();
 
 		public Task<MySqlTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
@@ -144,8 +149,8 @@ namespace MySql.Data.MySqlClient
 			{
 				if (m_hasBeenOpened)
 					throw new MySqlException("Cannot change connection string on a connection that has already been opened.");
-				m_connectionStringBuilder = new MySqlConnectionStringBuilder(value);
-				m_connectionSettings = new ConnectionSettings(m_connectionStringBuilder);
+
+				SetConnectionSettings(new MySqlConnectionStringBuilder(value));
 			}
 		}
 
@@ -347,6 +352,12 @@ namespace MySql.Data.MySqlClient
 				CurrentTransaction.Dispose();
 				CurrentTransaction = null;
 			}
+		}
+
+		private void SetConnectionSettings(MySqlConnectionStringBuilder connectionStringBuilder)
+		{
+			m_connectionStringBuilder = connectionStringBuilder;
+			m_connectionSettings = new ConnectionSettings(m_connectionStringBuilder);
 		}
 
 		MySqlConnectionStringBuilder m_connectionStringBuilder;

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -215,6 +215,15 @@ namespace MySql.Data.MySqlClient
 			return m_cachedConnectionStringWithoutPassword;
 		}
 
+		internal MySqlConnectionStringBuilder Clone()
+		{
+			var clone = new MySqlConnectionStringBuilder();
+			foreach (KeyValuePair<string, object> a in this)
+				clone.Add(a.Key, a.Value);
+
+			return clone;
+		}
+
 		string m_cachedConnectionString;
 		string m_cachedConnectionStringWithoutPassword;
 	}

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -218,8 +218,8 @@ namespace MySql.Data.MySqlClient
 		internal MySqlConnectionStringBuilder Clone()
 		{
 			var clone = new MySqlConnectionStringBuilder();
-			foreach (KeyValuePair<string, object> a in this)
-				clone.Add(a.Key, a.Value);
+			foreach (KeyValuePair<string, object> option in this)
+				clone.Add(option.Key, option.Value);
 
 			return clone;
 		}

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -120,5 +120,25 @@ namespace MySql.Data.Tests
 			Assert.Throws<InvalidOperationException>(() => csb.SslMode);
 		}
 #endif
+
+		[Fact]
+		public void CloneConnectionStringBuilder()
+		{
+			var csb = new MySqlConnectionStringBuilder
+			{
+				Port = 12345,
+				Database = "database",
+				OldGuids = true,
+				SslMode = MySqlSslMode.VerifyFull
+			};
+
+			var clone = csb.Clone();
+
+			Assert.Equal(csb.Port, clone.Port);
+			Assert.Equal(csb.Database, clone.Database);
+			Assert.Equal(csb.OldGuids, clone.OldGuids);
+			Assert.Equal(csb.SslMode, clone.SslMode);
+		}
 	}
 }
+


### PR DESCRIPTION
Since `MySqlConnectionStringBuilder` is public anyway, I found that I could get more performance by passing in an instance of `MySqlConnectionStringBuilder` into `MySqlConnection` as opposed to having to parse the connection string every time I created a new `MySqlConnection`.

According to dotTrace, `MySqlConnectionStringBuilder` was spending around 10% of CPU time in Regex