### PR TITLE
Update to .NET Core SDK 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ env:
 
 before_install:
 - .ci/docker-run.sh $IMAGE $NAME 3307 $FEATURES
-- sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
-- sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
+- curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+- sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+- sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 - sudo apt-get update
-- sudo apt-get install -y dotnet-sdk-2.0.0-preview2-006497 dotnet-sharedframework-microsoft.netcore.app-1.1.2
+- sudo apt-get install -y dotnet-sdk-2.0.0 dotnet-sharedframework-microsoft.netcore.app-1.1.2
 
 script:
 - dotnet restore


### PR DESCRIPTION
Updates from `preview2` to the final release. Uses latest instructions from [here](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.0.0-download.md).