### PR TITLE
Add fake MySQL Server

### DIFF
--- a/tests/MySqlConnector.Tests/BinaryWriterExtensions.cs
+++ b/tests/MySqlConnector.Tests/BinaryWriterExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+using System.Text;
+
+namespace MySqlConnector.Tests
+{
+	public static class BinaryWriterExtensions
+	{
+		public static void WriteRaw(this BinaryWriter writer, string value) => writer.Write(Encoding.UTF8.GetBytes(value));
+
+		public static void WriteNullTerminated(this BinaryWriter writer, string value)
+		{
+			writer.Write(Encoding.UTF8.GetBytes(value));
+			writer.Write((byte) 0);
+		}
+	}
+}

--- a/tests/MySqlConnector.Tests/ConnectionTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace MySqlConnector.Tests
+{
+    public class ConnectionTests : IDisposable
+	{
+		public ConnectionTests()
+		{
+			m_server = new FakeMySqlServer();
+			m_server.Start();
+
+			m_csb = new MySqlConnectionStringBuilder
+			{
+				Server = "localhost",
+				Port = (uint) m_server.Port,
+			};
+		}
+
+		public void Dispose()
+		{
+			m_server.Stop();
+		}
+
+		[Fact]
+		public void PooledConnectionIsReturnedToPool()
+		{
+			Assert.Equal(0, m_server.ActiveConnections);
+
+			m_csb.Pooling = true;
+			using (var connection = new MySqlConnection(m_csb.ConnectionString))
+			{
+				connection.Open();
+				Assert.Equal(1, m_server.ActiveConnections);
+
+				Assert.Equal(m_server.ServerVersion, connection.ServerVersion);
+				connection.Close();
+				Assert.Equal(1, m_server.ActiveConnections);
+			}
+
+			Assert.Equal(1, m_server.ActiveConnections);
+		}
+
+		[Fact]
+		public async Task UnpooledConnectionIsClosed()
+		{
+			Assert.Equal(0, m_server.ActiveConnections);
+
+			m_csb.Pooling = false;
+			using (var connection = new MySqlConnection(m_csb.ConnectionString))
+			{
+				await connection.OpenAsync();
+				Assert.Equal(1, m_server.ActiveConnections);
+
+				Assert.Equal(m_server.ServerVersion, connection.ServerVersion);
+				connection.Close();
+
+				await WaitForConditionAsync(0, () => m_server.ActiveConnections);
+			}
+		}
+
+		private static async Task WaitForConditionAsync<T>(T expected, Func<T> getValue)
+		{
+			var sw = Stopwatch.StartNew();
+			while (sw.ElapsedMilliseconds < 1000 && !expected.Equals(getValue()))
+				await Task.Delay(50);
+			Assert.Equal(expected, getValue());
+		}
+
+		readonly FakeMySqlServer m_server;
+		readonly MySqlConnectionStringBuilder m_csb;
+	}
+}

--- a/tests/MySqlConnector.Tests/FakeMySqlServer.cs
+++ b/tests/MySqlConnector.Tests/FakeMySqlServer.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MySqlConnector.Tests
+{
+	public sealed class FakeMySqlServer
+	{
+		public FakeMySqlServer()
+		{
+			m_tcpListener = new TcpListener(IPAddress.Any, 0);
+			m_tasks = new List<Task>();
+		}
+
+		public void Start()
+		{
+			m_activeConnections = 0;
+			m_cts = new CancellationTokenSource();
+			m_tcpListener.Start();
+			m_tasks.Add(AcceptConnectionsAsync());
+		}
+
+		public void Stop()
+		{
+			m_cts.Cancel();
+			m_tcpListener.Stop();
+			try
+			{
+				Task.WaitAll(m_tasks.ToArray());
+			}
+			catch (AggregateException)
+			{
+			}
+			m_tasks.Clear();
+			m_cts.Dispose();
+			m_cts = null;
+		}
+
+		public int Port => ((IPEndPoint) m_tcpListener.LocalEndpoint).Port;
+
+		public int ActiveConnections => m_activeConnections;
+
+		public string ServerVersion { get; set; } = "5.7.10-test";
+
+		internal void ClientDisconnected() => Interlocked.Decrement(ref m_activeConnections);
+
+		private async Task AcceptConnectionsAsync()
+		{
+			while (true)
+			{
+				var tcpClient = await m_tcpListener.AcceptTcpClientAsync();
+				Interlocked.Increment(ref m_activeConnections);
+				lock (m_tasks)
+				{
+					var connection = new FakeMySqlServerConnection(this, m_tasks.Count);
+					m_tasks.Add(connection.RunAsync(tcpClient, m_cts.Token));
+				}
+			}
+		}
+
+		readonly TcpListener m_tcpListener;
+		readonly List<Task> m_tasks;
+		CancellationTokenSource m_cts;
+		int m_activeConnections;
+	}
+}

--- a/tests/MySqlConnector.Tests/FakeMySqlServerConnection.cs
+++ b/tests/MySqlConnector.Tests/FakeMySqlServerConnection.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using MySql.Data.Serialization;
+
+namespace MySqlConnector.Tests
+{
+	internal sealed class FakeMySqlServerConnection
+	{
+		public FakeMySqlServerConnection(FakeMySqlServer server, int connectionId)
+		{
+			m_server = server ?? throw new ArgumentNullException(nameof(server));
+			m_connectionId = connectionId;
+		}
+
+		public async Task RunAsync(TcpClient client, CancellationToken token)
+		{
+			try
+			{
+				using (token.Register(client.Dispose))
+				using (client)
+				using (var stream = client.GetStream())
+				{
+					await SendAsync(stream, 0, WriteInitialHandshake);
+					await ReadPayloadAsync(stream, token); // handshake response
+					await SendAsync(stream, 2, WriteOk);
+
+					var keepRunning = true;
+					while (keepRunning)
+					{
+						var bytes = await ReadPayloadAsync(stream, token);
+						switch ((CommandKind) bytes[0])
+						{
+						case CommandKind.Quit:
+							await SendAsync(stream, 1, WriteOk);
+							keepRunning = false;
+							break;
+
+						case CommandKind.Ping:
+						case CommandKind.Query:
+						case CommandKind.ResetConnection:
+								await SendAsync(stream, 1, WriteOk);
+							break;
+
+						default:
+							Console.WriteLine("** UNHANDLED ** {0}", (CommandKind) bytes[0]);
+							await SendAsync(stream, 1, WriteError);
+							break;
+						}
+					}
+				}
+			}
+			finally
+			{
+				m_server.ClientDisconnected();
+			}
+		}
+
+		private static async Task SendAsync(Stream stream, int sequenceNumber, Action<BinaryWriter> writePayload)
+		{
+			var packet = MakePayload(sequenceNumber, writePayload);
+			await stream.WriteAsync(packet, 0, packet.Length);
+		}
+
+		private static byte[] MakePayload(int sequenceNumber, Action<BinaryWriter> writePayload)
+		{
+			using (var memoryStream = new MemoryStream())
+			{
+				using (var writer = new BinaryWriter(memoryStream, Encoding.UTF8, leaveOpen: true))
+				{
+					writer.Write(default(int));
+					writePayload(writer);
+					memoryStream.Position = 0;
+					writer.Write(((int) (memoryStream.Length - 4)) | ((sequenceNumber % 256) << 24));
+				}
+				return memoryStream.ToArray();
+			}
+		}
+
+		private static async Task<byte[]> ReadPayloadAsync(Stream stream, CancellationToken token)
+		{
+			var header = await ReadBytesAsync(stream, 4, token);
+			var length = header[0] | (header[1] << 8) | (header[2] << 16);
+			var sequenceNumber = header[3];
+			return await ReadBytesAsync(stream, length, token);
+		}
+
+		private static async Task<byte[]> ReadBytesAsync(Stream stream, int count, CancellationToken token)
+		{
+			var bytes = new byte[count];
+			for (var bytesRead = 0; bytesRead < count;)
+				bytesRead += await stream.ReadAsync(bytes, bytesRead, count - bytesRead, token);
+			return bytes;
+		}
+
+		private void WriteInitialHandshake(BinaryWriter writer)
+		{
+			var random = new Random(1);
+			var authData = new byte[20];
+			random.NextBytes(authData);
+			var capabilities =
+				ProtocolCapabilities.LongPassword |
+				ProtocolCapabilities.FoundRows |
+				ProtocolCapabilities.LongFlag |
+				ProtocolCapabilities.IgnoreSpace |
+				ProtocolCapabilities.Protocol41 |
+				ProtocolCapabilities.Transactions |
+				ProtocolCapabilities.SecureConnection |
+				ProtocolCapabilities.MultiStatements |
+				ProtocolCapabilities.MultiResults |
+				ProtocolCapabilities.PluginAuth |
+				ProtocolCapabilities.ConnectionAttributes |
+				ProtocolCapabilities.PluginAuthLengthEncodedClientData;
+
+			writer.Write((byte) 10); // protocol version
+			writer.WriteNullTerminated(m_server.ServerVersion); // server version
+			writer.Write(m_connectionId); // conection ID
+			writer.Write(authData, 0, 8); // auth plugin data part 1
+			writer.Write((byte) 0); // filler
+			writer.Write((ushort) capabilities);
+			writer.Write((byte) CharacterSet.Utf8Binary); // character set
+			writer.Write((ushort) 0); // status flags
+			writer.Write((ushort) ((uint) capabilities >> 16));
+			writer.Write((byte) authData.Length);
+			writer.Write(new byte[10]); // reserved
+			writer.Write(authData, 8, authData.Length - 8);
+			if (authData.Length - 8 < 13)
+				writer.Write(new byte[13 - (authData.Length - 8)]); // have to write at least 13 bytes
+			writer.WriteNullTerminated("mysql_native_password");
+		}
+
+		private static void WriteOk(BinaryWriter writer)
+		{
+			writer.Write((byte) 0); // signature
+			writer.Write((byte) 0); // 0 rows affected
+			writer.Write((byte) 0); // last insert ID
+			writer.Write((ushort) 0); // server status
+			writer.Write((ushort) 0); // warning count
+		}
+
+		private static void WriteError(BinaryWriter writer)
+		{
+			writer.Write((byte) 0xFF); // signature
+			writer.Write((ushort) MySqlErrorCode.UnknownError); // error code
+			writer.WriteRaw("#ERROR");
+			writer.WriteRaw("An unknown error occurred");
+		}
+
+		readonly FakeMySqlServer m_server;
+		readonly int m_connectionId;
+	}
+}

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'Baseline' ">
     <PackageReference Include="MySql.Data" Version="6.9.9" />
-    <Compile Remove="NormalizeTests.cs;TypeMapperTests.cs;Utf8Tests.cs" />
+    <Compile Remove="ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;NormalizeTests.cs;TypeMapperTests.cs;Utf8Tests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/tests/SideBySide/ConnectionPool.cs
+++ b/tests/SideBySide/ConnectionPool.cs
@@ -173,6 +173,9 @@ namespace SideBySide
 
 				// have to GC for leaked connections to be removed from the pool
 				GC.Collect();
+
+				// HACK: have to sleep (so that RecoverLeakedSessions is called in ConnectionPool.GetSessionAsync?)
+				Thread.Sleep(250);
 			}
 		}
 

--- a/tests/SideBySide/ConnectionPool.cs
+++ b/tests/SideBySide/ConnectionPool.cs
@@ -205,35 +205,6 @@ namespace SideBySide
 			}
 		}
 
-		[Theory]
-		[InlineData(2u, 3u, true)]
-		[InlineData(180u, 3u, false)]
-		public async Task ConnectionLifeTime(uint lifeTime, uint delaySeconds, bool shouldTimeout)
-		{
-			var csb = AppConfig.CreateConnectionStringBuilder();
-			csb.Pooling = true;
-			csb.MinimumPoolSize = 0;
-			csb.MaximumPoolSize = 1;
-			csb.ConnectionLifeTime = lifeTime;
-			int serverThread;
-
-			using (var connection = new MySqlConnection(csb.ConnectionString))
-			{
-				await connection.OpenAsync();
-				serverThread = connection.ServerThread;
-				await Task.Delay(TimeSpan.FromSeconds(delaySeconds));
-			}
-
-			using (var connection = new MySqlConnection(csb.ConnectionString))
-			{
-				await connection.OpenAsync();
-				if (shouldTimeout)
-					Assert.NotEqual(serverThread, connection.ServerThread);
-				else
-					Assert.Equal(serverThread, connection.ServerThread);
-			}
-		}
-
 		[Fact]
 		public async Task CharacterSet()
 		{

--- a/tests/SideBySide/ConnectionPool.cs
+++ b/tests/SideBySide/ConnectionPool.cs
@@ -149,36 +149,6 @@ namespace SideBySide
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "Throws MySqlException - error connecting: Timeout expired")]
-#else
-		[Fact]
-#endif
-		public void LeakReaders()
-		{
-			var csb = AppConfig.CreateConnectionStringBuilder();
-			csb.Pooling = true;
-			csb.MinimumPoolSize = 0;
-			csb.MaximumPoolSize = 6;
-			csb.ConnectionTimeout = 3u;
-
-			for (int i = 0; i < csb.MaximumPoolSize + 2; i++)
-			{
-				var connection = new MySqlConnection(csb.ConnectionString);
-				connection.Open();
-				var cmd = connection.CreateCommand();
-				cmd.CommandText = "SELECT 1";
-				var reader = cmd.ExecuteReader();
-				Assert.True(reader.Read());
-
-				// have to GC for leaked connections to be removed from the pool
-				GC.Collect();
-
-				// HACK: have to sleep (so that RecoverLeakedSessions is called in ConnectionPool.GetSessionAsync?)
-				Thread.Sleep(250);
-			}
-		}
-
 		[Fact]
 		public async Task WaitTimeout()
 		{


### PR DESCRIPTION
Exploration of adding a (simple so far) fake MySQL Server, for testing the protocol without using a real MySQL Server instance.

This allows introspection of the server state, so (for example) we can test that `Minimum Pool Size` opens the right number of initial connections. It should also allow unit testing of (simulated) behavior observed from various servers in the wild without having to recreate the exact conditions that put the server in that state.

Drawbacks are obviously that (due to bugs in the fake server) it could lead to testing conditions that never happen in real-world usage. Alternatively, a bug in the fake server could mask a bug in the client, resulting in a false passing test. (This is currently mitigated by reimplementing much of the protocol from scratch instead of reusing code from the connector.) Additionally, the state machine required to implement the server could become extremely complex, especially if faking query results were ever added to the server.

The current tests simply verify that connections aren't closed if pooling is enabled, but are closed if it's disabled.