### PR TITLE
Test net462 with netstandard2.0

### DIFF
--- a/.ci/build.ps1
+++ b/.ci/build.ps1
@@ -31,7 +31,7 @@ function DownloadWithRetry([string] $url, [string] $downloadLocation, [int] $ret
 $repoFolder = Join-Path $PSScriptRoot ..
 $env:REPO_FOLDER = $repoFolder
 
-$koreBuildZip="https://github.com/aspnet/KoreBuild/archive/rel/1.0.0-msbuild-rtm.zip"
+$koreBuildZip="https://github.com/aspnet/KoreBuild/archive/rel/2.0.0-preview1.zip"
 if ($env:KOREBUILD_ZIP)
 {
     $koreBuildZip=$env:KOREBUILD_ZIP
@@ -61,10 +61,9 @@ if (!(Test-Path $buildFolder)) {
     }
 }
 
-$dotnetVersion = "1.0.3"
-$dotnetChannel = "rel-1.0.0"
-$dotnetSharedRuntimeVersion = "1.1.1"
-$dotnetSharedRuntimeChannel = "rel-1.0.0"
+$dotnetArch = 'x64'
+$dotnetChannel = "preview"
+$dotnetVersion = "2.0.0-preview1-005957"
 
 $dotnetLocalInstallFolder = $env:DOTNET_INSTALL_DIR
 if (!$dotnetLocalInstallFolder)
@@ -72,10 +71,21 @@ if (!$dotnetLocalInstallFolder)
     $dotnetLocalInstallFolder = "$env:LOCALAPPDATA\Microsoft\dotnet\"
 }
 
-& "$buildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture x64
-# Avoid redownloading the CLI if it's already installed.
-$sharedRuntimePath = [IO.Path]::Combine($dotnetLocalInstallFolder, 'shared', 'Microsoft.NETCore.App', $dotnetSharedRuntimeVersion)
-if (!(Test-Path $sharedRuntimePath))
+function InstallSharedRuntime([string] $version, [string] $channel)
 {
-    & "$buildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetSharedRuntimeChannel -SharedRuntime -Version $dotnetSharedRuntimeVersion -Architecture x64
+    $sharedRuntimePath = [IO.Path]::Combine($dotnetLocalInstallFolder, 'shared', 'Microsoft.NETCore.App', $version)
+    # Avoid redownloading the CLI if it's already installed.
+    if (!(Test-Path $sharedRuntimePath))
+    {
+        & "$buildFolder\dotnet\dotnet-install.ps1" -Channel $channel `
+            -SharedRuntime `
+            -Version $version `
+            -Architecture $dotnetArch `
+            -InstallDir $dotnetLocalInstallFolder
+    }
 }
+
+& "$buildFolder\dotnet\dotnet-install.ps1" -Channel $dotnetChannel -Version $dotnetVersion -Architecture $dotnetArch
+InstallSharedRuntime -version "1.1.2" -channel "release/1.1.0"
+
+dotnet --info

--- a/.ci/test.ps1
+++ b/.ci/test.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = "Stop"
-
 # restore
 dotnet restore
 if ($LASTEXITCODE -ne 0){

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ before_install:
 - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
 - sudo apt-get update
-- sudo apt-get install -y dotnet-dev-1.0.1
+- sudo apt-get install -y dotnet-dev-2.0.0-preview1-005977
 
 script:
 - dotnet restore
-- dotnet test tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj -c Release -f netcoreapp1.1.1
-- dotnet build tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing tests with No Compression, No SSL' && ./.ci/use-config.sh config.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing Debug Only tests' && time dotnet test tests/SideBySide/SideBySide.csproj -c Debug -f netcoreapp1.1.1 --filter "FullyQualifiedName~SideBySide.DebugOnlyTests"
-- echo 'Executing tests with Compression, No SSL' && ./.ci/use-config.sh config.compression.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing tests with No Compression, SSL' && ./.ci/use-config.sh config.ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing tests with Compression, SSL' && ./.ci/use-config.sh config.compression+ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing tests with Unix Domain Socket, No Compression, No SSL' && ./.ci/use-config.sh config.uds.json && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
-- echo 'Executing tests with Buffering, No Compression, No SSL' && ./.ci/use-config.sh config.buffer.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp1.1.1
+- dotnet test tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj -c Release -f netcoreapp2.0
+- dotnet build tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing tests with No Compression, No SSL' && ./.ci/use-config.sh config.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing Debug Only tests' && time dotnet test tests/SideBySide/SideBySide.csproj -c Debug -f netcoreapp2.0 --filter "FullyQualifiedName~SideBySide.DebugOnlyTests"
+- echo 'Executing tests with Compression, No SSL' && ./.ci/use-config.sh config.compression.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing tests with No Compression, SSL' && ./.ci/use-config.sh config.ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing tests with Compression, SSL' && ./.ci/use-config.sh config.compression+ssl.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing tests with Unix Domain Socket, No Compression, No SSL' && ./.ci/use-config.sh config.uds.json && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
+- echo 'Executing tests with Buffering, No Compression, No SSL' && ./.ci/use-config.sh config.buffer.json 172.17.0.1 3307 && time dotnet test tests/SideBySide/SideBySide.csproj -c Release -f netcoreapp2.0
 
 after_script:
 - chmod +x .ci/build-docs.sh && ./.ci/build-docs.sh

--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Async MySQL Connector</AssemblyTitle>
     <VersionPrefix>0.20.1</VersionPrefix>
     <Authors>Bradley Grainger;Caleb Lloyd</Authors>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MySqlConnector</AssemblyName>
     <PackageId>MySqlConnector</PackageId>
@@ -28,7 +28,7 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Async MySQL Connector</AssemblyTitle>
     <VersionPrefix>0.20.1</VersionPrefix>
     <Authors>Bradley Grainger;Caleb Lloyd</Authors>
-    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MySqlConnector</AssemblyName>
     <PackageId>MySqlConnector</PackageId>

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -203,8 +203,12 @@ namespace MySql.Data.Serialization
 				throw new MySqlException("Unable to connect to any of the specified MySQL hosts.");
 			}
 
-			var socketByteHandler = new SocketByteHandler(m_socket);
-			m_payloadHandler = new StandardPayloadHandler(socketByteHandler);
+#if NETSTANDARD2_0
+ 			var byteHandler = new StreamByteHandler(m_networkStream);
+#else
+			var byteHandler = new SocketByteHandler(m_socket);
+#endif
+			m_payloadHandler = new StandardPayloadHandler(byteHandler);
 
 			var payload = await ReceiveAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 			var reader = new ByteArrayReader(payload.ArraySegment.Array, payload.ArraySegment.Offset, payload.ArraySegment.Count);
@@ -319,6 +323,9 @@ namespace MySql.Data.Serialization
 				return true;
 			}
 			catch (EndOfStreamException)
+			{
+			}
+			catch (IOException)
 			{
 			}
 			catch (SocketException)

--- a/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
+++ b/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MySqlConnector.Performance</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -12,16 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0-*" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'Baseline' ">

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(Configuration)' != 'Baseline' ">
-    <TargetFrameworks>netcoreapp1.1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">

--- a/tests/SideBySide/SideBySide.csproj
+++ b/tests/SideBySide/SideBySide.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup Condition=" '$(Configuration)' != 'Baseline' ">
-    <TargetFrameworks>net46;net462;netcoreapp1.1.2;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp1.1.2;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">

--- a/tests/SideBySide/SideBySide.csproj
+++ b/tests/SideBySide/SideBySide.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
  <PropertyGroup Condition=" '$(Configuration)' != 'Baseline' ">
-    <TargetFrameworks>netcoreapp1.1.1;net462</TargetFrameworks>
+    <TargetFrameworks>net46;net462;netcoreapp1.1.2;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">
@@ -33,6 +33,14 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="2.0.0-*" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(Configuration)' != 'Baseline' ">
     <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
   </ItemGroup>
@@ -43,6 +51,10 @@
 
   <ItemGroup Condition=" '$(Configuration)' != 'Debug' ">
     <Compile Remove="DebugOnlyTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1.2' ">
+    <Compile Remove="TransactionScopeTests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">

--- a/tests/SideBySide/TransactionScopeTests.cs
+++ b/tests/SideBySide/TransactionScopeTests.cs
@@ -1,4 +1,3 @@
-#if !NETCOREAPP1_1_1
 using System;
 using System.Linq;
 using System.Transactions;
@@ -317,4 +316,3 @@ namespace SideBySide
 		DatabaseFixture m_database;
 	}
 }
-#endif


### PR DESCRIPTION
- This is a test PR to see how AppVeyor responds
- Removed `net451` from library TargetFrameworks to force `net462` test to import `netstandard2.0` library