### PR TITLE
Support the CLIENT_DEPRECATE_EOF flag

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -71,7 +71,14 @@ namespace MySql.Data.MySqlClient
 		{
 			if (resultSet.ReadResultSetHeaderException != null)
 			{
-				throw resultSet.ReadResultSetHeaderException is MySqlException mySqlException ?
+				var mySqlException = resultSet.ReadResultSetHeaderException as MySqlException;
+
+				// for any exception not created from an ErrorPayload, mark the session as failed (because we can't guarantee that all data
+				// has been read from the connection and that the socket is still usable)
+				if (mySqlException?.SqlState == null)
+					Command.Connection.Session.SetFailed();
+
+				throw mySqlException != null ?
 					new MySqlException(mySqlException.Number, mySqlException.SqlState, mySqlException.Message, mySqlException) :
 					resultSet.ReadResultSetHeaderException;
 			}

--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -79,6 +79,9 @@ namespace MySql.Data.MySqlClient.Results
 					{
 						var reader = new ByteArrayReader(payload.ArraySegment);
 						var columnCount = (int) reader.ReadLengthEncodedInteger();
+						if (reader.BytesRemaining != 0)
+							throw new MySqlException("Unexpected data at end of column_count packet; see https://github.com/mysql-net/MySqlConnector/issues/324");
+
 						ColumnDefinitions = new ColumnDefinitionPayload[columnCount];
 						m_dataOffsets = new int[columnCount];
 						m_dataLengths = new int[columnCount];

--- a/src/MySqlConnector/Serialization/EofPayload.cs
+++ b/src/MySqlConnector/Serialization/EofPayload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace MySql.Data.Serialization
 {
@@ -32,7 +32,7 @@ namespace MySql.Data.Serialization
 		public static bool IsEof(PayloadData payload) =>
 			payload.ArraySegment.Count > 0 && payload.ArraySegment.Count < 9 && payload.ArraySegment.Array[payload.ArraySegment.Offset] == Signature;
 
-		private const byte Signature = 0xFE;
+		public const byte Signature = 0xFE;
 
 		private EofPayload(int warningCount, ServerStatus status)
 		{

--- a/src/MySqlConnector/Serialization/HandshakeResponse41Packet.cs
+++ b/src/MySqlConnector/Serialization/HandshakeResponse41Packet.cs
@@ -1,4 +1,4 @@
-﻿namespace MySql.Data.Serialization
+namespace MySql.Data.Serialization
 {
 	internal sealed class HandshakeResponse41Packet
 	{
@@ -20,6 +20,7 @@
 				(cs.UseAffectedRows ? 0 : ProtocolCapabilities.FoundRows) |
 				(useCompression ? ProtocolCapabilities.Compress : ProtocolCapabilities.None) |
 				(serverCapabilities & ProtocolCapabilities.ConnectionAttributes) |
+				(serverCapabilities & ProtocolCapabilities.DeprecateEof) |
 				additionalCapabilities));
 			writer.WriteInt32(0x4000_0000);
 			writer.WriteByte((byte) CharacterSet.Utf8Mb4Binary);

--- a/src/MySqlConnector/Serialization/HandshakeResponse41Packet.cs
+++ b/src/MySqlConnector/Serialization/HandshakeResponse41Packet.cs
@@ -14,7 +14,6 @@ namespace MySql.Data.Serialization
 				(serverCapabilities & ProtocolCapabilities.PluginAuthLengthEncodedClientData) |
 				ProtocolCapabilities.MultiStatements |
 				ProtocolCapabilities.MultiResults |
-				ProtocolCapabilities.PreparedStatementMultiResults |
 				ProtocolCapabilities.LocalFiles |
 				(string.IsNullOrWhiteSpace(cs.Database) ? 0 : ProtocolCapabilities.ConnectWithDatabase) |
 				(cs.UseAffectedRows ? 0 : ProtocolCapabilities.FoundRows) |

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -46,6 +46,7 @@ namespace MySql.Data.Serialization
 		public string DatabaseOverride { get; set; }
 		public IPAddress IPAddress => (m_tcpClient?.Client.RemoteEndPoint as IPEndPoint)?.Address;
 		public WeakReference<MySqlConnection> OwningConnection { get; set; }
+		public bool SupportsDeprecateEof => m_supportsDeprecateEof;
 
 		public void ReturnToPool()
 		{
@@ -235,6 +236,8 @@ namespace MySql.Data.Serialization
 			m_supportsConnectionAttributes = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.ConnectionAttributes) != 0;
 			if (m_supportsConnectionAttributes && s_connectionAttributes == null)
 				s_connectionAttributes = CreateConnectionAttributes();
+
+			m_supportsDeprecateEof = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.DeprecateEof) != 0;
 
 			var response = HandshakeResponse41Packet.Create(initialHandshake, cs, m_useCompression, m_supportsConnectionAttributes ? s_connectionAttributes : null);
 			payload = new PayloadData(new ArraySegment<byte>(response));
@@ -896,5 +899,6 @@ namespace MySql.Data.Serialization
 		bool m_useCompression;
 		bool m_isSecureConnection;
 		bool m_supportsConnectionAttributes;
+		bool m_supportsDeprecateEof;
 	}
 }

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -142,8 +142,10 @@ namespace MySql.Data.Serialization
 
 			lock (m_lock)
 			{
-				VerifyState(State.Querying, State.ClearingPendingCancellation);
-				m_state = State.Connected;
+				if (m_state == State.Querying || m_state == State.ClearingPendingCancellation)
+					m_state = State.Connected;
+				else
+					VerifyState(State.Failed);
 				m_activeCommandId = 0;
 			}
 		}
@@ -788,7 +790,7 @@ namespace MySql.Data.Serialization
 			return payload;
 		}
 
-		private void SetFailed()
+		internal void SetFailed()
 		{
 			lock (m_lock)
 				m_state = State.Failed;

--- a/src/MySqlConnector/Serialization/OkPayload.cs
+++ b/src/MySqlConnector/Serialization/OkPayload.cs
@@ -1,4 +1,6 @@
-﻿namespace MySql.Data.Serialization
+using System;
+
+namespace MySql.Data.Serialization
 {
 	internal sealed class OkPayload
 	{
@@ -9,10 +11,24 @@
 
 		public const byte Signature = 0x00;
 
-		public static OkPayload Create(PayloadData payload)
+		/* See
+		 * http://web.archive.org/web/20160604101747/http://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
+		 * https://mariadb.com/kb/en/the-mariadb-library/resultset/
+		 * https://github.com/MariaDB/mariadb-connector-j/blob/5fa814ac6e1b4c9cb6d141bd221cbd5fc45c8a78/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java#L443-L444
+		 */
+		public static bool IsOk(PayloadData payload, bool deprecateEof) =>
+			payload.ArraySegment.Array != null && payload.ArraySegment.Count > 0 &&
+				((payload.ArraySegment.Count > 6 && payload.ArraySegment.Array[payload.ArraySegment.Offset] == Signature) ||
+				(deprecateEof && payload.ArraySegment.Count < 0xFF_FFFF && payload.ArraySegment.Array[payload.ArraySegment.Offset] == EofPayload.Signature));
+
+		public static OkPayload Create(PayloadData payload) => Create(payload, false);
+
+		public static OkPayload Create(PayloadData payload, bool deprecateEof)
 		{
 			var reader = new ByteArrayReader(payload.ArraySegment);
-			reader.ReadByte(Signature);
+			var signature = reader.ReadByte();
+			if (signature != Signature && (!deprecateEof || signature != EofPayload.Signature))
+				throw new FormatException("Expected to read 0x00 or 0xFE but got 0x{0:X2}".FormatInvariant(signature));
 			var affectedRowCount = checked((int) reader.ReadLengthEncodedInteger());
 			var lastInsertId = checked((long) reader.ReadLengthEncodedInteger());
 			var serverStatus = (ServerStatus) reader.ReadUInt16();


### PR DESCRIPTION
Fixes #322.

Will test as a possible workaround for #267. Even if it doesn't fix that issue, it will be slightly more efficient as it transmits fractionally fewer bytes over the wire when processing a result set.