### PR TITLE
Escape single quote and backslash when writing GUIDs as byte arrays.

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlParameter.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlParameter.cs
@@ -161,7 +161,12 @@ namespace MySql.Data.MySqlClient
 				if ((options & StatementPreparerOptions.OldGuids) != 0)
 				{
 					writer.WriteUtf8("_binary'");
-					writer.Write(guidValue.ToByteArray());
+					foreach (var by in guidValue.ToByteArray())
+					{
+						if (by == 0x27 || by == 0x5C)
+							writer.Write((byte) 0x5C);
+						writer.Write(by);
+					}
 					writer.Write((byte) '\'');
 				}
 				else


### PR DESCRIPTION
This code is copied from [writing a byte array](https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector/MySqlClient/MySqlParameter.cs#L124-L129). 

These byte values were not escaped when writing a GUID as a byte array, causing syntax errors when doing something like

```
var query = @"insert into table(value) select @value from dual";
database.Connection.Execute(query, new { value = Guid.NewGuid() });
```

when `OldGuids=true`.

Since the code is duplicated, I can refactor it into a method if we feel that's appropriate.