### PR TITLE
Support System.Transactions.

### DIFF
--- a/docs/content/tutorials/migrating-from-connector-net.md
+++ b/docs/content/tutorials/migrating-from-connector-net.md
@@ -39,8 +39,16 @@ MySqlConnector has some different default connection string options:
 Some command line options that are supported in Connector/NET are not supported in MySqlConnector.  For a full list of options that are
 supported in MySqlConnector, see the [Connection Options](connection-options)
 
+### TransactionScope
+
+MySqlConnector adds full distributed transaction support (for client code using [`TransactionScope`](https://msdn.microsoft.com/en-us/library/system.transactions.transactionscope.aspx)),
+while Connector/NET uses regular database transactions. As a result, code that uses `TransactionScope`
+may execute differently with MySqlConnector. To get Connector/NET-compatible behavior, remove
+`TransactionScope` and use `BeginTransaction`/`Commit` directly.
+
 ### Bugs present in Connector/NET that are fixed in MySqlConnector
 
+* [#37283](https://bugs.mysql.com/bug.php?id=37283), [#70587](https://bugs.mysql.com/bug.php?id=70587): Distributed transactions are not supported
 * [#66476](https://bugs.mysql.com/bug.php?id=66476): Connection pool uses queue instead of stack
 * [#70111](https://bugs.mysql.com/bug.php?id=70111): `Async` methods execute synchronously
 * [#70686](https://bugs.mysql.com/bug.php?id=70686): `TIME(3)` and `TIME(6)` fields serialize milliseconds incorrectly

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -161,7 +161,7 @@ namespace MySql.Data.MySqlClient
 			}
 
 #if !NETSTANDARD1_3
-			if (System.Transactions.Transaction.Current != null)
+			if (m_connectionSettings.AutoEnlist && System.Transactions.Transaction.Current != null)
 				EnlistTransaction(System.Transactions.Transaction.Current);
 #endif
 		}

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -110,6 +110,12 @@ namespace MySql.Data.MySqlClient
 			set => MySqlConnectionStringOption.AllowUserVariables.SetValue(this, value);
 		}
 
+		public bool AutoEnlist
+		{
+			get => MySqlConnectionStringOption.AutoEnlist.GetValue(this);
+			set => MySqlConnectionStringOption.AutoEnlist.SetValue(this, value);
+		}
+
 		public bool BufferResultSets
 		{
 			get => MySqlConnectionStringOption.BufferResultSets.GetValue(this);
@@ -243,6 +249,7 @@ namespace MySql.Data.MySqlClient
 
 		// Other Options
 		public static readonly MySqlConnectionStringOption<bool> AllowUserVariables;
+		public static readonly MySqlConnectionStringOption<bool> AutoEnlist;
 		public static readonly MySqlConnectionStringOption<bool> BufferResultSets;
 		public static readonly MySqlConnectionStringOption<string> CharacterSet;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionTimeout;
@@ -344,6 +351,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(AllowUserVariables = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "AllowUserVariables", "Allow User Variables" },
 				defaultValue: false));
+
+			AddOption(AutoEnlist = new MySqlConnectionStringOption<bool>(
+				keys: new[] { "AutoEnlist", "Auto Enlist" },
+				defaultValue: true));
 
 			AddOption(BufferResultSets = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "BufferResultSets", "Buffer Result Sets" },

--- a/src/MySqlConnector/MySqlClient/MySqlXaTransaction.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlXaTransaction.cs
@@ -1,0 +1,65 @@
+#if !NETSTANDARD1_3
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Transactions;
+
+namespace MySql.Data.MySqlClient
+{
+	internal sealed class MySqlXaTransaction : IEnlistmentNotification
+	{
+		public MySqlXaTransaction(MySqlConnection connection) => m_connection = connection;
+
+		public void Start(Transaction transaction)
+		{
+			// generate an "xid" with "gtrid" (Global TRansaction ID) from the .NET Transaction and "bqual" (Branch QUALifier)
+			// unique to this object
+			var id = Interlocked.Increment(ref s_currentId);
+			m_xid = "'" + transaction.TransactionInformation.LocalIdentifier + "', '" + id.ToString(CultureInfo.InvariantCulture) + "'";
+
+			ExecuteXaCommand("START");
+
+			// TODO: Support EnlistDurable and enable recovery via "XA RECOVER"
+			transaction.EnlistVolatile(this, EnlistmentOptions.None);
+		}
+
+		public void Prepare(PreparingEnlistment enlistment)
+		{
+			ExecuteXaCommand("END");
+			ExecuteXaCommand("PREPARE");
+			enlistment.Prepared();
+		}
+
+		public void Commit(Enlistment enlistment)
+		{
+			ExecuteXaCommand("COMMIT");
+			enlistment.Done();
+			m_connection.UnenlistTransaction(this);
+		}
+
+		public void Rollback(Enlistment enlistment)
+		{
+			ExecuteXaCommand("END");
+			ExecuteXaCommand("ROLLBACK");
+			enlistment.Done();
+			m_connection.UnenlistTransaction(this);
+		}
+
+		public void InDoubt(Enlistment enlistment) => throw new NotSupportedException();
+
+		private void ExecuteXaCommand(string statement)
+		{
+			using (var cmd = m_connection.CreateCommand())
+			{
+				cmd.CommandText = "XA " + statement + " " + m_xid;
+				cmd.ExecuteNonQuery();
+			}
+		}
+
+		static int s_currentId;
+
+		readonly MySqlConnection m_connection;
+		string m_xid;
+	}
+}
+#endif

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -46,6 +46,7 @@ namespace MySql.Data.Serialization
 
 			// Other Options
 			AllowUserVariables = csb.AllowUserVariables;
+			AutoEnlist = csb.AutoEnlist;
 			BufferResultSets = csb.BufferResultSets;
 			ConnectionTimeout = (int)csb.ConnectionTimeout;
 			ConvertZeroDateTime = csb.ConvertZeroDateTime;
@@ -87,6 +88,7 @@ namespace MySql.Data.Serialization
 
 			// Other Options
 			AllowUserVariables = other.AllowUserVariables;
+			AutoEnlist = other.AutoEnlist;
 			BufferResultSets = other.BufferResultSets;
 			ConnectionTimeout = other.ConnectionTimeout;
 			ConvertZeroDateTime = other.ConvertZeroDateTime;
@@ -124,6 +126,7 @@ namespace MySql.Data.Serialization
 
 		// Other Options
 		internal readonly bool AllowUserVariables;
+		internal readonly bool AutoEnlist;
 		internal readonly bool BufferResultSets;
 		internal readonly int ConnectionTimeout;
 		internal readonly bool ConvertZeroDateTime;

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -11,6 +11,7 @@ namespace MySql.Data.Tests
 		{
 			var csb = new MySqlConnectionStringBuilder();
 			Assert.Equal(false, csb.AllowUserVariables);
+			Assert.Equal(true, csb.AutoEnlist);
 			Assert.Equal(null, csb.CertificateFile);
 			Assert.Equal(null, csb.CertificatePassword);
 			Assert.Equal("", csb.CharacterSet);
@@ -54,35 +55,37 @@ namespace MySql.Data.Tests
 			var csb = new MySqlConnectionStringBuilder
 			{
 				ConnectionString = "Data Source=db-server;" +
-				                   "Initial Catalog=schema_name;" +
-				                   "Allow User Variables=true;" +
-				                   "certificate file=file.pfx;" +
-				                   "certificate password=Pass1234;" +
-				                   "Character Set=latin1;" +
-				                   "Compress=true;" +
-				                   "connect timeout=30;" +
-				                   "connection lifetime=15;" +
-				                   "ConnectionReset=false;" +
-				                   "Convert Zero Datetime=true;" +
+					"Initial Catalog=schema_name;" +
+					"Allow User Variables=true;" +
+					"auto enlist=False;" +
+					"certificate file=file.pfx;" +
+					"certificate password=Pass1234;" +
+					"Character Set=latin1;" +
+					"Compress=true;" +
+					"connect timeout=30;" +
+					"connection lifetime=15;" +
+					"ConnectionReset=false;" +
+					"Convert Zero Datetime=true;" +
 #if !BASELINE
-				                   "connectionidletimeout=30;" +
-				                   "bufferresultsets=true;" +
-				                   "forcesynchronous=true;" +
+					"connectionidletimeout=30;" +
+					"bufferresultsets=true;" +
+					"forcesynchronous=true;" +
 #endif
-				                   "Keep Alive=90;" +
-				                   "minpoolsize=5;" +
-				                   "maxpoolsize=15;" +
-				                   "OldGuids=true;" +
-				                   "persistsecurityinfo=yes;" +
-				                   "Pooling=no;" +
-				                   "Port=1234;" +
-				                   "pwd=Pass1234;" +
-				                   "Treat Tiny As Boolean=false;" +
-				                   "ssl mode=verifyca;" +
-				                   "Uid=username;" +
-				                   "useaffectedrows=false"
+					"Keep Alive=90;" +
+					"minpoolsize=5;" +
+					"maxpoolsize=15;" +
+					"OldGuids=true;" +
+					"persistsecurityinfo=yes;" +
+					"Pooling=no;" +
+					"Port=1234;" +
+					"pwd=Pass1234;" +
+					"Treat Tiny As Boolean=false;" +
+					"ssl mode=verifyca;" +
+					"Uid=username;" +
+					"useaffectedrows=false"
 			};
 			Assert.Equal(true, csb.AllowUserVariables);
+			Assert.Equal(false, csb.AutoEnlist);
 			Assert.Equal("file.pfx", csb.CertificateFile);
 			Assert.Equal("Pass1234", csb.CertificatePassword);
 			Assert.Equal("latin1", csb.CharacterSet);

--- a/tests/SideBySide/SideBySide.csproj
+++ b/tests/SideBySide/SideBySide.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
+    <Reference Include="System.Transactions" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/tests/SideBySide/TransactionScopeTests.cs
+++ b/tests/SideBySide/TransactionScopeTests.cs
@@ -1,0 +1,269 @@
+#if !NETCOREAPP1_1_1
+using System;
+using System.Linq;
+using System.Transactions;
+using Dapper;
+using MySql.Data.MySqlClient;
+using Xunit;
+using SysTransaction = System.Transactions.Transaction;
+
+namespace SideBySide
+{
+	public class TransactionScopeTests : IClassFixture<DatabaseFixture>
+	{
+		public TransactionScopeTests(DatabaseFixture database)
+		{
+			m_database = database;
+		}
+
+		[Fact]
+		public void EnlistTwoTransactions()
+		{
+			using (var connection = new MySqlConnection(AppConfig.ConnectionString))
+			{
+				connection.Open();
+
+				using (var transaction1 = new CommittableTransaction())
+				using (var transaction2 = new CommittableTransaction())
+				{
+					connection.EnlistTransaction(transaction1);
+					Assert.Throws<MySqlException>(() => connection.EnlistTransaction(transaction2));
+				}
+			}
+		}
+
+		[Fact]
+		public void BeginTransactionInScope()
+		{
+			using (var transactionScope = new TransactionScope())
+			using (var connection = new MySqlConnection(AppConfig.ConnectionString))
+			{
+				connection.Open();
+				Assert.Throws<InvalidOperationException>(() => connection.BeginTransaction());
+			}
+		}
+
+		[Fact]
+		public void BeginTransactionThenEnlist()
+		{
+			using (var connection = new MySqlConnection(AppConfig.ConnectionString))
+			{
+				connection.Open();
+				using (var dbTransaction = connection.BeginTransaction())
+				using (var transaction = new CommittableTransaction())
+				{
+					Assert.Throws<InvalidOperationException>(() => connection.EnlistTransaction(transaction));
+				}
+			}
+		}
+
+		[Fact]
+		public void CommitOneTransactionWithTransactionScope()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			using (var transactionScope = new TransactionScope())
+			{
+				using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+				{
+					conn.Open();
+					conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+
+					transactionScope.Complete();
+				}
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new[] { 1, 2 }, values);
+		}
+
+		[Fact]
+		public void CommitOneTransactionWithEnlistTransaction()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+			{
+				conn.Open();
+				using (var transaction = new CommittableTransaction())
+				{
+					conn.EnlistTransaction(transaction);
+					conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+					transaction.Commit();
+				}
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new[] { 1, 2 }, values);
+		}
+
+		[Fact]
+		public void RollBackOneTransactionWithTransactionScope()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			using (var transactionScope = new TransactionScope())
+			{
+				using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+				{
+					conn.Open();
+					conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+				}
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new int[0], values);
+		}
+
+		[Fact]
+		public void RollBackOneTransactionWithEnlistTransaction()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+			{
+				conn.Open();
+				using (var transaction = new CommittableTransaction())
+				{
+					conn.EnlistTransaction(transaction);
+					conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+				}
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new int[0], values);
+		}
+
+		[Fact]
+		public void ThrowExceptionInTransaction()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			try
+			{
+				using (var transactionScope = new TransactionScope())
+				{
+					using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+					{
+						conn.Open();
+						conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+
+						throw new ApplicationException();
+					}
+				}
+			}
+			catch (ApplicationException)
+			{
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new int[0], values);
+		}
+
+
+		[Fact]
+		public void ThrowExceptionAfterCompleteInTransaction()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test;
+				create table transaction_scope_test(value integer not null);");
+
+			try
+			{
+				using (var transactionScope = new TransactionScope())
+				{
+					using (var conn = new MySqlConnection(AppConfig.ConnectionString))
+					{
+						conn.Open();
+						conn.Execute("insert into transaction_scope_test(value) values(1), (2);");
+
+						transactionScope.Complete();
+
+						throw new ApplicationException();
+					}
+				}
+			}
+			catch (ApplicationException)
+			{
+			}
+
+			var values = m_database.Connection.Query<int>(@"select value from transaction_scope_test order by value;").ToList();
+			Assert.Equal(new[] { 1, 2 }, values);
+		}
+
+		[Fact
+#if BASELINE
+		(Skip = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")
+#endif
+		]
+		public void CommitTwoTransactions()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test_1;
+				drop table if exists transaction_scope_test_2;
+				create table transaction_scope_test_1(value integer not null);
+				create table transaction_scope_test_2(value integer not null);");
+
+			using (var transactionScope = new TransactionScope())
+			{
+				using (var conn1 = new MySqlConnection(AppConfig.ConnectionString))
+				{
+					conn1.Open();
+					conn1.Execute("insert into transaction_scope_test_1(value) values(1), (2);");
+
+					using (var conn2 = new MySqlConnection(AppConfig.ConnectionString))
+					{
+						conn2.Open();
+						conn2.Execute("insert into transaction_scope_test_2(value) values(3), (4);");
+
+						transactionScope.Complete();
+					}
+				}
+			}
+
+			var values1 = m_database.Connection.Query<int>(@"select value from transaction_scope_test_1 order by value;").ToList();
+			var values2 = m_database.Connection.Query<int>(@"select value from transaction_scope_test_2 order by value;").ToList();
+			Assert.Equal(new[] { 1, 2 }, values1);
+			Assert.Equal(new[] { 3, 4 }, values2);
+		}
+
+
+		[Fact
+#if BASELINE
+		(Skip = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")
+#endif
+		]
+		public void RollBackTwoTransactions()
+		{
+			m_database.Connection.Execute(@"drop table if exists transaction_scope_test_1;
+				drop table if exists transaction_scope_test_2;
+				create table transaction_scope_test_1(value integer not null);
+				create table transaction_scope_test_2(value integer not null);");
+
+			using (var transactionScope = new TransactionScope())
+			{
+				using (var conn1 = new MySqlConnection(AppConfig.ConnectionString))
+				{
+					conn1.Open();
+					conn1.Execute("insert into transaction_scope_test_1(value) values(1), (2);");
+
+					using (var conn2 = new MySqlConnection(AppConfig.ConnectionString))
+					{
+						conn2.Open();
+						conn2.Execute("insert into transaction_scope_test_2(value) values(3), (4);");
+					}
+				}
+			}
+
+			var values1 = m_database.Connection.Query<int>(@"select value from transaction_scope_test_1 order by value;").ToList();
+			var values2 = m_database.Connection.Query<int>(@"select value from transaction_scope_test_2 order by value;").ToList();
+			Assert.Equal(new int[0], values1);
+			Assert.Equal(new int[0], values2);
+		}
+		DatabaseFixture m_database;
+	}
+}
+#endif


### PR DESCRIPTION
Adds support for ambient transactions, and for explicitly enlisting with `EnlistTransaction`.

Unlike Connector/NET, this is implemented using MySQL's [XA Transactions](https://dev.mysql.com/doc/refman/5.7/en/xa.html). This may be a compatibility problem for users migrating from Connector/NET, but better matches the purpose/intent of `TransactionScope`.

Currently only implemented for .NET Framework 4.5.1, since .NET Core won't support `System.Transactions` until netstandard-2.0: dotnet/corefx#10089

