### PR TITLE
Remove waiting for OK response after QUIT command

### DIFF
--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -170,7 +170,6 @@ namespace MySql.Data.Serialization
 					{
 						m_payloadHandler.StartNewConversation();
 						await m_payloadHandler.WritePayloadAsync(QuitPayload.Create(), ioBehavior).ConfigureAwait(false);
-						await m_payloadHandler.ReadPayloadAsync(m_payloadCache, ProtocolErrorBehavior.Ignore, ioBehavior).ConfigureAwait(false);
 					}
 					catch (IOException)
 					{


### PR DESCRIPTION
MySQL Server 5.7 does not send OK payload after QUIT command, but
simply closes the TCP connection, so this wait is unnecessary. Also
fixes #330, in which case there was an infinite waiting.