### PR TITLE
Fix hang when disposing a reader. Fixes #299

### DIFF
--- a/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
+++ b/src/MySqlConnector/MySqlClient/CommandExecutors/StoredProcedureCommandExecutor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Threading;
@@ -76,10 +77,17 @@ namespace MySql.Data.MySqlClient.CommandExecutors
 			}
 
 			var reader = (MySqlDataReader) await base.ExecuteReaderAsync(commandText, inParams, behavior, ioBehavior, cancellationToken).ConfigureAwait(false);
-			if (returnParam != null && await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
-				returnParam.Value = reader.GetValue(0);
-
-			return reader;
+			try
+			{
+				if (returnParam != null && await reader.ReadAsync(ioBehavior, cancellationToken).ConfigureAwait(false))
+					returnParam.Value = reader.GetValue(0);
+				return reader;
+			}
+			catch (Exception)
+			{
+				reader.Dispose();
+				throw;
+			}
 		}
 
 		internal void SetParams()

--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -172,16 +172,19 @@ namespace MySql.Data.MySqlClient.Results
 
 			async Task<Row> ScanRowAsyncAwaited(Task<PayloadData> payloadTask, CancellationToken token)
 			{
+				PayloadData payloadData;
 				try
 				{
-					return ScanRowAsyncRemainder(await payloadTask.ConfigureAwait(false));
+					payloadData = await payloadTask.ConfigureAwait(false);
 				}
-				catch (MySqlException ex) when (ex.Number == (int) MySqlErrorCode.QueryInterrupted)
+				catch (MySqlException ex)
 				{
 					BufferState = State = ResultSetState.NoMoreData;
-					token.ThrowIfCancellationRequested();
+					if (ex.Number == (int) MySqlErrorCode.QueryInterrupted)
+						token.ThrowIfCancellationRequested();
 					throw;
 				}
+				return ScanRowAsyncRemainder(payloadData);
 			}
 
 			Row ScanRowAsyncRemainder(PayloadData payload)

--- a/tests/SideBySide/StoredProcedureFixture.cs
+++ b/tests/SideBySide/StoredProcedureFixture.cs
@@ -14,6 +14,14 @@ namespace SideBySide
 				BEGIN
 					RETURN name;
 				END");
+			Connection.Execute(@"DROP FUNCTION IF EXISTS failing_function;
+				CREATE FUNCTION failing_function()
+				RETURNS INT
+				BEGIN
+					DECLARE v1 INT;
+					SELECT c1 FROM table_that_does_not_exist INTO v1;
+					RETURN v1;
+				END");
 			Connection.Execute(@"DROP PROCEDURE IF EXISTS echop;
 				CREATE PROCEDURE echop(
 					IN name VARCHAR(63)


### PR DESCRIPTION
Update the internal state to `NoMoreData` if an exception is thrown reading a payload. This prevents a hang when disposing `MySqlDataReader`/`MySqlConnection` if an error payload was sent and no more data is coming.