### PR TITLE
Recover leaked connection pool entries

### DIFF
--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -17,19 +17,21 @@ namespace MySql.Data.Serialization
 	internal sealed class MySqlSession
 	{
 		public MySqlSession()
-			: this(null, 0)
+			: this(null, 0, 0)
 		{
 		}
 
-		public MySqlSession(ConnectionPool pool, int poolGeneration)
+		public MySqlSession(ConnectionPool pool, int poolGeneration, int id)
 		{
 			m_lock = new object();
 			m_payloadCache = new ArraySegmentHolder<byte>();
+			Id = id;
 			CreatedUtc = DateTime.UtcNow;
 			Pool = pool;
 			PoolGeneration = poolGeneration;
 		}
 
+		public int Id { get; }
 		public ServerVersion ServerVersion { get; set; }
 		public int ConnectionId { get; set; }
 		public byte[] AuthPluginData { get; set; }

--- a/tests/SideBySide/ConnectionPool.cs
+++ b/tests/SideBySide/ConnectionPool.cs
@@ -131,6 +131,26 @@ namespace SideBySide
 		}
 
 		[Fact]
+		public void LeakConnections()
+		{
+			var csb = AppConfig.CreateConnectionStringBuilder();
+			csb.Pooling = true;
+			csb.MinimumPoolSize = 0;
+			csb.MaximumPoolSize = 6;
+			csb.ConnectionTimeout = 3u;
+
+			for (int i = 0; i < csb.MaximumPoolSize + 2; i++)
+			{
+				var connection = new MySqlConnection(csb.ConnectionString);
+				connection.Open();
+
+				// have to GC for leaked connections to be removed from the pool
+				GC.Collect();
+			}
+		}
+
+
+		[Fact]
 		public async Task WaitTimeout()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();


### PR DESCRIPTION
Uses a `WeakReference` to track `MySqlSession` objects, and restores free slots to the connection pool if it detects that a `MySqlSession` object has been garbage-collected (without the associated `MySqlConnection` having been disposed).

Although `MySqlConnection` objects should always be disposed, this connector should be resilient to client code that fails to do so.