### PR TITLE
Reduce memory usage when reading payloads that span multiple packets.

### DIFF
--- a/src/MySqlConnector/Protocol/Serialization/ArraySegmentHolder.cs
+++ b/src/MySqlConnector/Protocol/Serialization/ArraySegmentHolder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace MySql.Data.Protocol.Serialization
+{
+	/// <summary>
+	/// <see cref="ArraySegmentHolder{T}"/> is a class that holds an instance of <see cref="ArraySegment{T}"/>.
+	/// Its primary difference from <see cref="ArraySegment{T}"/> is that it's a reference type, so mutations
+	/// to this object are visible to other objects that hold a reference to it.
+	/// </summary>
+	internal sealed class ArraySegmentHolder<T>
+	{
+		public ArraySegment<T> ArraySegment { get; set; }
+
+		public T[] Array => ArraySegment.Array;
+		public int Offset => ArraySegment.Offset;
+		public int Count => ArraySegment.Count;
+
+		public void Clear()
+		{
+			if (ArraySegment.Count > 0)
+				ArraySegment = new ArraySegment<T>(ArraySegment.Array, 0, 0);
+		}
+	}
+}

--- a/src/MySqlConnector/Protocol/Serialization/CompressedPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/CompressedPayloadHandler.cs
@@ -30,8 +30,8 @@ namespace MySql.Data.Protocol.Serialization
 			set => throw new NotSupportedException();
 		}
 
-		public ValueTask<ArraySegment<byte>> ReadPayloadAsync(ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior) =>
-			ProtocolUtility.ReadPayloadAsync(m_bufferedByteReader, new CompressedByteHandler(this, protocolErrorBehavior), () => -1, default(ArraySegment<byte>), protocolErrorBehavior, ioBehavior);
+		public ValueTask<ArraySegment<byte>> ReadPayloadAsync(ArraySegmentHolder<byte> cache, ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior) =>
+			ProtocolUtility.ReadPayloadAsync(m_bufferedByteReader, new CompressedByteHandler(this, protocolErrorBehavior), () => -1, cache, protocolErrorBehavior, ioBehavior);
 
 		public ValueTask<int> WritePayloadAsync(ArraySegment<byte> payload, IOBehavior ioBehavior)
 		{

--- a/src/MySqlConnector/Protocol/Serialization/IPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/IPayloadHandler.cs
@@ -19,12 +19,15 @@ namespace MySql.Data.Protocol.Serialization
 		/// <summary>
 		/// Reads the next payload.
 		/// </summary>
+		/// <param name="cache">An <see cref="ArraySegmentHolder{Byte}"/> that will cache any buffers allocated during this
+		/// read. (To disable caching, pass <code>new ArraySegmentHolder&lt;byte&gt;</code> so the cache will be garbage-collected
+		/// when this method returns.)</param>
 		/// <param name="protocolErrorBehavior">The <see cref="ProtocolErrorBehavior"/> to use if there is a protocol error.</param>
 		/// <param name="ioBehavior">The <see cref="IOBehavior"/> to use when reading data.</param>
 		/// <returns>An <see cref="ArraySegment{Byte}"/> containing the data that was read. This
 		/// <see cref="ArraySegment{Byte}"/> will be valid to read from until the next time <see cref="ReadPayloadAsync"/> or
 		/// <see cref="WritePayloadAsync"/> is called.</returns>
-		ValueTask<ArraySegment<byte>> ReadPayloadAsync(ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior);
+		ValueTask<ArraySegment<byte>> ReadPayloadAsync(ArraySegmentHolder<byte> cache, ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior);
 
 		/// <summary>
 		/// Writes a payload.

--- a/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
@@ -26,8 +26,8 @@ namespace MySql.Data.Protocol.Serialization
 			}
 		}
 
-		public ValueTask<ArraySegment<byte>> ReadPayloadAsync(ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior) =>
-			ProtocolUtility.ReadPayloadAsync(m_bufferedByteReader, m_byteHandler, m_getNextSequenceNumber, default(ArraySegment<byte>), protocolErrorBehavior, ioBehavior);
+		public ValueTask<ArraySegment<byte>> ReadPayloadAsync(ArraySegmentHolder<byte> cache, ProtocolErrorBehavior protocolErrorBehavior, IOBehavior ioBehavior) =>
+			ProtocolUtility.ReadPayloadAsync(m_bufferedByteReader, m_byteHandler, m_getNextSequenceNumber, cache, protocolErrorBehavior, ioBehavior);
 
 		public ValueTask<int> WritePayloadAsync(ArraySegment<byte> payload, IOBehavior ioBehavior) =>
 			ProtocolUtility.WritePayloadAsync(m_byteHandler, m_getNextSequenceNumber, payload, ioBehavior);


### PR DESCRIPTION
Change `ref ArraySegment<byte>` to `ArraySegmentHolder<byte>` so that a mutated `ArraySegment<byte>` can be passed back through a lambda function.

When run with larger BLOBs (i.e., > 16MiB, the size of one packet), the test results are as follows. `ReadBlobsNew` allocates 60% less data and becomes 16% faster. Other tests are essentially unchanged.

### Before


Method | Mean | StdDev | StdErr | Min | Q1 | Median | Q3 | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
---------------------- |---------------- |-------------- |------------ |---------------- |---------------- |---------------- |---------------- |---------------- |--------- |---------- |---------- |---------- |---------- |
ReadBlobsOldAsync | 183,667.8394 us | 1,161.7614 us | 322.2146 us | 181,856.7220 us | 182,956.8441 us | 183,361.9487 us | 184,116.7797 us | 185,937.5694 us | 5.44 | - | - | - | 67.01 MB |
ReadBlobsOldSync | 180,624.3700 us | 1,573.1979 us | 406.1979 us | 178,565.8162 us | 179,487.9914 us | 180,454.4471 us | 181,738.6010 us | 184,863.7147 us | 5.54 | 16.6667 | 16.6667 | 16.6667 | 67.01 MB |
ReadBlobsNewAsync | 202,842.5955 us | 1,238.6008 us | 319.8054 us | 200,103.8980 us | 202,173.3350 us | 202,988.8227 us | 203,793.3685 us | 204,539.6862 us | 4.93 | 1275.0000 | 1275.0000 | 1275.0000 | 167.76 MB |
ReadBlobsNewSync | 200,136.9124 us | 675.7203 us | 187.4111 us | 198,914.1884 us | 199,651.0397 us | 200,025.8022 us | 200,667.8334 us | 201,531.4505 us | 5 | 1391.6667 | 1391.6667 | 1391.6667 | 167.67 MB |

### After

Method | Mean | StdErr | StdDev | Median | Min | Q1 | Q3 | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
---------------------- |---------------- |------------ |-------------- |---------------- |---------------- |---------------- |---------------- |---------------- |--------- |--------- |--------- |--------- |---------- |
ReadBlobsOldAsync | 181,221.9569 us | 769.7803 us | 2,981.3462 us | 179,935.0513 us | 177,621.6681 us | 179,229.9717 us | 183,292.2712 us | 188,012.1440 us | 5.52 | - | - | - | 67.01 MB |
ReadBlobsOldSync | 182,072.6833 us | 516.8273 us | 2,001.6635 us | 181,741.0179 us | 178,817.1828 us | 180,375.7257 us | 183,730.9112 us | 185,683.7819 us | 5.49 | - | - | - | 67.01 MB |
ReadBlobsNewAsync | 168,934.5490 us | 358.2424 us | 1,387.4668 us | 168,436.2817 us | 167,306.9631 us | 167,929.1449 us | 169,611.1639 us | 172,052.8617 us | 5.92 | 829.1667 | 829.1667 | 829.1667 | 67.12 MB |
ReadBlobsNewSync | 166,960.6247 us | 264.5874 us | 989.9953 us | 167,157.0712 us | 165,231.1244 us | 166,155.5539 us | 167,565.4565 us | 168,570.1445 us | 5.99 | 170.8333 | 170.8333 | 170.8333 | 67.01 MB |
