### PR TITLE
Reduce allocations

### DIFF
--- a/src/MySqlConnector/Protocol/Serialization/Packet.cs
+++ b/src/MySqlConnector/Protocol/Serialization/Packet.cs
@@ -1,16 +1,14 @@
-﻿using System;
+using System;
 
 namespace MySql.Data.Protocol.Serialization
 {
-	internal class Packet
+	internal struct Packet
 	{
-		public Packet(int sequenceNumber, ArraySegment<byte> contents)
+		public Packet(ArraySegment<byte> contents)
 		{
-			SequenceNumber = sequenceNumber;
 			Contents = contents;
 		}
 
-		public int SequenceNumber { get; }
 		public ArraySegment<byte> Contents { get; }
 	}
 }

--- a/tests/Benchmark/Benchmark.csproj
+++ b/tests/Benchmark/Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;net462;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net47;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.8" />

--- a/tests/Benchmark/Program.cs
+++ b/tests/Benchmark/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -24,7 +24,7 @@ namespace Benchmark
 				.With(JitOptimizationsValidator.FailOnError)
 				.With(MemoryDiagnoser.Default)
 				.With(StatisticColumn.AllStatistics)
-				.With(Job.Default.With(Runtime.Clr).With(Jit.RyuJit).With(Platform.X64).With(CsProjClassicNetToolchain.Net462).WithId("net462"))
+				.With(Job.Default.With(Runtime.Clr).With(Jit.RyuJit).With(Platform.X64).With(CsProjClassicNetToolchain.Net47).WithId("net47"))
 				.With(Job.Default.With(Runtime.Core).With(CsProjCoreToolchain.NetCoreApp11).WithId("netcore11"))
 				.With(Job.Default.With(Runtime.Core).With(CsProjCoreToolchain.NetCoreApp20).WithId("netcore20"))
 				.With(DefaultExporters.Csv);


### PR DESCRIPTION
* Fix unnecessary allocations from capturing a parameter in a local function
* Change `Packet` (which is allocated a lot) to a `struct`

`ManyRowsAsync` "Allocated" went from 713.54 KB to 408.76 KB to 27.1 KB.

`ManyRowsSync` "Allocated" went from 686.26 KB to 383 KB to 3.69 KB.

## Before

Method | Job | Runtime | Toolchain | Mean | Error | StdDev | StdErr | Median | Min | Q1 | Q3 | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated | 
--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | 
OpenFromPoolAsync | net47 | Clr | CsProjnet47 | 210.07 us | 0.8249 us | 0.7716 us | 0.1992 us | 209.91 us | 209.17 us | 209.52 us | 210.57 us | 212.02 us | 4,760.2 | 1.4648 | - | - | 9.49 KB | 
OpenFromPoolSync | net47 | Clr | CsProjnet47 | 84.98 us | 0.3289 us | 0.3076 us | 0.0794 us | 85.05 us | 84.57 us | 84.72 us | 85.25 us | 85.54 us | 11,767.7 | 0.1221 | - | - | 1.51 KB | 
ExecuteScalarAsync | net47 | Clr | CsProjnet47 | 118.55 us | 0.6200 us | 0.5799 us | 0.1497 us | 118.40 us | 117.43 us | 118.14 us | 119.06 us | 119.51 us | 8,435.5 | 0.9766 | - | - | 6.98 KB | 
ExecuteScalarSync | net47 | Clr | CsProjnet47 | 74.37 us | 0.3741 us | 0.3500 us | 0.0904 us | 74.37 us | 73.68 us | 74.17 us | 74.70 us | 75.03 us | 13,447.2 | 0.2441 | - | - | 2.16 KB | 
ReadBlobsAsync | net47 | Clr | CsProjnet47 | 2,023.07 us | 39.5726 us | 42.3422 us | 9.9802 us | 2,014.41 us | 1,952.26 us | 1,991.24 us | 2,058.08 us | 2,104.05 us | 494.3 | 332.0313 | 332.0313 | 332.0313 | 1106.23 KB | 
ReadBlobsSync | net47 | Clr | CsProjnet47 | 1,747.56 us | 8.4598 us | 7.4994 us | 2.0043 us | 1,748.70 us | 1,734.00 us | 1,741.74 us | 1,753.77 us | 1,758.97 us | 572.2 | 332.0313 | 332.0313 | 332.0313 | 1076.97 KB | 
ManyRowsAsync | net47 | Clr | CsProjnet47 | 5,611.45 us | 8.1218 us | 7.5971 us | 1.9616 us | 5,609.41 us | 5,602.03 us | 5,604.03 us | 5,618.21 us | 5,625.86 us | 178.2 | 109.3750 | - | - | 713.54 KB | 
ManyRowsSync | net47 | Clr | CsProjnet47 | 4,978.51 us | 15.7616 us | 13.1616 us | 3.6504 us | 4,977.06 us | 4,950.46 us | 4,971.68 us | 4,988.46 us | 5,004.70 us | 200.9 | 109.3750 | - | - | 686.26 KB | 
OpenFromPoolAsync | netcore11 | Core | CoreCsProj | 207.33 us | 0.4606 us | 0.4309 us | 0.1112 us | 207.31 us | 206.51 us | 207.06 us | 207.61 us | 208.18 us | 4,823.2 | 1.4648 | 0.2441 | - | 3.38 KB | 
OpenFromPoolSync | netcore11 | Core | CoreCsProj | 81.67 us | 0.9172 us | 0.8579 us | 0.2215 us | 81.54 us | 80.34 us | 81.17 us | 82.24 us | 83.19 us | 12,244.3 | 0.1221 | - | - | 1.46 KB | 
ExecuteScalarAsync | netcore11 | Core | CoreCsProj | 127.99 us | 1.8791 us | 1.5692 us | 0.4352 us | 127.82 us | 125.71 us | 126.85 us | 128.99 us | 131.35 us | 7,813.2 | 0.9766 | - | - | 2.75 KB | 
ExecuteScalarSync | netcore11 | Core | CoreCsProj | 74.32 us | 0.2107 us | 0.1645 us | 0.0475 us | 74.29 us | 74.03 us | 74.22 us | 74.41 us | 74.63 us | 13,455.5 | 0.2441 | - | - | 2.14 KB | 
ReadBlobsAsync | netcore11 | Core | CoreCsProj | 2,093.97 us | 40.7655 us | 68.1100 us | 11.3517 us | 2,061.22 us | 2,013.55 us | 2,047.90 us | 2,142.15 us | 2,273.70 us | 477.6 | 332.0313 | 332.0313 | 332.0313 | 2.54 KB | 
ReadBlobsSync | netcore11 | Core | CoreCsProj | 1,855.69 us | 32.3809 us | 30.2891 us | 7.8206 us | 1,853.67 us | 1,800.08 us | 1,837.43 us | 1,873.30 us | 1,911.89 us | 538.9 | 332.0313 | 332.0313 | 332.0313 | 1076.58 KB | 
ManyRowsAsync | netcore11 | Core | CoreCsProj | 4,953.25 us | 21.0057 us | 19.6487 us | 5.0733 us | 4,952.38 us | 4,924.09 us | 4,937.22 us | 4,968.39 us | 4,994.68 us | 201.9 | 109.3750 | - | - | 2.68 KB | 
ManyRowsSync | netcore11 | Core | CoreCsProj | 4,505.30 us | 27.3038 us | 22.7999 us | 6.3236 us | 4,510.58 us | 4,463.23 us | 4,487.24 us | 4,524.89 us | 4,534.91 us | 222.0 | 109.3750 | - | - | 686.28 KB | 
OpenFromPoolAsync | netcore20 | Core | CoreCsProj | 209.19 us | 1.0494 us | 0.9816 us | 0.2534 us | 209.13 us | 207.91 us | 208.28 us | 209.92 us | 210.86 us | 4,780.4 | 0.9766 | - | - | 3.73 KB | 
OpenFromPoolSync | netcore20 | Core | CoreCsProj | 77.68 us | 0.2110 us | 0.1973 us | 0.0510 us | 77.68 us | 77.32 us | 77.49 us | 77.85 us | 78.00 us | 12,872.6 | 0.1221 | - | - | 1.43 KB | 
ExecuteScalarAsync | netcore20 | Core | CoreCsProj | 116.79 us | 0.6208 us | 0.5184 us | 0.1438 us | 116.79 us | 115.85 us | 116.42 us | 117.15 us | 117.59 us | 8,562.6 | 0.8545 | - | - | 4.15 KB | 
ExecuteScalarSync | netcore20 | Core | CoreCsProj | 70.28 us | 0.2629 us | 0.2459 us | 0.0635 us | 70.29 us | 69.83 us | 70.07 us | 70.51 us | 70.62 us | 14,229.8 | 0.2441 | - | - | 2.09 KB | 
ReadBlobsAsync | netcore20 | Core | CoreCsProj | 1,952.39 us | 32.3741 us | 30.2828 us | 7.8190 us | 1,947.78 us | 1,910.68 us | 1,924.50 us | 1,983.53 us | 2,002.91 us | 512.2 | 332.0313 | 332.0313 | 332.0313 | 3.95 KB | 
ReadBlobsSync | netcore20 | Core | CoreCsProj | 1,687.79 us | 6.7180 us | 6.2840 us | 1.6225 us | 1,687.06 us | 1,679.05 us | 1,682.31 us | 1,691.28 us | 1,702.81 us | 592.5 | 332.0313 | 332.0313 | 332.0313 | 1076.54 KB | 
ManyRowsAsync | netcore20 | Core | CoreCsProj | 3,989.25 us | 16.5210 us | 15.4537 us | 3.9901 us | 3,986.90 us | 3,958.43 us | 3,979.03 us | 4,000.48 us | 4,023.98 us | 250.7 | 109.3750 | - | - | 4.02 KB | 
ManyRowsSync | netcore20 | Core | CoreCsProj | 3,968.76 us | 36.0417 us | 33.7134 us | 8.7048 us | 3,957.06 us | 3,926.56 us | 3,941.61 us | 3,995.85 us | 4,046.95 us | 252.0 | 109.3750 | - | - | 686.17 KB | 

## Improve ScanRowAsync

Method | Job | Runtime | Toolchain | Mean | Error | StdDev | StdErr | Min | Q1 | Median | Q3 | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
OpenFromPoolAsync | net47 | Clr | CsProjnet47 | 209.21 us | 1.5813 us | 1.4791 us | 0.3819 us | 207.71 us | 208.23 us | 208.55 us | 210.06 us | 212.23 us | 4,780.0 | 1.4648 | - | - | 9.49 KB |
OpenFromPoolSync | net47 | Clr | CsProjnet47 | 80.23 us | 0.8368 us | 0.7418 us | 0.1983 us | 79.49 us | 79.68 us | 80.07 us | 80.41 us | 82.03 us | 12,464.2 | 0.1221 | - | - | 1.51 KB |
ExecuteScalarAsync | net47 | Clr | CsProjnet47 | 118.43 us | 2.5297 us | 2.2425 us | 0.5993 us | 115.31 us | 117.29 us | 117.78 us | 119.09 us | 123.23 us | 8,443.7 | 0.9766 | - | - | 6.92 KB |
ExecuteScalarSync | net47 | Clr | CsProjnet47 | 73.04 us | 0.6351 us | 0.5630 us | 0.1505 us | 72.42 us | 72.58 us | 72.89 us | 73.49 us | 74.32 us | 13,692.0 | 0.2441 | - | - | 2.1 KB |
ReadBlobsAsync | net47 | Clr | CsProjnet47 | 1,968.97 us | 43.3765 us | 38.4521 us | 10.2768 us | 1,915.92 us | 1,940.61 us | 1,962.11 us | 1,984.53 us | 2,066.74 us | 507.9 | 332.0313 | 332.0313 | 332.0313 | 1107.29 KB |
ReadBlobsSync | net47 | Clr | CsProjnet47 | 1,635.46 us | 16.6506 us | 15.5750 us | 4.0214 us | 1,613.30 us | 1,626.31 us | 1,630.12 us | 1,645.70 us | 1,666.86 us | 611.4 | 332.0313 | 332.0313 | 332.0313 | 1076.97 KB |
ManyRowsAsync | net47 | Clr | CsProjnet47 | 5,652.74 us | 23.3417 us | 21.8338 us | 5.6375 us | 5,615.87 us | 5,638.10 us | 5,645.65 us | 5,666.48 us | 5,703.65 us | 176.9 | 62.5000 | - | - | 408.76 KB |
ManyRowsSync | net47 | Clr | CsProjnet47 | 5,066.26 us | 21.9346 us | 18.3164 us | 5.0801 us | 5,039.38 us | 5,049.86 us | 5,065.66 us | 5,081.69 us | 5,097.39 us | 197.4 | 54.6875 | - | - | 383 KB |
OpenFromPoolAsync | netcore11 | Core | CoreCsProj | 210.02 us | 0.5983 us | 0.5596 us | 0.1445 us | 208.98 us | 209.46 us | 210.09 us | 210.59 us | 210.73 us | 4,761.5 | 1.4648 | 0.2441 | - | 3.38 KB |
OpenFromPoolSync | netcore11 | Core | CoreCsProj | 78.84 us | 0.4382 us | 0.4099 us | 0.1058 us | 77.97 us | 78.57 us | 78.79 us | 79.10 us | 79.64 us | 12,684.3 | 0.1221 | - | - | 1.46 KB |
ExecuteScalarAsync | netcore11 | Core | CoreCsProj | 114.00 us | 0.9872 us | 0.9235 us | 0.2384 us | 112.02 us | 113.43 us | 113.87 us | 114.58 us | 115.44 us | 8,771.8 | 1.0986 | 0.1221 | - | 2.75 KB |
ExecuteScalarSync | netcore11 | Core | CoreCsProj | 70.68 us | 0.3011 us | 0.2514 us | 0.0697 us | 70.15 us | 70.61 us | 70.71 us | 70.90 us | 70.97 us | 14,149.0 | 0.2441 | - | - | 2.14 KB |
ReadBlobsAsync | netcore11 | Core | CoreCsProj | 1,914.54 us | 37.7078 us | 56.4393 us | 10.3044 us | 1,830.94 us | 1,868.88 us | 1,901.48 us | 1,953.25 us | 2,033.60 us | 522.3 | 332.0313 | 332.0313 | 332.0313 | 2.54 KB |
ReadBlobsSync | netcore11 | Core | CoreCsProj | 1,667.61 us | 17.4012 us | 15.4257 us | 4.1227 us | 1,646.84 us | 1,656.08 us | 1,666.53 us | 1,677.82 us | 1,704.51 us | 599.7 | 332.0313 | 332.0313 | 332.0313 | 1076.58 KB |
ManyRowsAsync | netcore11 | Core | CoreCsProj | 4,953.86 us | 29.8993 us | 24.9673 us | 6.9247 us | 4,922.99 us | 4,934.45 us | 4,951.41 us | 4,968.61 us | 5,016.29 us | 201.9 | 109.3750 | - | - | 2.68 KB |
ManyRowsSync | netcore11 | Core | CoreCsProj | 4,483.04 us | 18.1552 us | 16.0941 us | 4.3013 us | 4,457.42 us | 4,473.18 us | 4,482.65 us | 4,489.77 us | 4,510.57 us | 223.1 | 109.3750 | - | - | 686.28 KB |
OpenFromPoolAsync | netcore20 | Core | CoreCsProj | 206.11 us | 1.0527 us | 0.9847 us | 0.2542 us | 204.17 us | 205.52 us | 206.31 us | 207.03 us | 207.52 us | 4,851.7 | 0.9766 | - | - | 3.73 KB |
OpenFromPoolSync | netcore20 | Core | CoreCsProj | 77.51 us | 0.5762 us | 0.5107 us | 0.1365 us | 76.57 us | 77.29 us | 77.52 us | 77.78 us | 78.50 us | 12,901.0 | 0.1221 | - | - | 1.43 KB |
ExecuteScalarAsync | netcore20 | Core | CoreCsProj | 114.84 us | 1.1059 us | 0.9804 us | 0.2620 us | 113.47 us | 114.25 us | 114.58 us | 115.36 us | 117.24 us | 8,707.7 | 0.8545 | - | - | 4.15 KB |
ExecuteScalarSync | netcore20 | Core | CoreCsProj | 68.22 us | 0.4497 us | 0.4207 us | 0.1086 us | 67.60 us | 67.85 us | 68.18 us | 68.58 us | 68.99 us | 14,658.6 | 0.2441 | - | - | 2.09 KB |
ReadBlobsAsync | netcore20 | Core | CoreCsProj | 1,905.60 us | 37.6875 us | 56.4088 us | 10.2988 us | 1,834.48 us | 1,853.27 us | 1,893.05 us | 1,952.02 us | 2,043.83 us | 524.8 | 332.0313 | 332.0313 | 332.0313 | 3.95 KB |
ReadBlobsSync | netcore20 | Core | CoreCsProj | 1,667.80 us | 10.8643 us | 10.1625 us | 2.6239 us | 1,654.88 us | 1,659.44 us | 1,664.52 us | 1,677.03 us | 1,686.30 us | 599.6 | 332.0313 | 332.0313 | 332.0313 | 1076.54 KB |
ManyRowsAsync | netcore20 | Core | CoreCsProj | 3,997.42 us | 9.2742 us | 8.2214 us | 2.1973 us | 3,987.23 us | 3,989.78 us | 3,995.71 us | 4,003.54 us | 4,015.15 us | 250.2 | 109.3750 | - | - | 4.02 KB |
ManyRowsSync | netcore20 | Core | CoreCsProj | 3,902.60 us | 19.8277 us | 18.5469 us | 4.7888 us | 3,859.54 us | 3,886.15 us | 3,902.36 us | 3,919.66 us | 3,927.46 us | 256.2 | 109.3750 | - | - | 686.17 KB |

## Change Packet to struct

Method | Job | Runtime | Toolchain | Mean | Error | StdDev | StdErr | Min | Q1 | Median | Q3 | Max | Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated | 
--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | 
OpenFromPoolAsync | net47 | Clr | CsProjnet47 | 211.60 us | 4.0951 us | 4.7159 us | 1.0545 us | 207.00 us | 208.10 us | 209.40 us | 214.65 us | 223.14 us | 4,725.8 | 1.4648 | - | - | 9.45 KB | 
OpenFromPoolSync | net47 | Clr | CsProjnet47 | 82.63 us | 0.6823 us | 0.6382 us | 0.1648 us | 81.57 us | 82.07 us | 82.37 us | 83.25 us | 83.62 us | 12,101.8 | 0.1221 | - | - | 1.43 KB | 
ExecuteScalarAsync | net47 | Clr | CsProjnet47 | 115.00 us | 0.7494 us | 0.7010 us | 0.1810 us | 113.59 us | 114.62 us | 115.16 us | 115.51 us | 116.18 us | 8,695.5 | 0.9766 | - | - | 6.78 KB | 
ExecuteScalarSync | net47 | Clr | CsProjnet47 | 73.63 us | 0.3145 us | 0.2455 us | 0.0709 us | 73.20 us | 73.48 us | 73.63 us | 73.77 us | 74.13 us | 13,580.6 | 0.2441 | - | - | 1.95 KB | 
ReadBlobsAsync | net47 | Clr | CsProjnet47 | 1,925.17 us | 26.1112 us | 24.4244 us | 6.3064 us | 1,873.87 us | 1,912.80 us | 1,929.30 us | 1,940.93 us | 1,958.06 us | 519.4 | 332.0313 | 332.0313 | 332.0313 | 1106.87 KB | 
ReadBlobsSync | net47 | Clr | CsProjnet47 | 1,637.81 us | 9.5615 us | 8.9439 us | 2.3093 us | 1,617.87 us | 1,629.40 us | 1,639.91 us | 1,643.57 us | 1,650.72 us | 610.6 | 332.0313 | 332.0313 | 332.0313 | 1076.95 KB | 
ManyRowsAsync | net47 | Clr | CsProjnet47 | 5,636.77 us | 13.2515 us | 12.3955 us | 3.2005 us | 5,616.84 us | 5,627.19 us | 5,635.97 us | 5,647.82 us | 5,658.51 us | 177.4 | - | - | - | 27.1 KB | 
ManyRowsSync | net47 | Clr | CsProjnet47 | 5,048.46 us | 19.6131 us | 16.3778 us | 4.5424 us | 5,031.22 us | 5,037.51 us | 5,046.37 us | 5,054.58 us | 5,093.91 us | 198.1 | - | - | - | 3.69 KB | 
OpenFromPoolAsync | netcore11 | Core | CoreCsProj | 208.08 us | 1.8107 us | 1.6937 us | 0.4373 us | 205.50 us | 206.62 us | 208.13 us | 209.84 us | 210.47 us | 4,805.8 | 1.4648 | 0.2441 | - | 3.38 KB | 
OpenFromPoolSync | netcore11 | Core | CoreCsProj | 82.01 us | 0.4521 us | 0.4008 us | 0.1071 us | 81.24 us | 81.75 us | 82.09 us | 82.32 us | 82.67 us | 12,192.9 | 0.1221 | - | - | 1.46 KB | 
ExecuteScalarAsync | netcore11 | Core | CoreCsProj | 111.69 us | 0.8078 us | 0.6746 us | 0.1871 us | 110.66 us | 111.22 us | 111.74 us | 112.13 us | 113.12 us | 8,953.4 | 1.0986 | 0.1221 | - | 2.75 KB | 
ExecuteScalarSync | netcore11 | Core | CoreCsProj | 70.79 us | 0.2346 us | 0.2194 us | 0.0567 us | 70.54 us | 70.59 us | 70.79 us | 70.88 us | 71.31 us | 14,126.5 | 0.2441 | - | - | 2.14 KB | 
ReadBlobsAsync | netcore11 | Core | CoreCsProj | 1,882.76 us | 27.1644 us | 25.4096 us | 6.5607 us | 1,831.84 us | 1,865.34 us | 1,879.16 us | 1,895.32 us | 1,937.65 us | 531.1 | 332.0313 | 332.0313 | 332.0313 | 2.54 KB | 
ReadBlobsSync | netcore11 | Core | CoreCsProj | 1,626.09 us | 31.1401 us | 29.1285 us | 7.5209 us | 1,593.03 us | 1,607.29 us | 1,613.23 us | 1,646.84 us | 1,700.93 us | 615.0 | 332.0313 | 332.0313 | 332.0313 | 1076.58 KB | 
ManyRowsAsync | netcore11 | Core | CoreCsProj | 5,034.60 us | 25.4275 us | 22.5408 us | 6.0243 us | 4,999.04 us | 5,017.21 us | 5,033.42 us | 5,042.66 us | 5,080.55 us | 198.6 | 109.3750 | - | - | 2.68 KB | 
ManyRowsSync | netcore11 | Core | CoreCsProj | 4,504.51 us | 25.4222 us | 21.2287 us | 5.8878 us | 4,469.58 us | 4,491.97 us | 4,503.29 us | 4,516.25 us | 4,553.63 us | 222.0 | 109.3750 | - | - | 686.28 KB | 
OpenFromPoolAsync | netcore20 | Core | CoreCsProj | 209.84 us | 3.1329 us | 2.7772 us | 0.7423 us | 206.10 us | 208.11 us | 209.33 us | 210.90 us | 217.20 us | 4,765.6 | 0.9766 | - | - | 3.73 KB | 
OpenFromPoolSync | netcore20 | Core | CoreCsProj | 78.41 us | 0.3273 us | 0.3062 us | 0.0791 us | 77.93 us | 78.16 us | 78.55 us | 78.68 us | 78.86 us | 12,753.6 | 0.1221 | - | - | 1.43 KB | 
ExecuteScalarAsync | netcore20 | Core | CoreCsProj | 117.19 us | 2.2679 us | 2.1214 us | 0.5477 us | 114.15 us | 114.98 us | 117.02 us | 119.00 us | 120.77 us | 8,533.2 | 0.7324 | - | - | 4.15 KB | 
ExecuteScalarSync | netcore20 | Core | CoreCsProj | 69.31 us | 0.5193 us | 0.4858 us | 0.1254 us | 68.68 us | 68.95 us | 69.13 us | 69.76 us | 70.19 us | 14,427.0 | 0.2441 | - | - | 2.09 KB | 
ReadBlobsAsync | netcore20 | Core | CoreCsProj | 1,919.88 us | 38.3849 us | 70.1890 us | 10.8304 us | 1,818.55 us | 1,863.21 us | 1,914.55 us | 1,968.79 us | 2,079.72 us | 520.9 | 332.0313 | 332.0313 | 332.0313 | 3.95 KB | 
ReadBlobsSync | netcore20 | Core | CoreCsProj | 1,665.01 us | 13.2143 us | 12.3607 us | 3.1915 us | 1,652.66 us | 1,655.14 us | 1,662.38 us | 1,670.71 us | 1,692.01 us | 600.6 | 332.0313 | 332.0313 | 332.0313 | 1076.54 KB | 
ManyRowsAsync | netcore20 | Core | CoreCsProj | 3,980.58 us | 25.9151 us | 22.9731 us | 6.1398 us | 3,944.65 us | 3,963.30 us | 3,987.04 us | 3,994.74 us | 4,025.87 us | 251.2 | 109.3750 | - | - | 4.02 KB | 
ManyRowsSync | netcore20 | Core | CoreCsProj | 3,838.51 us | 12.3970 us | 11.5962 us | 2.9941 us | 3,819.46 us | 3,831.18 us | 3,835.10 us | 3,847.16 us | 3,862.88 us | 260.5 | 109.3750 | - | - | 686.17 KB | 

