### PR TITLE
Rewrite test skipping attributes

### DIFF
--- a/tests/SideBySide/Attributes.cs
+++ b/tests/SideBySide/Attributes.cs
@@ -1,168 +1,73 @@
-using System;
 using MySql.Data.MySqlClient;
 using Xunit;
 
 namespace SideBySide
 {
-	public class RequiresFeatureFactAttribute : FactAttribute
+	public class SkippableFactAttribute : FactAttribute
 	{
-		public RequiresFeatureFactAttribute()
+		public SkippableFactAttribute()
+			: this(ServerFeatures.None, ConfigSettings.None)
 		{
 		}
 
-		public RequiresFeatureFactAttribute(ServerFeatures features)
+		public SkippableFactAttribute(ServerFeatures serverFeatures)
+			: this(serverFeatures, ConfigSettings.None)
 		{
-			if (!AppConfig.SupportedFeatures.HasFlag(features))
-				Skip = "Doesn't support " + features;
 		}
 
-		public bool RequiresSsl
+		public SkippableFactAttribute(ConfigSettings configSettings)
+			: this(ServerFeatures.None, configSettings)
 		{
-			get => m_requiresSsl;
+		}
+
+		public SkippableFactAttribute(ServerFeatures serverFeatures, ConfigSettings configSettings)
+		{
+			Skip = TestUtilities.GetSkipReason(serverFeatures, configSettings);
+		}
+
+		public string Baseline
+		{
+			get => null;
 			set
 			{
-				m_requiresSsl = value;
-				if (m_requiresSsl)
-				{
-					var csb = AppConfig.CreateConnectionStringBuilder();
-					if (csb.SslMode == MySqlSslMode.None || csb.SslMode == MySqlSslMode.Preferred)
-						Skip = "SSL not explicitly required";
-				}
-			}
-		}
-
-		private bool m_requiresSsl;
-	}
-
-	public class RequiresFeatureTheoryAttribute : TheoryAttribute
-	{
-		public RequiresFeatureTheoryAttribute()
-		{
-		}
-
-		public RequiresFeatureTheoryAttribute(ServerFeatures features)
-		{
-			if (!AppConfig.SupportedFeatures.HasFlag(features))
-				Skip = "Doesn't support " + features;
-		}
-
-		public bool RequiresSsl
-		{
-			get => m_requiresSsl;
-			set
-			{
-				m_requiresSsl = value;
-				if (m_requiresSsl)
-				{
-					var csb = AppConfig.CreateConnectionStringBuilder();
-					if (csb.SslMode == MySqlSslMode.None || csb.SslMode == MySqlSslMode.Preferred)
-						Skip = "SSL not explicitly required";
-				}
-			}
-		}
-
-		private bool m_requiresSsl;
-	}
-
-	public class PasswordlessUserFactAttribute : FactAttribute
-	{
-		public PasswordlessUserFactAttribute()
-		{
-			if(string.IsNullOrWhiteSpace(AppConfig.PasswordlessUser))
-				Skip = "No passwordless user";
-		}
-	}
-
-	public class BulkLoaderCsvFileFactAttribute : FactAttribute
-	{
-		public BulkLoaderCsvFileFactAttribute()
-		{
-			if(string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderCsvFile))
-				Skip = "No bulk loader CSV file specified";
-		}
-	}
-
-	public class BulkLoaderTsvFileFactAttribute : FactAttribute
-	{
-		public BulkLoaderTsvFileFactAttribute()
-		{
-			if(string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderTsvFile))
-				Skip = "No bulk loader TSV file specified";
-		}
-	}
-
-	public class BulkLoaderLocalCsvFileFactAttribute : FactAttribute
-	{
-		public BulkLoaderLocalCsvFileFactAttribute()
-		{
-			if(string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderLocalCsvFile))
-				Skip = "No bulk loader local CSV file specified";
-		}
-
-		public bool TrustedHost
-		{
-			
-			get => _trustedHost;
-			set
-			{
-				_trustedHost = value;
-
-				var csb = AppConfig.CreateConnectionStringBuilder();
-				if (_trustedHost)
-				{
-					if (csb.SslMode == MySqlSslMode.None
-						|| csb.SslMode == MySqlSslMode.Preferred
-						|| csb.SslMode == MySqlSslMode.Required)
-						Skip = "SslMode should be VerifyCA or higher.";
-				}
-				else
-				{
-					if (csb.SslMode == MySqlSslMode.VerifyCA
-						|| csb.SslMode == MySqlSslMode.VerifyFull)
-						Skip = "SslMode should be less than VerifyCA.";
-				}
-			}
-		}
-		private bool _trustedHost;
-	}
-
-	public class BulkLoaderLocalTsvFileFactAttribute : FactAttribute
-	{
-		public BulkLoaderLocalTsvFileFactAttribute()
-		{
-			if(string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderLocalTsvFile))
-				Skip = "No bulk loader local TSV file specified";
-		}
-	}
-
-	public class UnbufferedResultSetsFactAttribute : FactAttribute
-	{
-#if !BASELINE
-		public UnbufferedResultSetsFactAttribute()
-		{
-			var csb = AppConfig.CreateConnectionStringBuilder();
-			if(csb.BufferResultSets == true)
-				Skip = "Do not run when BufferResultSets are used";
-		}
+#if BASELINE
+				Skip = value;
 #endif
-	}
-
-	public class TcpConnectionFactAttribute : FactAttribute
-	{
-		public TcpConnectionFactAttribute()
-		{
-			var csb = AppConfig.CreateConnectionStringBuilder();
-			if(csb.Server.StartsWith("/", StringComparison.Ordinal) || csb.Server.StartsWith("./", StringComparison.Ordinal))
-				Skip = "Not a TCP Connection";
+			}
 		}
 	}
 
-	public class SecondaryDatabaseRequiredFactAttribute : FactAttribute
+	public class SkippableTheoryAttribute : TheoryAttribute
 	{
-		public SecondaryDatabaseRequiredFactAttribute()
+		public SkippableTheoryAttribute()
+			: this(ServerFeatures.None, ConfigSettings.None)
 		{
-			if (string.IsNullOrEmpty(AppConfig.SecondaryDatabase))
-				Skip = "No SecondaryDatabase specified.";
+		}
+
+		public SkippableTheoryAttribute(ServerFeatures serverFeatures)
+			: this(serverFeatures, ConfigSettings.None)
+		{
+		}
+
+		public SkippableTheoryAttribute(ConfigSettings configSettings)
+			: this(ServerFeatures.None, configSettings)
+		{
+		}
+
+		public SkippableTheoryAttribute(ServerFeatures serverFeatures, ConfigSettings configSettings)
+		{
+			Skip = TestUtilities.GetSkipReason(serverFeatures, configSettings);
+		}
+
+		public string Baseline
+		{
+			get => null;
+			set
+			{
+#if BASELINE
+				Skip = value;
+#endif
+			}
 		}
 	}
 }

--- a/tests/SideBySide/BulkLoaderAsync.cs
+++ b/tests/SideBySide/BulkLoaderAsync.cs
@@ -38,7 +38,7 @@ namespace SideBySide
 ");
 		}
 
-		[BulkLoaderTsvFileFact]
+		[SkippableFact(ConfigSettings.TsvFile)]
 		public async Task BulkLoadTsvFile()
 		{
 			using (MySqlConnection connection = new MySqlConnection(AppConfig.ConnectionString))
@@ -55,7 +55,7 @@ namespace SideBySide
 			}
 		}
 
-		[BulkLoaderLocalTsvFileFact]
+		[SkippableFact(ConfigSettings.LocalTsvFile)]
 		public async Task BulkLoadLocalTsvFile()
 		{
 			using (MySqlConnection connection = new MySqlConnection(AppConfig.ConnectionString))
@@ -72,7 +72,7 @@ namespace SideBySide
 			}
 		}
 
-		[BulkLoaderLocalTsvFileFact]
+		[SkippableFact(ConfigSettings.LocalTsvFile)]
 		public async Task BulkLoadLocalTsvFileDoubleEscapedTerminators()
 		{
 			using (MySqlConnection connection = new MySqlConnection(AppConfig.ConnectionString))
@@ -91,7 +91,7 @@ namespace SideBySide
 			}
 		}
 
-		[BulkLoaderCsvFileFact]
+		[SkippableFact(ConfigSettings.CsvFile)]
 		public async Task BulkLoadCsvFile()
 		{
 			using (MySqlConnection connection = new MySqlConnection(AppConfig.ConnectionString))
@@ -111,7 +111,7 @@ namespace SideBySide
 			}
 		}
 
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public async Task BulkLoadLocalCsvFile()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -304,7 +304,7 @@ namespace SideBySide
 #endif
 		}
 
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public async Task BulkLoadMissingTableName()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -329,11 +329,8 @@ namespace SideBySide
 #endif
 		}
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadFileStreamInvalidOperation() {}
-#else
-		[BulkLoaderLocalCsvFileFact]
+#if !BASELINE
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public async Task BulkLoadFileStreamInvalidOperation()
 		{
 			using (MySqlConnection connection = new MySqlConnection(AppConfig.ConnectionString))
@@ -357,13 +354,8 @@ namespace SideBySide
 				}
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadLocalFileStream() {}
-#else
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public async Task BulkLoadLocalFileStream()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -382,12 +374,7 @@ namespace SideBySide
 				Assert.Equal(20, rowCount);
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadMemoryStreamInvalidOperation() {}
-#else
 		[Fact]
 		public async Task BulkLoadMemoryStreamInvalidOperation()
 		{
@@ -408,12 +395,7 @@ namespace SideBySide
 				});
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadLocalMemoryStream() {}
-#else
 		[Fact]
 		public async Task BulkLoadLocalMemoryStream()
 		{

--- a/tests/SideBySide/BulkLoaderSync.cs
+++ b/tests/SideBySide/BulkLoaderSync.cs
@@ -51,7 +51,7 @@ namespace SideBySide
 		}
 #endif
 
-		[BulkLoaderTsvFileFact]
+		[SkippableFact(ConfigSettings.TsvFile)]
 		public void BulkLoadTsvFile()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -65,7 +65,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalTsvFileFact]
+		[SkippableFact(ConfigSettings.LocalTsvFile)]
 		public void BulkLoadLocalTsvFile()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -79,7 +79,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalTsvFileFact]
+		[SkippableFact(ConfigSettings.LocalTsvFile)]
 		public void BulkLoadLocalTsvFileDoubleEscapedTerminators()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -95,7 +95,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderCsvFileFact]
+		[SkippableFact(ConfigSettings.CsvFile)]
 		public void BulkLoadCsvFile()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -113,7 +113,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public void BulkLoadLocalCsvFile()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -307,7 +307,7 @@ namespace SideBySide
 #endif
 		}
 
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public void BulkLoadMissingTableName()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -332,11 +332,8 @@ namespace SideBySide
 #endif
 		}
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadFileStreamInvalidOperation() {}
-#else
-		[BulkLoaderLocalCsvFileFact]
+#if !BASELINE
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public void BulkLoadFileStreamInvalidOperation()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -358,13 +355,8 @@ namespace SideBySide
 				});
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadLocalFileStream() {}
-#else
-		[BulkLoaderLocalCsvFileFact]
+		[SkippableFact(ConfigSettings.LocalCsvFile)]
 		public void BulkLoadLocalFileStream()
 		{
 			MySqlBulkLoader bl = new MySqlBulkLoader(m_database.Connection);
@@ -384,12 +376,7 @@ namespace SideBySide
 				Assert.Equal(20, rowCount);
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadMemoryStreamInvalidOperation() {}
-#else
 		[Fact]
 		public void BulkLoadMemoryStreamInvalidOperation()
 		{
@@ -411,12 +398,7 @@ namespace SideBySide
 				});
 			}
 		}
-#endif
 
-#if BASELINE
-		[Fact(Skip = "SourceStream not implemented")]
-		public void BulkLoadLocalMemoryStream() {}
-#else
 		[Fact]
 		public void BulkLoadLocalMemoryStream()
 		{

--- a/tests/SideBySide/CancelTests.cs
+++ b/tests/SideBySide/CancelTests.cs
@@ -54,7 +54,7 @@ namespace SideBySide
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public void CancelReaderAsynchronously()
 		{
 			using (var barrier = new Barrier(2))
@@ -90,7 +90,7 @@ namespace SideBySide
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public void CancelCommandBeforeRead()
 		{
 			using (var cmd = new MySqlCommand(c_hugeQuery, m_database.Connection))
@@ -117,11 +117,7 @@ namespace SideBySide
 			}
 		}
 
-		[UnbufferedResultSetsFact
-#if BASELINE
-			(Skip = "Hangs in NextResult")
-#endif
-		]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets, Baseline = "Hangs in NextResult")]
 		public void CancelMultiStatementReader()
 		{
 			using (var barrier = new Barrier(2))
@@ -159,7 +155,7 @@ namespace SideBySide
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public void DapperQueryMultiple()
 		{
 			Stopwatch stopwatch;
@@ -275,7 +271,7 @@ create table cancel_completed_command(id integer not null primary key, value tex
 			Assert.Equal("value", value);
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task CancelHugeQueryWithTokenAfterExecuteReader()
 		{
 			using (var cmd = new MySqlCommand(c_hugeQuery, m_database.Connection))
@@ -301,7 +297,7 @@ create table cancel_completed_command(id integer not null primary key, value tex
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task CancelHugeQueryWithTokenInNextResult()
 		{
 			using (var cmd = new MySqlCommand(c_hugeQuery + "select 1, 2, 3;", m_database.Connection))
@@ -330,7 +326,7 @@ create table cancel_completed_command(id integer not null primary key, value tex
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task CancelSlowQueryWithTokenAfterExecuteReader()
 		{
 			using (var cmd = new MySqlCommand(c_slowQuery, m_database.Connection))
@@ -359,7 +355,7 @@ create table cancel_completed_command(id integer not null primary key, value tex
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task CancelSlowQueryWithTokenAfterNextResult()
 		{
 			using (var cmd = new MySqlCommand("SELECT 1; " + c_slowQuery, m_database.Connection))
@@ -395,7 +391,7 @@ create table cancel_completed_command(id integer not null primary key, value tex
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task CancelMultiStatementInRead()
 		{
 			using (var cmd = new MySqlCommand(c_hugeQuery + c_hugeQuery + c_hugeQuery, m_database.Connection))

--- a/tests/SideBySide/ConfigSettings.cs
+++ b/tests/SideBySide/ConfigSettings.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace SideBySide
+{
+	[Flags]
+	public enum ConfigSettings
+	{
+		None = 0,
+		RequiresSsl = 0x1,
+		TrustedHost = 0x2,
+		UntrustedHost = 0x4,
+		PasswordlessUser = 0x8,
+		CsvFile = 0x10,
+		LocalCsvFile = 0x20,
+		TsvFile = 0x40,
+		LocalTsvFile = 0x80,
+		UnbufferedResultSets = 0x100,
+		TcpConnection = 0x200,
+		SecondaryDatabase = 0x400,
+	}
+}

--- a/tests/SideBySide/ConnectAsync.cs
+++ b/tests/SideBySide/ConnectAsync.cs
@@ -69,11 +69,7 @@ namespace SideBySide
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "https://bugs.mysql.com/bug.php?id=81650")]
-#else
-		[TcpConnectionFact]
-#endif
+		[SkippableFact(ConfigSettings.TcpConnection, Baseline = "https://bugs.mysql.com/bug.php?id=81650")]
 		public async Task ConnectMultipleHostNames()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -87,7 +83,7 @@ namespace SideBySide
 			}
 		}
 
-		[PasswordlessUserFact]
+		[SkippableFact(ConfigSettings.PasswordlessUser)]
 		public async Task ConnectNoPassword()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -150,7 +146,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public async Task ChangeDatabase()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -168,7 +164,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public async Task ChangeDatabaseNotOpen()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -178,7 +174,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public async Task ChangeDatabaseNull()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -189,7 +185,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public async Task ChangeDatabaseInvalidName()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -205,7 +201,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public async Task ChangeDatabaseConnectionPooling()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -239,7 +235,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureFact(ServerFeatures.Sha256Password, RequiresSsl = true)]
+		[SkippableFact(ServerFeatures.Sha256Password, ConfigSettings.RequiresSsl)]
 		public async Task Sha256WithSecureConnection()
 		{
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
@@ -247,7 +243,7 @@ namespace SideBySide
 				await connection.OpenAsync();
 		}
 
-		[RequiresFeatureFact(ServerFeatures.Sha256Password)]
+		[SkippableFact(ServerFeatures.Sha256Password)]
 		public async Task Sha256WithoutSecureConnection()
 		{
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
@@ -268,7 +264,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureFact(ServerFeatures.CachingSha2Password, RequiresSsl = true)]
+		[SkippableFact(ServerFeatures.CachingSha2Password, ConfigSettings.RequiresSsl)]
 		public async Task CachingSha2WithSecureConnection()
 		{
 			var csb = AppConfig.CreateCachingSha2ConnectionStringBuilder();
@@ -276,7 +272,7 @@ namespace SideBySide
 				await connection.OpenAsync();
 		}
 
-		[RequiresFeatureFact(ServerFeatures.CachingSha2Password)]
+		[SkippableFact(ServerFeatures.CachingSha2Password)]
 		public async Task CachingSha2WithoutSecureConnection()
 		{
 			var csb = AppConfig.CreateCachingSha2ConnectionStringBuilder();

--- a/tests/SideBySide/ConnectSync.cs
+++ b/tests/SideBySide/ConnectSync.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -147,11 +147,7 @@ namespace SideBySide
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "https://bugs.mysql.com/bug.php?id=81650")]
-#else
-		[TcpConnectionFact]
-#endif
+		[SkippableFact(ConfigSettings.TcpConnection, Baseline = "https://bugs.mysql.com/bug.php?id=81650")]
 		public void ConnectMultipleHostNames()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -165,7 +161,7 @@ namespace SideBySide
 			}
 		}
 
-		[PasswordlessUserFact]
+		[SkippableFact(ConfigSettings.PasswordlessUser)]
 		public void ConnectNoPassword()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -181,7 +177,7 @@ namespace SideBySide
 			}
 		}
 
-		[PasswordlessUserFact]
+		[SkippableFact(ConfigSettings.PasswordlessUser)]
 		public void ConnectionPoolNoPassword()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -237,7 +233,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public void ChangeDatabase()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -255,7 +251,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public void ChangeDatabaseNotOpen()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -265,7 +261,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public void ChangeDatabaseNull()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -276,7 +272,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public void ChangeDatabaseInvalidName()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -292,7 +288,7 @@ namespace SideBySide
 			}
 		}
 
-		[SecondaryDatabaseRequiredFact]
+		[SkippableFact(ConfigSettings.SecondaryDatabase)]
 		public void ChangeDatabaseConnectionPooling()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -326,7 +322,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureFact(ServerFeatures.Sha256Password, RequiresSsl = true)]
+		[SkippableFact(ServerFeatures.Sha256Password, ConfigSettings.RequiresSsl)]
 		public void Sha256WithSecureConnection()
 		{
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();
@@ -334,7 +330,7 @@ namespace SideBySide
 				connection.Open();
 		}
 
-		[RequiresFeatureFact(ServerFeatures.Sha256Password)]
+		[SkippableFact(ServerFeatures.Sha256Password)]
 		public void Sha256WithoutSecureConnection()
 		{
 			var csb = AppConfig.CreateSha256ConnectionStringBuilder();

--- a/tests/SideBySide/DataTypes.cs
+++ b/tests/SideBySide/DataTypes.cs
@@ -145,11 +145,7 @@ namespace SideBySide
 			DoQuery("set", column, dataTypeName, expected, reader => reader.GetString(0));
 		}
 
-#if BASELINE
-		[Theory(Skip = "https://bugs.mysql.com/bug.php?id=78917")]
-#else
-		[Theory]
-#endif
+		[SkippableTheory(Baseline = "https://bugs.mysql.com/bug.php?id=78917")]
 		[InlineData("Boolean", "BOOL", new object[] { null, false, true, false, true, true, true })]
 		[InlineData("TinyInt1", "BOOL", new object[] { null, false, true, false, true, true, true })]
 		public void QueryBoolean(string column, string dataTypeName, object[] expected)
@@ -835,7 +831,7 @@ create table schema_table({createColumn});");
 			return data;
 		}
 
-		[RequiresFeatureTheory(ServerFeatures.Json)]
+		[SkippableTheory(ServerFeatures.Json)]
 		[InlineData(new object[] { new[] { null, "NULL", "BOOLEAN", "ARRAY", "ARRAY", "ARRAY", "INTEGER", "INTEGER", "OBJECT", "OBJECT" }})]
 		public void JsonType(string[] expectedTypes)
 		{
@@ -843,7 +839,7 @@ create table schema_table({createColumn});");
 			Assert.Equal(expectedTypes, types);
 		}
 
-		[RequiresFeatureTheory(ServerFeatures.Json)]
+		[SkippableTheory(ServerFeatures.Json)]
 		[InlineData("value", new[] { null, "null", "true", "[]", "[0]", "[1]", "0", "1", "{}", "{\"a\": \"b\"}" })]
 		public void QueryJson(string column, string[] expected)
 		{

--- a/tests/SideBySide/InsertTests.cs
+++ b/tests/SideBySide/InsertTests.cs
@@ -92,11 +92,7 @@ select last_insert_id();";
 				Assert.Equal(1L, rowid);
 		}
 
-#if BASELINE
-		[Theory(Skip = "http://bugs.mysql.com/bug.php?id=70686")]
-#else
-		[Theory]
-#endif
+		[SkippableTheory(Baseline = "http://bugs.mysql.com/bug.php?id=70686")]
 		[InlineData(3)]
 		[InlineData(6)]
 		public void InsertTime(int precision)
@@ -128,11 +124,7 @@ create table insert_time(value TIME({precision}));");
 		}
 
 
-#if BASELINE
-		[Fact(Skip = "https://bugs.mysql.com/bug.php?id=73788")]
-#else
-		[Fact]
-#endif
+		[SkippableFact(Baseline = "https://bugs.mysql.com/bug.php?id=73788")]
 		public void InsertDateTimeOffset()
 		{
 			m_database.Connection.Execute(@"drop table if exists insert_datetimeoffset;

--- a/tests/SideBySide/LoadDataInfileAsync.cs
+++ b/tests/SideBySide/LoadDataInfileAsync.cs
@@ -1,5 +1,4 @@
 using System.Data;
-using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
 using Xunit;
 using Dapper;
@@ -31,7 +30,7 @@ namespace SideBySide
 			m_loadDataInfileCommand = "LOAD DATA{0} INFILE '{1}' INTO TABLE " + m_testTable + " CHARACTER SET UTF8MB4 FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES (one, two, three, four, five) SET five = UNHEX(five);";
 		}
 
-		[BulkLoaderCsvFileFact]
+		[SkippableFact(ConfigSettings.CsvFile)]
 		public async void CommandLoadCsvFile()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, "", AppConfig.MySqlBulkLoaderCsvFile.Replace("\\", "\\\\"));
@@ -42,7 +41,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalCsvFileFact(TrustedHost = true)]
+		[SkippableFact(ConfigSettings.LocalCsvFile | ConfigSettings.TrustedHost)]
 		public async void CommandLoadLocalCsvFile()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL",
@@ -58,8 +57,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-#if !BASELINE
-		[BulkLoaderLocalCsvFileFact(TrustedHost = false)]
+		[SkippableFact(ConfigSettings.LocalCsvFile | ConfigSettings.TrustedHost, Baseline = "Doesn't require trusted host for LOAD DATA LOCAL INFILE")]
 		public async void ThrowsNotSupportedExceptionForNotTrustedHostAndNotStream()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL",
@@ -71,7 +69,6 @@ namespace SideBySide
 
 			await Assert.ThrowsAsync<MySqlException>(async () => await command.ExecuteNonQueryAsync());
 		}
-#endif
 
 		readonly DatabaseFixture m_database;
 		readonly string m_testTable;

--- a/tests/SideBySide/LoadDataInfileSync.cs
+++ b/tests/SideBySide/LoadDataInfileSync.cs
@@ -30,7 +30,7 @@ namespace SideBySide
 			m_loadDataInfileCommand = "LOAD DATA{0} INFILE '{1}' INTO TABLE " + m_testTable + " CHARACTER SET UTF8MB4 FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' IGNORE 1 LINES (one, two, three, four, five) SET five = UNHEX(five);";
 		}
 
-		[BulkLoaderCsvFileFact]
+		[SkippableFact(ConfigSettings.CsvFile)]
 		public void CommandLoadCsvFile()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, "", AppConfig.MySqlBulkLoaderCsvFile.Replace("\\", "\\\\"));
@@ -41,7 +41,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-		[BulkLoaderLocalCsvFileFact(TrustedHost = true)]
+		[SkippableFact(ConfigSettings.LocalCsvFile | ConfigSettings.TrustedHost)]
 		public void CommandLoadLocalCsvFile()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL", AppConfig.MySqlBulkLoaderLocalCsvFile.Replace("\\", "\\\\"));
@@ -52,8 +52,7 @@ namespace SideBySide
 			Assert.Equal(20, rowCount);
 		}
 
-#if !BASELINE
-		[BulkLoaderLocalCsvFileFact(TrustedHost = false)]
+		[SkippableFact(ConfigSettings.LocalCsvFile | ConfigSettings.TrustedHost, Baseline = "Doesn't require trusted host for LOAD DATA LOCAL INFILE")]
 		public void ThrowsNotSupportedExceptionForNotTrustedHostAndNotStream()
 		{
 			string insertInlineCommand = string.Format(m_loadDataInfileCommand, " LOCAL",
@@ -66,7 +65,6 @@ namespace SideBySide
 
 			m_database.Connection.Close();
 		}
-#endif
 
 		readonly DatabaseFixture m_database;
 		readonly string m_testTable;

--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -124,7 +124,7 @@ create table query_invalid_sql(id integer not null primary key auto_increment);"
 			}
 		}
 
-		[UnbufferedResultSetsFact]
+		[SkippableFact(ConfigSettings.UnbufferedResultSets)]
 		public async Task MultipleReaders()
 		{
 			using (var cmd = m_database.Connection.CreateCommand())
@@ -168,11 +168,7 @@ create table query_invalid_sql(id integer not null primary key auto_increment);"
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "Does not support BufferResultSets")]
-#else
-		[Fact]
-#endif
+		[SkippableFact(Baseline = "Does not support BufferResultSets")]
 		public async Task MultipleBufferedReaders()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -440,11 +436,7 @@ insert into query_null_parameter (id, value) VALUES (1, 'one'), (2, 'two'), (3, 
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "http://bugs.mysql.com/bug.php?id=82292")]
-#else
-		[Fact]
-#endif
+		[SkippableFact(Baseline = "http://bugs.mysql.com/bug.php?id=82292")]
 		public void DapperNullableBoolNullFirst()
 		{
 			// adapted from https://github.com/StackExchange/dapper-dot-net/issues/552
@@ -458,12 +450,8 @@ insert into query_null_parameter (id, value) VALUES (1, 'one'), (2, 'two'), (3, 
 			Assert.True(rows[1].IsBold);
 			Assert.Null(rows[2].IsBold);
 		}
-
-#if BASELINE
-		[Fact(Skip = "https://bugs.mysql.com/bug.php?id=78760")]
-#else
-		[Fact]
-#endif
+		
+		[SkippableFact(Baseline = "https://bugs.mysql.com/bug.php?id=78760")]
 		public void TabsAndNewLines()
 		{
 			m_database.Connection.Execute(@"drop table if exists query_tabs;
@@ -738,11 +726,7 @@ insert into enum_test (id, value) VALUES (1002, 'no'), (1003, 'yes');
 			}
 		}
 
-		[Fact
-#if BASELINE
-			(Skip = "https://bugs.mysql.com/bug.php?id=84701")
-#endif
-		]
+		[SkippableFact(Baseline = "https://bugs.mysql.com/bug.php?id=84701")]
 		public void Int64EnumParameter()
 		{
 			m_database.Connection.Execute(@"drop table if exists long_enum_test;

--- a/tests/SideBySide/SslTests.cs
+++ b/tests/SideBySide/SslTests.cs
@@ -12,7 +12,7 @@ namespace SideBySide
 			m_database = database;
 		}
 
-		[RequiresFeatureFact(RequiresSsl = true)]
+		[SkippableFact(ConfigSettings.RequiresSsl)]
 		public async Task ConnectSslPreferred()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -41,7 +41,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureTheory(RequiresSsl = true)]
+		[SkippableTheory(ConfigSettings.RequiresSsl)]
 		[InlineData("ssl-client.pfx", null, null)]
 		[InlineData("ssl-client-pw-test.pfx", "test", null)]
 		[InlineData("ssl-client-cert.pem", null, null)]
@@ -74,7 +74,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureFact(RequiresSsl = true)]
+		[SkippableFact(ConfigSettings.RequiresSsl)]
 		public async Task ConnectSslBadClientCertificate()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();
@@ -91,11 +91,7 @@ namespace SideBySide
 			}
 		}
 
-#if BASELINE
-		[Fact(Skip = "MySql.Data does not support CACertificateFile")]
-#else
-		[RequiresFeatureFact(RequiresSsl = true)]
-#endif
+		[SkippableFact(ConfigSettings.RequiresSsl, Baseline = "MySql.Data does not support CACertificateFile")]
 		public async Task ConnectSslBadCaCertificate()
 		{
 			var csb = AppConfig.CreateConnectionStringBuilder();

--- a/tests/SideBySide/StoredProcedureTests.cs
+++ b/tests/SideBySide/StoredProcedureTests.cs
@@ -98,7 +98,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureTheory(ServerFeatures.StoredProcedures)]
+		[SkippableTheory(ServerFeatures.StoredProcedures)]
 		[InlineData("FUNCTION")]
 		[InlineData("PROCEDURE")]
 		public async Task StoredProcedureEchoException(string procedureType)
@@ -181,7 +181,7 @@ namespace SideBySide
 			}
 		}
 
-		[RequiresFeatureTheory(ServerFeatures.StoredProcedures)]
+		[SkippableTheory(ServerFeatures.StoredProcedures)]
 		[InlineData("NonQuery")]
 		[InlineData("Scalar")]
 		[InlineData("Reader")]
@@ -380,11 +380,7 @@ namespace SideBySide
 			}
 		}
 
-		[Theory
-#if BASELINE
-			(Skip = "https://bugs.mysql.com/bug.php?id=84220")
-#endif
-		]
+		[SkippableTheory(Baseline = "https://bugs.mysql.com/bug.php?id=84220")]
 		[InlineData(false)]
 		[InlineData(true)]
 		public async Task DottedName(bool useDatabaseName)

--- a/tests/SideBySide/TransactionScopeTests.cs
+++ b/tests/SideBySide/TransactionScopeTests.cs
@@ -245,11 +245,7 @@ namespace SideBySide
 			Assert.Equal(new int[0], values);
 		}
 
-		[Fact
-#if BASELINE
-		(Skip = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")
-#endif
-		]
+		[SkippableFact(Baseline = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")]
 		public void CommitTwoTransactions()
 		{
 			m_database.Connection.Execute(@"drop table if exists transaction_scope_test_1;
@@ -280,12 +276,7 @@ namespace SideBySide
 			Assert.Equal(new[] { 3, 4 }, values2);
 		}
 
-
-		[Fact
-#if BASELINE
-		(Skip = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")
-#endif
-		]
+		[SkippableFact(Baseline = "Multiple simultaneous connections or connections with different connection strings inside the same transaction are not currently supported.")]
 		public void RollBackTwoTransactions()
 		{
 			m_database.Connection.Execute(@"drop table if exists transaction_scope_test_1;


### PR DESCRIPTION
Refactor the test attribute classes down to two common implementations: `[SkippableFact]` and `[SkippableTheory]`.

Reduce duplicated code and also eliminate some `#if BASELINE` blocks.