### PR TITLE
Concurrency Tests

### DIFF
--- a/tests/MySqlConnector.Performance/Commands/CommandRunner.cs
+++ b/tests/MySqlConnector.Performance/Commands/CommandRunner.cs
@@ -1,0 +1,46 @@
+﻿using System;
+
+namespace MySqlConnector.Performance.Commands
+{
+	public static class CommandRunner
+	{
+		public static void Help()
+		{
+			Console.Error.WriteLine(@"dotnet run
+concurrency [iterations] [concurrency] [operations]
+-h, --help		 show this message
+");
+		}
+
+		public static int Run(string[] args)
+		{
+			var cmd = args[0];
+
+			try
+			{
+				switch (cmd)
+				{
+					case "concurrency":
+						if (args.Length != 4)
+							goto default;
+						ConcurrencyCommand.Run(int.Parse(args[1]), int.Parse(args[2]), int.Parse(args[3]));
+						break;
+					case "-h":
+					case "--help":
+						Help();
+						break;
+					default:
+						Help();
+						return 1;
+				}
+			}
+			catch (Exception e)
+			{
+				Console.Error.WriteLine(e.Message);
+				Console.Error.WriteLine(e.StackTrace);
+				return 1;
+			}
+			return 0;
+		}
+	}
+}

--- a/tests/MySqlConnector.Performance/Commands/ConcurrencyCommand.cs
+++ b/tests/MySqlConnector.Performance/Commands/ConcurrencyCommand.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector.Performance.Models;
+
+namespace MySqlConnector.Performance.Commands
+{
+	public static class ConcurrencyCommand
+	{
+		public static void Run(int iterations, int concurrency, int ops)
+		{
+
+			var recordNum = 0;
+			async Task InsertOne(AppDb db)
+			{
+				var blog = new BlogPost(db)
+				{
+					Title = "Title " + Interlocked.Increment(ref recordNum),
+					Content = "content"
+				};
+				await blog.InsertAsync();
+			}
+
+			var selected = new ConcurrentQueue<string>();
+			async Task SelectTen(AppDb db)
+			{
+				var blogPosts = await (new BlogPostQuery(db)).LatestPostsAsync();
+				selected.Enqueue(blogPosts.FirstOrDefault().Title);
+			}
+
+			var sleepNum = 0;
+			async Task SleepMillisecond(AppDb db)
+			{
+				using (var cmd = db.Connection.CreateCommand())
+				{
+					cmd.CommandText = "SELECT SLEEP(0.001)";
+					await cmd.ExecuteNonQueryAsync();
+				}
+				Interlocked.Increment(ref sleepNum);
+			}
+
+			using (var db = new AppDb())
+			{
+				db.Connection.Open();
+				using (var cmd = db.Connection.CreateCommand())
+				{
+					cmd.CommandText = "DELETE FROM `BlogPost`";
+					cmd.ExecuteNonQuery();
+				}
+			}
+
+			PerfTest(InsertOne, "Insert One", iterations, concurrency, ops).GetAwaiter().GetResult();
+			using (var db = new AppDb())
+			{
+				db.Connection.Open();
+				using (var cmd = db.Connection.CreateCommand())
+				{
+					cmd.CommandText = "SELECT COUNT(*) FROM `BlogPost`";
+					Console.WriteLine("Records Inserted: " + cmd.ExecuteScalar());
+					Console.WriteLine();
+				}
+			}
+
+			PerfTest(SelectTen, "Select Ten", iterations, concurrency, ops).GetAwaiter().GetResult();
+			Console.WriteLine("Records Selected: " + selected.Count * 10);
+			string firstRecord;
+			if (selected.TryDequeue(out firstRecord))
+				Console.WriteLine("First Record: " + firstRecord);
+			Console.WriteLine();
+
+			PerfTest(SleepMillisecond, "Sleep 1ms", iterations, concurrency, ops).GetAwaiter().GetResult();
+			Console.WriteLine("Total Sleep Commands: " + sleepNum);
+			Console.WriteLine();
+		}
+
+		public static async Task PerfTest(Func<AppDb, Task> test, string testName, int iterations, int concurrency, int ops)
+		{
+			var timers = new List<TimeSpan>();
+			for (var iteration = 0; iteration < iterations; iteration++)
+			{
+				var tasks = new List<Task>();
+				var start = DateTime.UtcNow;
+				for (var connection = 0; connection < concurrency; connection++)
+				{
+					tasks.Add(ConnectionTask(test, ops));
+				}
+				await Task.WhenAll(tasks);
+				timers.Add(DateTime.UtcNow - start);
+			}
+			Console.WriteLine("Test                     " + testName);
+			Console.WriteLine("Iterations:              " + iterations);
+			Console.WriteLine("Concurrency:             " + concurrency);
+			Console.WriteLine("Operations:              " + ops);
+			Console.WriteLine("Times (Min, Average, Max) "
+							  + timers.Min() + ", "
+							  + TimeSpan.FromTicks(timers.Sum(timer => timer.Ticks) / timers.Count) + ", "
+							  + timers.Max());
+			Console.WriteLine();
+		}
+
+		private static async Task ConnectionTask(Func<AppDb, Task> cb, int ops)
+		{
+			using (var db = new AppDb())
+			{
+				await db.Connection.OpenAsync();
+				for (var op = 0; op < ops; op++)
+				{
+					await cb(db);
+				}
+			}
+		}
+
+	}
+}

--- a/tests/MySqlConnector.Performance/Controllers/AsyncController.cs
+++ b/tests/MySqlConnector.Performance/Controllers/AsyncController.cs
@@ -118,13 +118,21 @@ namespace MySqlConnector.Performance.Controllers
 						};
 						await blogPost.InsertAsync();
 					}
+#if BASELINE
+					txn.Commit();
+#else
+					await txn.CommitAsync();
+#endif
 				}
 				catch (Exception)
 				{
+#if BASELINE
+					txn.Rollback();
+#else
 					await txn.RollbackAsync();
+#endif
 					throw;
 				}
-				await txn.CommitAsync();
 				var timing = $"Async: Inserted {num} records in " + (DateTime.Now - time);
 				Console.WriteLine(timing);
 				return new OkObjectResult(timing);

--- a/tests/MySqlConnector.Performance/Models/BlogPostQuery.cs
+++ b/tests/MySqlConnector.Performance/Models/BlogPostQuery.cs
@@ -58,11 +58,19 @@ namespace MySqlConnector.Performance.Models
 			try
 			{
 				await DeleteAllCmd().ExecuteNonQueryAsync();
+#if BASELINE
+				txn.Commit();
+#else
 				await txn.CommitAsync();
+#endif
 			}
 			catch
 			{
+#if BASELINE
+				txn.Rollback();
+#else
 				await txn.RollbackAsync();
+#endif
 				throw;
 			}
 		}

--- a/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
+++ b/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1.1</TargetFramework>
@@ -6,11 +6,10 @@
     <AssemblyName>MySqlConnector.Performance</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>MySqlConnector.Performance</PackageId>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <ThreadPoolMinThreads>64</ThreadPoolMinThreads>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
@@ -24,5 +23,16 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' != 'Baseline' ">
+    <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(Configuration)' == 'Baseline' ">
+    <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">
+    <DefineConstants>BASELINE</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/tests/MySqlConnector.Performance/Program.cs
+++ b/tests/MySqlConnector.Performance/Program.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System;
+using Microsoft.AspNetCore.Hosting;
+using MySqlConnector.Performance.Commands;
 
 namespace MySqlConnector.Performance
 {
@@ -7,12 +9,19 @@ namespace MySqlConnector.Performance
 		public static void Main(string[] args)
 		{
 			AppDb.Initialize();
-			var host = new WebHostBuilder()
-				.UseKestrel()
-				.UseStartup<Startup>()
-				.Build();
-
-			host.Run();
+			if (args.Length == 0)
+			{
+				var host = new WebHostBuilder()
+					.UseUrls("http://*:5000")
+					.UseKestrel()
+					.UseStartup<Startup>()
+					.Build();
+				host.Run();
+			}
+			else
+			{
+				Environment.Exit(CommandRunner.Run(args));
+			}
 		}
 	}
 }

--- a/tests/MySqlConnector.Performance/README.md
+++ b/tests/MySqlConnector.Performance/README.md
@@ -1,6 +1,22 @@
 Performance Tests
 =================
 
+## Concurrency Testing
+
+To run concurrency tests, execute the following command
+
+```
+dotnet run concurrency [iterations] [concurrency] [operations]
+```
+
+For example, the following command will run 3 iterations using 100 concurrent connections and 10 operations in each concurrency test:
+
+```
+dotnet run concurrency 3 100 10
+```
+
+## HTTP Load Testing
+
 The `MySqlConnector.Performance` project runs a .NET Core MVC API application that is intended to be used to load test asynchronous and synchronous MySqlConnector methods.
 
 You first must configure your MySql Database.  Open the `config.json.example` file, configure the connection string, and save it as `config.json`.  Now you can run the application with `dotnet run`.
@@ -31,3 +47,17 @@ The `scripts` directory contains load testing scripts.  These scripts require th
 
     # run 50 sync queries per second for 1 minute on windows
     ./stress.ps1 50 1m sync
+
+## Baseline Tests
+
+To run the Baseline tests against MySql.Data, first restore the project to include MySql.Data:
+
+```
+dotnet restore /p:Configuration=Baseline
+```
+
+Next, run use `dotnet -c Baseline` when running any dotnet commands.  Example:
+
+```
+dotnet run -c Baseline concurrency 3 100 10
+```


### PR DESCRIPTION
I've adapted https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/270 for MySqlConnector so that we can test concurrency against MySql.Data.  Running the tests here now and I'll post the results.

Would it be a good idea to enable the Wiki so that we can put concurrency results there?  Much like we do on the [Pomelo Wiki](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/wiki/Concurrency-Benchmark-Results)

Other option would be putting the test results on the Docs website