### PR TITLE
Handle QueryInterrupted exceptions when canceling completed queries.

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -66,6 +66,7 @@ namespace MySql.Data.MySqlClient
 
 		public override string CommandText { get; set; }
 		public override int CommandTimeout { get; set; }
+		public bool	IsCanceled { get; internal set; }
 
 		public override CommandType CommandType
 		{

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -293,16 +293,8 @@ namespace MySql.Data.MySqlClient
 					// KILL QUERY will kill a subsequent query if the command it was intended to cancel has already completed.
 					// In order to handle this case, we issue a dummy query to catch the QueryInterrupted exception.
 					// See https://bugs.mysql.com/bug.php?id=45679
-					var killClearCommand = new MySqlCommand("SELECT * FROM fake_table LIMIT 0;", connection);
-					try
-					{
-						killClearCommand.ExecuteReader();
-					}
-					catch (MySqlException ex)
-					{
-						if (ex.Number != (int) MySqlErrorCode.QueryInterrupted && ex.Number != (int) MySqlErrorCode.NoSuchTable)
-							throw;
-					}
+					var killClearCommand = new MySqlCommand("DO SLEEP(0);", connection);
+					killClearCommand.ExecuteNonQuery();
 				}
 
 				Command.ReaderClosed();

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -84,6 +84,8 @@ namespace MySql.Data.Serialization
 				// blocking the other thread for an extended duration.
 				killCommand.CommandTimeout = 3;
 				killCommand.ExecuteNonQuery();
+
+				commandToCancel.IsCanceled = true;
 			}
 		}
 

--- a/tests/SideBySide/CancelTests.cs
+++ b/tests/SideBySide/CancelTests.cs
@@ -231,12 +231,25 @@ namespace SideBySide
 		[Fact]
 		public async Task CancelCompletedCommand()
 		{
+			await m_database.Connection.ExecuteAsync(@"drop table if exists cancel_completed_command;
+create table cancel_completed_command (
+	id bigint unsigned,
+	value varchar(45)
+);").ConfigureAwait(false);
+
 			using (var cmd = m_database.Connection.CreateCommand())
 			{
-				cmd.CommandText = @"select 1;";
+				cmd.CommandText = @"insert into cancel_completed_command (id, value) values (1, null);";
 
 				using (await cmd.ExecuteReaderAsync().ConfigureAwait(false))
 					cmd.Cancel();
+			}
+
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = @"update cancel_completed_command SET value = ""value"" where id = 1;";
+
+				await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 			}
 		}
 

--- a/tests/SideBySide/CancelTests.cs
+++ b/tests/SideBySide/CancelTests.cs
@@ -228,6 +228,18 @@ namespace SideBySide
 			}
 		}
 
+		[Fact]
+		public async Task CancelCompletedCommand()
+		{
+			using (var cmd = m_database.Connection.CreateCommand())
+			{
+				cmd.CommandText = @"select 1;";
+
+				using (await cmd.ExecuteReaderAsync().ConfigureAwait(false))
+					cmd.Cancel();
+			}
+		}
+
 		[UnbufferedResultSetsFact]
 		public async Task CancelHugeQueryWithTokenAfterExecuteReader()
 		{


### PR DESCRIPTION
KILL QUERY will interrupt a subsequent query if the command it was intended to cancel has already completed, and the connection is idle. In order to handle this case, we issue a dummy query to catch the QueryInterrupted exception. See https://bugs.mysql.com/bug.php?id=45679.

I ran into this issue while using Dapper's `QueryImpl` method. If `reader.FieldCount == 0`, then Dapper will try to cancel the query. Upon the next command issued by the connection, it is immediately interrupted. 

Generally, using `Query` without selecting any columns is wrong, but this would be a problem for any query that completed before it was canceled. The MySQL.Data implementation from Oracle handles both of these cases without an error.