### PR TITLE
Fix "Aborted connection" error when connection leaks.

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -311,7 +311,7 @@ namespace MySql.Data.MySqlClient
 					{
 						var pool = ConnectionPool.GetPool(m_connectionSettings);
 						// this returns an open session
-						return await pool.GetSessionAsync(ioBehavior, linkedSource.Token).ConfigureAwait(false);
+						return await pool.GetSessionAsync(this, ioBehavior, linkedSource.Token).ConfigureAwait(false);
 					}
 					else
 					{

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -41,6 +41,7 @@ namespace MySql.Data.Serialization
 		public DateTime LastReturnedUtc { get; private set; }
 		public string DatabaseOverride { get; set; }
 		public IPAddress IPAddress => (m_tcpClient?.Client.RemoteEndPoint as IPEndPoint)?.Address;
+		public WeakReference<MySqlConnection> OwningConnection { get; set; }
 
 		public void ReturnToPool()
 		{


### PR DESCRIPTION
This fixes most of the errors logged during a test run noted in #290.

It accomplishes this by making `MySqlSession` have a `WeakReference<MySqlConnection>` to its owning connection, so we can return the session to the pool after the connection has been GCed. Reap and ClearPool both now recover sessions before cleaning.

There still appears to be one final "Aborted connection ... (Got an error reading communication packets)" logged when running `SideBySide.ConnectionPool` tests, but not when running `SideBySide.ConnectionPool.LeakConnections` by itself, even though I suspect (from mapping IP source ports back to originating call stacks) that the problem originates in the `LeakConnections` test.