### PR TITLE
Test with MySQL Server 5.6.

### DIFF
--- a/.ci/config/config.buffer.json
+++ b/.ci/config/config.buffer.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true;BufferResultSets=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;use compression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;UseCompression=true;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;certificate file=../../../../../.ci/server/certs/ssl-client.pfx;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../../.ci/mysqld/mysqld.sock;user id=ssltest;password=test;database=mysqltest;ssl mode=required;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.uds.json
+++ b/.ci/config/config.uds.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../../.ci/run/mysql/mysqld.sock;user id=mysqltest;password='test;key=\"val';database=mysqltest;ssl mode=none;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "SupportedFeatures": "Json,StoredProcedures,Sha256Password",
+      "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,18 @@ dist: trusty
 services: docker
 
 env:
+  - IMAGE=mysql:5.6
+    NAME=mysql
+    FEATURES=StoredProcedures
   - IMAGE=mysql:5.7
     NAME=mysql
-    FEATURES=Json,StoredProcedures,Sha256Password
+    FEATURES=Json,StoredProcedures,Sha256Password,LargePackets
   - IMAGE=percona:5.7
     NAME=percona
-    FEATURES=Json,StoredProcedures,Sha256Password,OpenSsl
+    FEATURES=Json,StoredProcedures,Sha256Password,OpenSsl,LargePackets
   - IMAGE=mariadb:10.3
     NAME=mariadb
-    FEATURES=StoredProcedures,OpenSsl
+    FEATURES=StoredProcedures,OpenSsl,LargePackets
 
 before_install:
 - .ci/docker-run.sh $IMAGE $NAME 3307 $FEATURES

--- a/tests/SideBySide/DataTypes.cs
+++ b/tests/SideBySide/DataTypes.cs
@@ -520,11 +520,8 @@ namespace SideBySide
 				await connection.OpenAsync();
 				var transaction = await connection.BeginTransactionAsync();
 
-				// verify that this amount of data can be sent to MySQL successfully
-				var maxAllowedPacket = (await connection.QueryAsync<int>("select @@max_allowed_packet").ConfigureAwait(false)).Single();
-				var shouldFail = maxAllowedPacket < size + 100;
-
 				var data = CreateByteArray(size);
+				var isSupported = size < 1048576 || AppConfig.SupportedFeatures.HasFlag(ServerFeatures.LargePackets);
 
 				long lastInsertId;
 				using (var cmd = new MySqlCommand(Invariant($"insert into datatypes_blobs(`{column}`) values(?)"), connection, transaction)
@@ -536,17 +533,17 @@ namespace SideBySide
 					{
 						await cmd.ExecuteNonQueryAsync().ConfigureAwait(false);
 						lastInsertId = cmd.LastInsertedId;
-						Assert.False(shouldFail);
+						Assert.True(isSupported);
 					}
 					catch (MySqlException ex)
 					{
 						lastInsertId = -1;
-						Assert.True(shouldFail);
-						Assert.Contains("packet", ex.Message);
+						Assert.False(isSupported);
+						Assert.True(ex.Message.IndexOf("packet") >= 0 || ex.Message.IndexOf("innodb_log_file_size") >= 0);
 					}
 				}
 
-				if (!shouldFail)
+				if (isSupported)
 				{
 					var queryResult = (await connection.QueryAsync<byte[]>(Invariant($"select `{column}` from datatypes_blobs where rowid = {lastInsertId}")).ConfigureAwait(false)).Single();
 					TestUtilities.AssertEqual(data, queryResult);
@@ -569,11 +566,8 @@ namespace SideBySide
 				connection.Open();
 				var transaction = connection.BeginTransaction();
 
-				// verify that this amount of data can be sent to MySQL successfully
-				var maxAllowedPacket = m_database.Connection.Query<int>("select @@max_allowed_packet").Single();
-				var shouldFail = maxAllowedPacket < size + 100;
-
 				var data = CreateByteArray(size);
+				var isSupported = size < 1048576 || AppConfig.SupportedFeatures.HasFlag(ServerFeatures.LargePackets);
 
 				long lastInsertId;
 				using (var cmd = new MySqlCommand(Invariant($"insert into datatypes_blobs(`{column}`) values(?)"), connection, transaction)
@@ -585,16 +579,17 @@ namespace SideBySide
 					{
 						cmd.ExecuteNonQuery();
 						lastInsertId = cmd.LastInsertedId;
+						Assert.True(isSupported);
 					}
 					catch (MySqlException ex)
 					{
 						lastInsertId = -1;
-						Assert.True(shouldFail);
-						Assert.Contains("packet", ex.Message);
+						Assert.False(isSupported);
+						Assert.True(ex.Message.IndexOf("packet") >= 0 || ex.Message.IndexOf("innodb_log_file_size") >= 0);
 					}
 				}
 
-				if (!shouldFail)
+				if (isSupported)
 				{
 					var queryResult = connection.Query<byte[]>(Invariant($"select `{column}` from datatypes_blobs where rowid = {lastInsertId}")).Single();
 					TestUtilities.AssertEqual(data, queryResult);

--- a/tests/SideBySide/ServerFeatures.cs
+++ b/tests/SideBySide/ServerFeatures.cs
@@ -10,5 +10,6 @@ namespace SideBySide
 		StoredProcedures = 2,
 		Sha256Password = 4,
 		OpenSsl = 8,
+		LargePackets = 16,
 	}
 }


### PR DESCRIPTION
Anecdotally, MySQL Server 5.6 still seems fairly popular, so we should routinely test against it to catch compatibility issues.

This adds `ServerFeatures.LargePackets` to control whether large BLOBs should be sent to the server. Although `max_allowed_packet` can be increased for MySQL Server 5.6, inserting a large BLOB will still fail with the message:

> The size of BLOB/TEXT data inserted in one transaction is greater than 10% of redo log size. Increase the redo log size using innodb_log_file_size.

Rather than customizing this option for MySQL Server 5.6, I've simply feature-flagged the affected tests. (They do pass locally with a correctly-configured `mysql:5.6` Docker container.)