### PR TITLE
GetCodeRootPath breaks things

### DIFF
--- a/.ci/config/config.buffer.json
+++ b/.ci/config/config.buffer.json
@@ -4,6 +4,8 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+      "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -9,6 +9,6 @@
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV",
 
-      "CertificatesPath": "..\\..\\..\\..\\..\\.ci\\server\\certs"
+      "CertificatesPath": "../../../../../.ci/server/certs"
     }
 }

--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -4,7 +4,11 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+      "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
-      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
+      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV",
+	  
+	  "CertificatesPath": "..\\..\\..\\..\\..\\.ci\\server\\certs"
     }
 }

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -4,6 +4,8 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+      "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -4,6 +4,8 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+      "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -9,6 +9,6 @@
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV",
 
-      "CertificatesPath": "..\\..\\..\\..\\..\\.ci\\server\\certs"
+      "CertificatesPath": "../../../../../.ci/server/certs"
     }
 }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -4,7 +4,11 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+      "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
-      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
+      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV",
+	  
+	  "CertificatesPath": "..\\..\\..\\..\\..\\.ci\\server\\certs"
     }
 }

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -7,6 +7,8 @@
 
       "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
-      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
+      "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV",
+
+      "CertificatesPath": "../../../../../.ci/server/certs"
     }
 }

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -4,6 +4,8 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+	  "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.uds.json
+++ b/.ci/config/config.uds.json
@@ -4,6 +4,8 @@
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
       "SupportedFeatures": "Json,StoredProcedures,Sha256Password,LargePackets",
+	  
+	  "TestData": "../../../../TestData",
       "MySqlBulkLoaderLocalCsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "%TESTDATA%/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/run-tests.bat
+++ b/.ci/run-tests.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Executing tests with No Compression, No SSL && copy /y tests\SideBySide\config.json.example tests\SideBySide\config.json && dotnet test tests/SideBySide --configuration Release
-echo Executing tests with Compression, No SSL && copy /y .ci\config\config.compression.json tests\SideBySide\config.json && dotnet test tests/SideBySide --configuration Release
-echo Executing tests with No Compression, SSL && copy /y .ci\config\config.ssl.json tests\SideBySide\config.json && dotnet test tests/SideBySide --configuration Release
-echo Executing tests with Compression, SSL && copy /y ".ci\config\config.compression+ssl.json" tests\SideBySide\config.json && dotnet test tests/SideBySide --configuration Release
+echo Executing tests with No Compression, No SSL && copy /y .ci\config\config.json tests\SideBySide\config.json && dotnet test tests/SideBySide/SideBySide.csproj --configuration Release
+echo Executing tests with Compression, No SSL && copy /y .ci\config\config.compression.json tests\SideBySide\config.json && dotnet test tests/SideBySide/SideBySide.csproj --configuration Release
+echo Executing tests with No Compression, SSL && copy /y .ci\config\config.ssl.json tests\SideBySide\config.json && dotnet test tests/SideBySide/SideBySide.csproj --configuration Release
+echo Executing tests with Compression, SSL && copy /y ".ci\config\config.compression+ssl.json" tests\SideBySide\config.json && dotnet test tests/SideBySide/SideBySide.csproj --configuration Release

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -19,18 +19,14 @@ namespace SideBySide
 				["Data:SupportsJson"] = "false",
 			};
 
-		private static string CodeRootPath = GetCodeRootPath();
+		public static string CertsPath => Config.GetValue<string>("Data:CertificatesPath");
 
-		public static string BasePath = Path.Combine(CodeRootPath, "tests", "SideBySide");
-
-		public static string CertsPath = Path.Combine(CodeRootPath, ".ci", "server", "certs");
-
-		public static string TestDataPath = Path.Combine(CodeRootPath, "tests", "TestData");
+		public static string TestDataPath => Config.GetValue<string>("Data:TestData");
+		public static string RemoteTestDataPath => Config.GetValue<string>("Data:RemoteTestData");
 
 		private static int _configFirst;
 
 		private static IConfiguration ConfigBuilder { get; } = new ConfigurationBuilder()
-			.SetBasePath(BasePath)
 			.AddInMemoryCollection(DefaultConfig)
 			.AddJsonFile("config.json")
 			.Build();
@@ -55,10 +51,10 @@ namespace SideBySide
 
 		public static bool SupportsJson => SupportedFeatures.HasFlag(ServerFeatures.Json);
 
-		public static string MySqlBulkLoaderCsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderCsvFile"));
-		public static string MySqlBulkLoaderLocalCsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalCsvFile"));
-		public static string MySqlBulkLoaderTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderTsvFile"));
-		public static string MySqlBulkLoaderLocalTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalTsvFile"));
+		public static string MySqlBulkLoaderCsvFile => ExpandRemoteVariables(Config.GetValue<string>("Data:MySqlBulkLoaderCsvFile"));
+		public static string MySqlBulkLoaderLocalCsvFile => ExpandLocalVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalCsvFile"));
+		public static string MySqlBulkLoaderTsvFile => ExpandRemoteVariables(Config.GetValue<string>("Data:MySqlBulkLoaderTsvFile"));
+		public static string MySqlBulkLoaderLocalTsvFile => ExpandLocalVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalTsvFile"));
 
 		public static MySqlConnectionStringBuilder CreateConnectionStringBuilder() => new MySqlConnectionStringBuilder(ConnectionString);
 
@@ -74,19 +70,8 @@ namespace SideBySide
 		// tests can run much slower in CI environments
 		public static int TimeoutDelayFactor { get; } = (Environment.GetEnvironmentVariable("APPVEYOR") == "True" || Environment.GetEnvironmentVariable("TRAVIS") == "true") ? 6 : 1;
 
-		private static string GetCodeRootPath()
-		{
-#if NET46
-			var currentAssembly = Assembly.GetExecutingAssembly();
-#else
-			var currentAssembly = typeof(AppConfig).GetTypeInfo().Assembly;
-#endif
-			var directory = new Uri(currentAssembly.CodeBase).LocalPath;
-			while (!string.Equals(Path.GetFileName(directory), "MySqlConnector", StringComparison.OrdinalIgnoreCase))
-				directory = Path.GetDirectoryName(directory);
-			return directory;
-		}
-
-		private static string ExpandVariables(string value) => value?.Replace("%TESTDATA%", TestDataPath);
+		private static string ExpandVariables(string value, string replacement) => value?.Replace("%TESTDATA%", replacement);
+		private static string ExpandLocalVariables(string value) => ExpandVariables(value, TestDataPath);
+		private static string ExpandRemoteVariables(string value) => ExpandVariables(value, RemoteTestDataPath);
 	}
 }

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -19,13 +19,10 @@ namespace SideBySide
 				["Data:SupportsJson"] = "false",
 			};
 
-		public static string CertsPath => Config.GetValue<string>("Data:CertificatesPath")
-			// normalize path to whatever the system prefers
-			.Replace('\\', Path.DirectorySeparatorChar)
-			.Replace('/', Path.DirectorySeparatorChar);
+		public static string CertsPath => Path.GetFullPath(Config.GetValue<string>("Data:CertificatesPath"));
 
-		public static string TestDataPath => Config.GetValue<string>("Data:TestData");
-		public static string RemoteTestDataPath => Config.GetValue<string>("Data:RemoteTestData");
+		public static string TestDataPath => Path.GetFullPath(Config.GetValue<string>("Data:TestData"));
+		public static string RemoteTestDataPath => Path.GetFullPath(Config.GetValue<string>("Data:RemoteTestData"));
 
 		private static int _configFirst;
 

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -19,7 +19,10 @@ namespace SideBySide
 				["Data:SupportsJson"] = "false",
 			};
 
-		public static string CertsPath => Config.GetValue<string>("Data:CertificatesPath");
+		public static string CertsPath => Config.GetValue<string>("Data:CertificatesPath")
+			// normalize path to whatever the system prefers
+			.Replace('\\', Path.DirectorySeparatorChar)
+			.Replace('/', Path.DirectorySeparatorChar);
 
 		public static string TestDataPath => Config.GetValue<string>("Data:TestData");
 		public static string RemoteTestDataPath => Config.GetValue<string>("Data:RemoteTestData");

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -54,10 +54,10 @@ namespace SideBySide
 
 		public static bool SupportsJson => SupportedFeatures.HasFlag(ServerFeatures.Json);
 
-		public static string MySqlBulkLoaderCsvFile => ExpandRemoteVariables(Config.GetValue<string>("Data:MySqlBulkLoaderCsvFile"));
-		public static string MySqlBulkLoaderLocalCsvFile => ExpandLocalVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalCsvFile"));
-		public static string MySqlBulkLoaderTsvFile => ExpandRemoteVariables(Config.GetValue<string>("Data:MySqlBulkLoaderTsvFile"));
-		public static string MySqlBulkLoaderLocalTsvFile => ExpandLocalVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalTsvFile"));
+		public static string MySqlBulkLoaderCsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderCsvFile"));
+		public static string MySqlBulkLoaderLocalCsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalCsvFile"));
+		public static string MySqlBulkLoaderTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderTsvFile"));
+		public static string MySqlBulkLoaderLocalTsvFile => ExpandVariables(Config.GetValue<string>("Data:MySqlBulkLoaderLocalTsvFile"));
 
 		public static MySqlConnectionStringBuilder CreateConnectionStringBuilder() => new MySqlConnectionStringBuilder(ConnectionString);
 
@@ -73,8 +73,6 @@ namespace SideBySide
 		// tests can run much slower in CI environments
 		public static int TimeoutDelayFactor { get; } = (Environment.GetEnvironmentVariable("APPVEYOR") == "True" || Environment.GetEnvironmentVariable("TRAVIS") == "true") ? 6 : 1;
 
-		private static string ExpandVariables(string value, string replacement) => value?.Replace("%TESTDATA%", replacement);
-		private static string ExpandLocalVariables(string value) => ExpandVariables(value, TestDataPath);
-		private static string ExpandRemoteVariables(string value) => ExpandVariables(value, RemoteTestDataPath);
+		private static string ExpandVariables(string value) => value?.Replace("%TESTDATA%", TestDataPath).Replace("%REMOTETESTDATA%", RemoteTestDataPath);
 	}
 }

--- a/tests/SideBySide/SideBySide.csproj
+++ b/tests/SideBySide/SideBySide.csproj
@@ -51,4 +51,10 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/SideBySide/config.json.example
+++ b/tests/SideBySide/config.json.example
@@ -1,8 +1,13 @@
-{
+﻿{
     "Data": {
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;Use Affected Rows=true",
       "PasswordlessUser": "no_password",
       "SupportsCachedProcedures": true,
-      "SupportsJson": true
+      "SupportsJson": true,
+
+      "CertificatesPath": "C:\\work\\MySqlConnector\\.ci\\server\\certs",
+
+      "TestData": "C:/work/MySqlConnector/tests/TestData",
+      "RemoteTestData": "/var/lib/mysql-files"
     }
 }

--- a/tests/SideBySide/config.json.example
+++ b/tests/SideBySide/config.json.example
@@ -5,7 +5,7 @@
       "SupportsCachedProcedures": true,
       "SupportsJson": true,
 
-      "CertificatesPath": "C:\\work\\MySqlConnector\\.ci\\server\\certs",
+      "CertificatesPath": "C:/work/MySqlConnector/.ci/server/certs",
 
       "TestData": "C:/work/MySqlConnector/tests/TestData",
       "RemoteTestData": "/var/lib/mysql-files"


### PR DESCRIPTION
There is a bit of a code smell in AppConfig's startup logic to find the "RootPath" of the executing assembly. Even more problematic is that it is hardcoded to look for the solution dir "MySqlConnector". If someone renames their top level checkout it creates a wonderful infinite loop in testing (took me awhile to notice this was why).

CodeRootPath is used in only three places: to create the path for certificate files, to create the path for test data files, and to set the location of config.json relative to the SideBySide directory. The first two can easily just be pulled from new properties in config.json. And the third, calling SetBasePath on ConfigurationBuilder, is totally un-necessary. We just need to make sure config.json is copied to output directory.

I added the new properties to the config files in ".ci/config" to point to the correct paths on checkout, so all the tests still work as is.

One minor addition I made to differeniate the "server" and "local" bulk file insertion paths, was to use a different property to "expand" the paths %TESTDATA% variable. Note the "server" bulk file insertion isn't even used in the config files, only "local" files. The two properties are "TestData" and "RemoteTestData", fairly obvious. Confirmed that the "server" bulk file insertions still work as well.