### PR TITLE
Support sha256_password authentication

### DIFF
--- a/.ci/config/config.buffer.json
+++ b/.ci/config/config.buffer.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true;BufferResultSets=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;use compression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;UseCompression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;certificate file=../../../../../.ci/server/certs/ssl-client.pfx;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../../.ci/mysqld/mysqld.sock;user id=ssltest;password=test;database=mysqltest;ssl mode=required;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.uds.json
+++ b/.ci/config/config.uds.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../../.ci/run/mysql/mysqld.sock;user id=mysqltest;password='test;key=\"val';database=mysqltest;ssl mode=none;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/docker-run.sh
+++ b/.ci/docker-run.sh
@@ -2,7 +2,7 @@
 cd $(dirname $0)
 
 display_usage() {
-    echo -e "\nUsage:\n$0 [image] [name] [port]\n"
+    echo -e "\nUsage:\n$0 [image] [name] [port] [features]\n"
 }
 
 # check whether user had supplied -h or --help . If yes display usage
@@ -13,7 +13,7 @@ then
 fi
 
 # check number of arguments
-if [ $# -ne 3 ]
+if [ $# -ne 4 ]
 then
     display_usage
     exit 1
@@ -22,6 +22,7 @@ fi
 IMAGE=$1
 NAME=$2
 PORT=$3
+FEATURES=$4
 
 sudo mkdir -p run/$NAME
 sudo chmod 777 run/$NAME
@@ -39,30 +40,34 @@ for i in `seq 1 30`; do
 	sleep 1
 	# try running the init script
 	docker exec -it $NAME bash -c 'mysql -uroot -ptest < /etc/mysql/conf.d/init.sql' >/dev/null 2>&1
+	if [ $? -ne 0 ]; then continue; fi
+	if [[ $FEATURES == *"Sha256Password"* ]]; then
+	 	docker exec -it $NAME bash -c 'mysql -uroot -ptest < /etc/mysql/conf.d/init_sha256.sql' >/dev/null 2>&1
+		if [ $? -ne 0 ]; then continue; fi
+	fi
+
 	# exit if successful
-	if [ $? -eq 0 ]; then
+	docker exec -it $NAME mysql -ussltest -ptest \
+		--ssl-mode=REQUIRED \
+		--ssl-ca=/etc/mysql/conf.d/certs/ssl-ca-cert.pem \
+		--ssl-cert=/etc/mysql/conf.d/certs/ssl-client-cert.pem \
+		--ssl-key=/etc/mysql/conf.d/certs/ssl-client-key.pem \
+		-e "SELECT 1"
+	if [ $? -ne 0 ]; then
+		# mariadb uses --ssl=TRUE instead of --ssl-mode=REQUIRED
 		docker exec -it $NAME mysql -ussltest -ptest \
-			--ssl-mode=REQUIRED \
+			--ssl=TRUE \
 			--ssl-ca=/etc/mysql/conf.d/certs/ssl-ca-cert.pem \
 			--ssl-cert=/etc/mysql/conf.d/certs/ssl-client-cert.pem \
 			--ssl-key=/etc/mysql/conf.d/certs/ssl-client-key.pem \
 			-e "SELECT 1"
 		if [ $? -ne 0 ]; then
-			# mariadb uses --ssl=TRUE instead of --ssl-mode=REQUIRED
-			docker exec -it $NAME mysql -ussltest -ptest \
-				--ssl=TRUE \
-				--ssl-ca=/etc/mysql/conf.d/certs/ssl-ca-cert.pem \
-				--ssl-cert=/etc/mysql/conf.d/certs/ssl-client-cert.pem \
-				--ssl-key=/etc/mysql/conf.d/certs/ssl-client-key.pem \
-				-e "SELECT 1"
-			if [ $? -ne 0 ]; then
-				>&2 echo "Problem with SSL"
-				exit 1
-			fi
+			>&2 echo "Problem with SSL"
+			exit 1
 		fi
-		echo "Ran Init Script"
-		exit 0
 	fi
+	echo "Ran Init Script"
+	exit 0
 done
 
 # init script did not run

--- a/.ci/server/init_sha256.sql
+++ b/.ci/server/init_sha256.sql
@@ -1,0 +1,3 @@
+CREATE USER 'sha256user'@'%' IDENTIFIED WITH sha256_password BY 'Sh@256Pa55';
+GRANT ALL PRIVILEGES ON *.* TO 'sha256user'@'%';
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,16 @@ services: docker
 env:
   - IMAGE=mysql:5.7
     NAME=mysql
-    FEATURES=Json,StoredProcedures
+    FEATURES=Json,StoredProcedures,Sha256Password
   - IMAGE=percona:5.7
     NAME=percona
-    FEATURES=Json,StoredProcedures
+    FEATURES=Json,StoredProcedures,Sha256Password
   - IMAGE=mariadb:10.3
     NAME=mariadb
     FEATURES=StoredProcedures
 
 before_install:
-- .ci/docker-run.sh $IMAGE $NAME 3307
+- .ci/docker-run.sh $IMAGE $NAME 3307 $FEATURES
 - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
 - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ env:
     FEATURES=Json,StoredProcedures,Sha256Password
   - IMAGE=percona:5.7
     NAME=percona
-    FEATURES=Json,StoredProcedures,Sha256Password
+    FEATURES=Json,StoredProcedures,Sha256Password,OpenSsl
   - IMAGE=mariadb:10.3
     NAME=mariadb
-    FEATURES=StoredProcedures
+    FEATURES=StoredProcedures,OpenSsl
 
 before_install:
 - .ci/docker-run.sh $IMAGE $NAME 3307 $FEATURES

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ build_script:
 before_test:
 - cmd: |-
     "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! < .ci\server\init.sql
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! < .ci\server\init_sha256.sql
 test_script:
 - ps: .\.ci\test.ps1
 after_test:

--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Async MySQL Connector</AssemblyTitle>
     <VersionPrefix>0.21.0</VersionPrefix>
     <Authors>Bradley Grainger;Caleb Lloyd</Authors>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;net46;netstandard1.3</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>MySqlConnector</AssemblyName>
     <PackageId>MySqlConnector</PackageId>
@@ -28,11 +28,20 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="System.Buffers" Version="4.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.0.0" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Transactions" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.0" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/MySqlConnector/Serialization/AuthenticationMoreDataPayload.cs
+++ b/src/MySqlConnector/Serialization/AuthenticationMoreDataPayload.cs
@@ -1,0 +1,18 @@
+﻿namespace MySql.Data.Serialization
+{
+	internal class AuthenticationMoreDataPayload
+	{
+		public byte[] Data { get; }
+
+		public const byte Signature = 0x01;
+
+		public static AuthenticationMoreDataPayload Create(PayloadData payload)
+		{
+			var reader = new ByteArrayReader(payload.ArraySegment);
+			reader.ReadByte(Signature);
+			return new AuthenticationMoreDataPayload(reader.ReadByteString(reader.BytesRemaining));
+		}
+
+		private AuthenticationMoreDataPayload(byte[] data) => Data = data;
+	}
+}

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -60,9 +60,15 @@ namespace SideBySide
 		public static string MySqlBulkLoaderTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderTsvFile"));
 		public static string MySqlBulkLoaderLocalTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalTsvFile"));
 
-		public static MySqlConnectionStringBuilder CreateConnectionStringBuilder()
+		public static MySqlConnectionStringBuilder CreateConnectionStringBuilder() => new MySqlConnectionStringBuilder(ConnectionString);
+
+		public static MySqlConnectionStringBuilder CreateSha256ConnectionStringBuilder()
 		{
-			return new MySqlConnectionStringBuilder(ConnectionString);
+			var csb = CreateConnectionStringBuilder();
+			csb.UserID = "sha256user";
+			csb.Password = "Sh@256Pa55";
+			csb.Database = null;
+			return csb;
 		}
 
 		// tests can run much slower in CI environments

--- a/tests/SideBySide/ConnectAsync.cs
+++ b/tests/SideBySide/ConnectAsync.cs
@@ -219,6 +219,23 @@ namespace SideBySide
 			}
 		}
 
+		[RequiresFeatureFact(ServerFeatures.Sha256Password, RequiresSsl = true)]
+		public async Task Sha256WithSecureConnection()
+		{
+			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+				await connection.OpenAsync();
+		}
+
+		[RequiresFeatureFact(ServerFeatures.Sha256Password)]
+		public async Task Sha256WithoutSecureConnection()
+		{
+			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
+			csb.SslMode = MySqlSslMode.None;
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+				await Assert.ThrowsAsync<NotImplementedException>(() => connection.OpenAsync());
+		}
+
 		readonly DatabaseFixture m_database;
 	}
 

--- a/tests/SideBySide/ConnectAsync.cs
+++ b/tests/SideBySide/ConnectAsync.cs
@@ -233,7 +233,16 @@ namespace SideBySide
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
 			csb.SslMode = MySqlSslMode.None;
 			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+#if BASELINE || NET451
 				await Assert.ThrowsAsync<NotImplementedException>(() => connection.OpenAsync());
+#else
+				if (AppConfig.SupportedFeatures.HasFlag(ServerFeatures.OpenSsl))
+					await connection.OpenAsync();
+				else
+					await Assert.ThrowsAsync<MySqlException>(() => connection.OpenAsync());
+#endif
+			}
 		}
 
 		readonly DatabaseFixture m_database;

--- a/tests/SideBySide/ConnectSync.cs
+++ b/tests/SideBySide/ConnectSync.cs
@@ -326,6 +326,23 @@ namespace SideBySide
 			}
 		}
 
+		[RequiresFeatureFact(ServerFeatures.Sha256Password, RequiresSsl = true)]
+		public void Sha256WithSecureConnection()
+		{
+			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+				connection.Open();
+		}
+
+		[RequiresFeatureFact(ServerFeatures.Sha256Password)]
+		public void Sha256WithoutSecureConnection()
+		{
+			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
+			csb.SslMode = MySqlSslMode.None;
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+				Assert.Throws<NotImplementedException>(() => connection.Open());
+		}
+
 		readonly DatabaseFixture m_database;
 	}
 }

--- a/tests/SideBySide/ConnectSync.cs
+++ b/tests/SideBySide/ConnectSync.cs
@@ -340,7 +340,16 @@ namespace SideBySide
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
 			csb.SslMode = MySqlSslMode.None;
 			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+#if BASELINE || NET451
 				Assert.Throws<NotImplementedException>(() => connection.Open());
+#else
+				if (AppConfig.SupportedFeatures.HasFlag(ServerFeatures.OpenSsl))
+					connection.Open();
+				else
+					Assert.Throws<MySqlException>(() => connection.Open());
+#endif
+			}
 		}
 
 		readonly DatabaseFixture m_database;

--- a/tests/SideBySide/ServerFeatures.cs
+++ b/tests/SideBySide/ServerFeatures.cs
@@ -8,5 +8,6 @@ namespace SideBySide
 		None = 0,
 		Json = 1,
 		StoredProcedures = 2,
+		Sha256Password = 4,
 	}
 }

--- a/tests/SideBySide/ServerFeatures.cs
+++ b/tests/SideBySide/ServerFeatures.cs
@@ -9,5 +9,6 @@ namespace SideBySide
 		Json = 1,
 		StoredProcedures = 2,
 		Sha256Password = 4,
+		OpenSsl = 8,
 	}
 }


### PR DESCRIPTION
Fixes #281.

This PR supports `sha256_password` authentication. sending the password in plaintext for SSL connections, and encrypting it with the server's RSA public key (if supported) for non-SSL connections.