### PR TITLE
Fix Buffering Bug causing Excess Allocations

### DIFF
--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -205,7 +205,7 @@ namespace MySql.Data.MySqlClient.Results
 
 				if (row == null)
 					row = new Row(this);
-				row.SetData(m_dataLengths, m_dataOffsets, payload.ArraySegment.Array);
+				row.SetData(m_dataLengths, m_dataOffsets, payload.ArraySegment);
 				m_rowBuffered = row;
 				return row;
 			}


### PR DESCRIPTION
- Fixes #244 
- Removes `ArrayPool<byte>.Shared.Rent/Return` in buffering code in favor of allocating arrays
- Fixes bug where entire network packet was copied instead of current Row