### PR TITLE
Send client connection attributes. Fixes #293

### DIFF
--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -20,15 +20,7 @@
     <RepositoryUrl>https://github.com/mysql-net/MySqlConnector.git</RepositoryUrl>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="System.Buffers" Version="4.0.0" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.0.0" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Transactions" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="System.Buffers" Version="4.0.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.0.0" />
@@ -39,6 +31,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Buffers" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />

--- a/src/MySqlConnector/Serialization/ChangeUserPayload.cs
+++ b/src/MySqlConnector/Serialization/ChangeUserPayload.cs
@@ -4,7 +4,7 @@ namespace MySql.Data.Serialization
 {
 	internal class ChangeUserPayload
 	{
-		public static PayloadData Create(string user, byte[] authResponse, string schemaName)
+		public static PayloadData Create(string user, byte[] authResponse, string schemaName, byte[] connectionAttributes)
 		{
 			var writer = new PayloadWriter();
 
@@ -16,6 +16,8 @@ namespace MySql.Data.Serialization
 			writer.WriteByte((byte) CharacterSet.Utf8Mb4Binary);
 			writer.WriteByte(0);
 			writer.WriteNullTerminatedString("mysql_native_password");
+			if (connectionAttributes != null)
+				writer.Write(connectionAttributes);
 
 			return new PayloadData(new ArraySegment<byte>(writer.ToBytes()));
 		}

--- a/src/MySqlConnector/Serialization/PayloadWriter.cs
+++ b/src/MySqlConnector/Serialization/PayloadWriter.cs
@@ -43,6 +43,13 @@ namespace MySql.Data.Serialization
 			}
 		}
 
+		public void WriteLengthEncodedString(string value)
+		{
+			var bytes = Encoding.UTF8.GetBytes(value);
+			WriteLengthEncodedInteger((ulong) bytes.Length);
+			m_writer.Write(bytes);
+		}
+
 		public void WriteNullTerminatedString(string value)
 		{
 			var bytes = Encoding.UTF8.GetBytes(value);

--- a/src/MySqlConnector/Serialization/ProtocolCapabilities.cs
+++ b/src/MySqlConnector/Serialization/ProtocolCapabilities.cs
@@ -105,7 +105,7 @@ namespace MySql.Data.Serialization
 		/// <summary>
 		/// Permits connection attributes in Protocol::HandshakeResponse41.
 		/// </summary>
-		ConnectAttributes = 0x10_0000,
+		ConnectionAttributes = 0x10_0000,
 
 		/// <summary>
 		/// Understands length-encoded integer for auth response data in Protocol::HandshakeResponse41.


### PR DESCRIPTION
We need not do the workaround with username. I think in this week we can fix the COM_CHANGE_USER 
 username handling issue. So just send the attributes to Azure will work soon.