### PR TITLE
Treat File as SourceStream in case of LOAD DATA LOCAL INFILE

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -301,6 +301,8 @@ namespace MySql.Data.MySqlClient
 		internal bool TreatTinyAsBoolean => m_connectionSettings.TreatTinyAsBoolean;
 		internal IOBehavior AsyncIOBehavior => m_connectionSettings.ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
 
+		internal MySqlSslMode SslMode => m_connectionSettings.SslMode;
+
 		internal void SetActiveReader(MySqlDataReader dataReader)
 		{
 			if (dataReader == null)

--- a/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
+++ b/src/MySqlConnector/MySqlClient/Results/ResultSet.cs
@@ -56,6 +56,10 @@ namespace MySql.Data.MySqlClient.Results
 						try
 						{
 							var localInfile = LocalInfilePayload.Create(payload);
+							if(!IsHostVerified(Connection)
+								&& !localInfile.FileName.StartsWith(MySqlBulkLoader.StreamPrefix, StringComparison.Ordinal))
+								throw new NotSupportedException("Use SourceStream or SslMode >= VerifyCA for LOAD DATA LOCAL INFILE");
+
 							using (var stream = localInfile.FileName.StartsWith(MySqlBulkLoader.StreamPrefix, StringComparison.Ordinal) ?
 								MySqlBulkLoader.GetAndRemoveStream(localInfile.FileName) :
 								File.OpenRead(localInfile.FileName))
@@ -127,6 +131,12 @@ namespace MySql.Data.MySqlClient.Results
 			}
 
 			return this;
+		}
+
+		private bool IsHostVerified(MySqlConnection connection)
+		{
+			return connection.SslMode == MySqlSslMode.VerifyCA
+				|| connection.SslMode == MySqlSslMode.VerifyFull;
 		}
 
 		public async Task BufferEntireAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)

--- a/tests/SideBySide/Attributes.cs
+++ b/tests/SideBySide/Attributes.cs
@@ -98,6 +98,32 @@ namespace SideBySide
 			if(string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderLocalCsvFile))
 				Skip = "No bulk loader local CSV file specified";
 		}
+
+		public bool TrustedHost
+		{
+			
+			get => _trustedHost;
+			set
+			{
+				_trustedHost = value;
+
+				var csb = AppConfig.CreateConnectionStringBuilder();
+				if (_trustedHost)
+				{
+					if (csb.SslMode == MySqlSslMode.None
+						|| csb.SslMode == MySqlSslMode.Preferred
+						|| csb.SslMode == MySqlSslMode.Required)
+						Skip = "SslMode should be VerifyCA or higher.";
+				}
+				else
+				{
+					if (csb.SslMode == MySqlSslMode.VerifyCA
+						|| csb.SslMode == MySqlSslMode.VerifyFull)
+						Skip = "SslMode should be less than VerifyCA.";
+				}
+			}
+		}
+		private bool _trustedHost;
 	}
 
 	public class BulkLoaderLocalTsvFileFactAttribute : FactAttribute

--- a/tests/SideBySide/LoadDataInfileSync.cs
+++ b/tests/SideBySide/LoadDataInfileSync.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using MySql.Data.MySqlClient;
 using Xunit;
 using Dapper;
@@ -41,7 +41,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalCsvFileFact]
+		[BulkLoaderLocalCsvFileFact(TrustedHost = true)]
 		public void CommandLoadLocalCsvFile()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL", AppConfig.MySqlBulkLoaderLocalCsvFile.Replace("\\", "\\\\"));
@@ -51,6 +51,22 @@ namespace SideBySide
 			m_database.Connection.Close();
 			Assert.Equal(20, rowCount);
 		}
+
+#if !BASELINE
+		[BulkLoaderLocalCsvFileFact(TrustedHost = false)]
+		public void ThrowsNotSupportedExceptionForNotTrustedHostAndNotStream()
+		{
+			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL",
+				AppConfig.MySqlBulkLoaderLocalCsvFile.Replace("\\", "\\\\"));
+			MySqlCommand command = new MySqlCommand(insertInlineCommand, m_database.Connection);
+			if (m_database.Connection.State != ConnectionState.Open)
+				m_database.Connection.Open();
+
+			Assert.Throws<MySqlException>(() => command.ExecuteNonQuery());
+
+			m_database.Connection.Close();
+		}
+#endif
 
 		readonly DatabaseFixture m_database;
 		readonly string m_testTable;


### PR DESCRIPTION
I have implemented some logic according to #334:
 - In case of Local File create `FileStream` for the file and use it as `SourceStream`.
 - If the host is not trusted and `localInfile` does not start with StreamPrefix, throw `NotSupportedException`.