### PR TITLE
Use await instead of hand-written continuation

### DIFF
--- a/src/MySqlConnector/ValueTaskExtensions.cs
+++ b/src/MySqlConnector/ValueTaskExtensions.cs
@@ -1,15 +1,11 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace MySql.Data
 {
 	internal static class ValueTaskExtensions
 	{
-		public static ValueTask<TResult> ContinueWith<T, TResult>(this ValueTask<T> valueTask, Func<T, ValueTask<TResult>> continuation)
-		{
-			return valueTask.IsCompleted ? continuation(valueTask.Result) :
-				new ValueTask<TResult>(valueTask.AsTask().ContinueWith(task => continuation(task.GetAwaiter().GetResult()).AsTask()).Unwrap());
-		}
+		public static async ValueTask<TResult> ContinueWith<T, TResult>(this ValueTask<T> valueTask, Func<T, ValueTask<TResult>> continuation) => await continuation(await valueTask);
 
 		public static ValueTask<T> FromException<T>(Exception exception) => new ValueTask<T>(Utility.TaskFromException<T>(exception));
 	}


### PR DESCRIPTION
The compiler-generated state machine reduces allocations and performs better in benchmarks.

## Command Timeout PR (most recent benchmark)

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Xeon CPU E5-1650 v3 3.50GHz, ProcessorCount=12
Frequency=3410073 Hz, Resolution=293.2489 ns, Timer=TSC
  [Host]    : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0
  net47     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0
  netcore11 : .NET Core 1.1.2 (Framework 4.6.25211.01), 64bit RyuJIT
  netcore20 : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT

Jit=RyuJit  Platform=X64  

```
 |             Method |       Job | Runtime |   Toolchain |        Mean |      Error |     StdDev |    StdErr |      Median |         Min |          Q1 |          Q3 |         Max |     Op/s |    Gen 0 |    Gen 1 |    Gen 2 |  Allocated |
 |------------------- |---------- |-------- |------------ |------------:|-----------:|-----------:|----------:|------------:|------------:|------------:|------------:|------------:|---------:|---------:|---------:|---------:|-----------:|
 |  OpenFromPoolAsync |     net47 |     Clr | CsProjnet47 |   214.80 us |  1.6467 us |  1.3751 us | 0.3814 us |   214.64 us |   212.41 us |   213.76 us |   215.69 us |   217.24 us |  4,655.5 |   1.4648 |        - |        - |    9.45 KB |
 |   OpenFromPoolSync |     net47 |     Clr | CsProjnet47 |    83.64 us |  0.9082 us |  0.8051 us | 0.2152 us |    83.44 us |    82.45 us |    83.06 us |    84.19 us |    85.19 us | 11,956.6 |   0.1221 |        - |        - |    1.43 KB |
 | ExecuteScalarAsync |     net47 |     Clr | CsProjnet47 |   120.18 us |  2.3184 us |  2.4807 us | 0.5847 us |   120.02 us |   116.81 us |   118.36 us |   122.05 us |   126.62 us |  8,321.1 |   0.9766 |        - |        - |     6.9 KB |
 |  ExecuteScalarSync |     net47 |     Clr | CsProjnet47 |    75.98 us |  0.5483 us |  0.5129 us | 0.1324 us |    75.85 us |    75.31 us |    75.55 us |    76.34 us |    77.32 us | 13,162.0 |   0.2441 |        - |        - |    2.09 KB |
 |     ReadBlobsAsync |     net47 |     Clr | CsProjnet47 | 1,986.04 us | 35.6083 us | 33.3080 us | 8.6001 us | 1,988.23 us | 1,931.23 us | 1,954.59 us | 2,007.34 us | 2,041.73 us |    503.5 | 332.0313 | 332.0313 | 332.0313 | 1106.12 KB |
 |      ReadBlobsSync |     net47 |     Clr | CsProjnet47 | 1,890.30 us | 18.0214 us | 15.9755 us | 4.2696 us | 1,892.29 us | 1,854.74 us | 1,883.36 us | 1,899.16 us | 1,918.71 us |    529.0 | 332.0313 | 332.0313 | 332.0313 | 1079.59 KB |
 |      ManyRowsAsync |     net47 |     Clr | CsProjnet47 | 5,956.84 us | 14.1689 us | 11.8316 us | 3.2815 us | 5,956.22 us | 5,934.22 us | 5,949.55 us | 5,964.17 us | 5,978.48 us |    167.9 |        - |        - |        - |   26.67 KB |
 |       ManyRowsSync |     net47 |     Clr | CsProjnet47 | 5,316.81 us | 25.6195 us | 22.7110 us | 6.0698 us | 5,314.65 us | 5,282.84 us | 5,300.51 us | 5,336.55 us | 5,357.98 us |    188.1 |        - |        - |        - |     3.5 KB |
 |  OpenFromPoolAsync | netcore11 |    Core |  CoreCsProj |   210.25 us |  0.4599 us |  0.4302 us | 0.1111 us |   210.23 us |   209.58 us |   209.91 us |   210.55 us |   211.12 us |  4,756.4 |   1.4648 |   0.2441 |        - |    3.38 KB |
 |   OpenFromPoolSync | netcore11 |    Core |  CoreCsProj |    83.72 us |  1.8118 us |  3.4472 us | 0.5139 us |    82.26 us |    79.82 us |    81.35 us |    85.25 us |    93.67 us | 11,944.8 |   0.1221 |        - |        - |    1.38 KB |
 | ExecuteScalarAsync | netcore11 |    Core |  CoreCsProj |   121.65 us |  2.3851 us |  4.1772 us | 0.6689 us |   120.79 us |   115.63 us |   118.10 us |   124.52 us |   130.33 us |  8,220.6 |   1.0986 |   0.1221 |        - |    2.75 KB |
 |  ExecuteScalarSync | netcore11 |    Core |  CoreCsProj |    75.05 us |  1.4750 us |  2.5047 us | 0.4118 us |    74.63 us |    71.81 us |    72.70 us |    76.86 us |    81.06 us | 13,324.8 |   0.2441 |        - |        - |    2.02 KB |
 |     ReadBlobsAsync | netcore11 |    Core |  CoreCsProj | 1,939.94 us | 32.1737 us | 30.0953 us | 7.7706 us | 1,928.82 us | 1,896.88 us | 1,919.79 us | 1,967.05 us | 1,989.47 us |    515.5 | 332.0313 | 332.0313 | 332.0313 |    2.54 KB |
 |      ReadBlobsSync | netcore11 |    Core |  CoreCsProj | 1,637.53 us | 33.0565 us | 29.3037 us | 7.8318 us | 1,624.30 us | 1,614.30 us | 1,619.53 us | 1,643.92 us | 1,715.51 us |    610.7 | 332.0313 | 332.0313 | 332.0313 | 1076.16 KB |
 |      ManyRowsAsync | netcore11 |    Core |  CoreCsProj | 5,036.84 us | 15.0494 us | 14.0772 us | 3.6347 us | 5,032.46 us | 5,017.68 us | 5,027.23 us | 5,048.34 us | 5,061.58 us |    198.5 |        - |        - |        - |    2.68 KB |
 |       ManyRowsSync | netcore11 |    Core |  CoreCsProj | 4,535.03 us | 15.8731 us | 12.3927 us | 3.5775 us | 4,537.96 us | 4,514.20 us | 4,525.20 us | 4,543.17 us | 4,552.40 us |    220.5 |        - |        - |        - |    3.16 KB |
 |  OpenFromPoolAsync | netcore20 |    Core |  CoreCsProj |   221.73 us |  4.3130 us |  4.9669 us | 1.1106 us |   219.95 us |   214.80 us |   218.71 us |   224.83 us |   234.61 us |  4,510.0 |   0.9766 |        - |        - |    3.73 KB |
 |   OpenFromPoolSync | netcore20 |    Core |  CoreCsProj |    83.31 us |  1.6589 us |  2.4830 us | 0.4533 us |    82.85 us |    80.19 us |    81.30 us |    85.18 us |    90.62 us | 12,003.0 |   0.1221 |        - |        - |    1.35 KB |
 | ExecuteScalarAsync | netcore20 |    Core |  CoreCsProj |   125.32 us |  2.6532 us |  6.0426 us | 0.7674 us |   124.55 us |   116.04 us |   120.82 us |   128.43 us |   144.96 us |  7,979.6 |   0.7324 |        - |        - |    4.17 KB |
 |  ExecuteScalarSync | netcore20 |    Core |  CoreCsProj |    73.09 us |  1.1260 us |  1.0533 us | 0.2720 us |    73.07 us |    71.78 us |    72.23 us |    74.01 us |    75.28 us | 13,681.6 |   0.2441 |        - |        - |    1.98 KB |
 |     ReadBlobsAsync | netcore20 |    Core |  CoreCsProj | 1,828.06 us | 36.4529 us | 55.6675 us | 9.9982 us | 1,808.48 us | 1,744.15 us | 1,782.86 us | 1,881.08 us | 1,950.24 us |    547.0 | 332.0313 | 332.0313 | 332.0313 |    3.97 KB |
 |      ReadBlobsSync | netcore20 |    Core |  CoreCsProj | 1,695.93 us | 36.8787 us | 43.9015 us | 9.5801 us | 1,677.71 us | 1,641.75 us | 1,666.23 us | 1,730.33 us | 1,799.90 us |    589.6 | 332.0313 | 332.0313 | 332.0313 | 1076.13 KB |
 |      ManyRowsAsync | netcore20 |    Core |  CoreCsProj | 4,006.36 us | 17.0521 us | 15.9505 us | 4.1184 us | 4,002.60 us | 3,978.97 us | 3,995.93 us | 4,017.68 us | 4,039.70 us |    249.6 |        - |        - |        - |    4.04 KB |
 |       ManyRowsSync | netcore20 |    Core |  CoreCsProj | 3,930.19 us | 14.9531 us | 12.4865 us | 3.4631 us | 3,928.85 us | 3,904.65 us | 3,921.47 us | 3,939.96 us | 3,949.22 us |    254.4 |        - |        - |        - |    3.05 KB |

## This PR

``` ini

BenchmarkDotNet=v0.10.9, OS=Windows 10 Redstone 2 (10.0.15063)
Processor=Intel Xeon CPU E5-1650 v3 3.50GHz, ProcessorCount=12
Frequency=3410073 Hz, Resolution=293.2489 ns, Timer=TSC
  [Host]    : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0
  net47     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2115.0
  netcore11 : .NET Core 1.1.2 (Framework 4.6.25211.01), 64bit RyuJIT
  netcore20 : .NET Core 2.0.0 (Framework 4.6.00001.0), 64bit RyuJIT

Jit=RyuJit  Platform=X64  

```
 |             Method |       Job | Runtime |   Toolchain |        Mean |      Error |     StdDev |     StdErr |      Median |         Min |          Q1 |          Q3 |         Max |     Op/s |    Gen 0 |    Gen 1 |    Gen 2 |  Allocated |
 |------------------- |---------- |-------- |------------ |------------:|-----------:|-----------:|-----------:|------------:|------------:|------------:|------------:|------------:|---------:|---------:|---------:|---------:|-----------:|
 |  OpenFromPoolAsync |     net47 |     Clr | CsProjnet47 |   210.04 us |  4.8002 us |  6.7293 us |  1.2950 us |   209.69 us |   198.12 us |   205.72 us |   213.08 us |   226.72 us |  4,761.1 |   1.2207 |        - |        - |    8.89 KB |
 |   OpenFromPoolSync |     net47 |     Clr | CsProjnet47 |    90.07 us |  1.0583 us |  0.9900 us |  0.2556 us |    89.77 us |    88.77 us |    89.26 us |    90.84 us |    91.91 us | 11,102.3 |   0.1221 |        - |        - |    1.43 KB |
 | ExecuteScalarAsync |     net47 |     Clr | CsProjnet47 |   118.61 us |  1.1409 us |  1.0114 us |  0.2703 us |   118.42 us |   117.39 us |   117.66 us |   119.64 us |   120.21 us |  8,430.8 |   0.9766 |        - |        - |    6.59 KB |
 |  ExecuteScalarSync |     net47 |     Clr | CsProjnet47 |    82.48 us |  1.8993 us |  4.6233 us |  0.5526 us |    80.96 us |    78.21 us |    79.64 us |    83.32 us |   101.00 us | 12,124.8 |   0.2441 |        - |        - |    2.09 KB |
 |     ReadBlobsAsync |     net47 |     Clr | CsProjnet47 | 2,134.33 us | 41.3800 us | 49.2599 us | 10.7494 us | 2,119.88 us | 2,061.83 us | 2,092.83 us | 2,175.83 us | 2,238.22 us |    468.5 | 332.0313 | 332.0313 | 332.0313 | 1093.98 KB |
 |      ReadBlobsSync |     net47 |     Clr | CsProjnet47 | 2,203.57 us | 54.5588 us | 64.9484 us | 14.1729 us | 2,193.96 us | 2,132.14 us | 2,151.77 us | 2,239.80 us | 2,408.23 us |    453.8 | 332.0313 | 332.0313 | 332.0313 | 1079.69 KB |
 |      ManyRowsAsync |     net47 |     Clr | CsProjnet47 | 5,742.85 us | 47.0533 us | 39.2916 us | 10.8975 us | 5,744.82 us | 5,677.94 us | 5,709.30 us | 5,770.67 us | 5,819.18 us |    174.1 |        - |        - |        - |   24.92 KB |
 |       ManyRowsSync |     net47 |     Clr | CsProjnet47 | 5,525.48 us | 70.2415 us | 65.7039 us | 16.9647 us | 5,508.90 us | 5,448.76 us | 5,472.01 us | 5,570.34 us | 5,659.44 us |    181.0 |        - |        - |        - |     3.5 KB |
 |  OpenFromPoolAsync | netcore11 |    Core |  CoreCsProj |   156.82 us |  3.4390 us |  9.4142 us |  1.0093 us |   154.66 us |   141.74 us |   150.32 us |   160.71 us |   185.99 us |  6,376.9 |   1.2207 |   0.2441 |        - |    3.25 KB |
 |   OpenFromPoolSync | netcore11 |    Core |  CoreCsProj |    84.71 us |  1.6750 us |  3.7807 us |  0.4841 us |    83.54 us |    82.25 us |    83.16 us |    84.27 us |   105.65 us | 11,804.4 |   0.1221 |        - |        - |    1.38 KB |
 | ExecuteScalarAsync | netcore11 |    Core |  CoreCsProj |   115.02 us |  2.2725 us |  2.6170 us |  0.5852 us |   114.18 us |   112.27 us |   113.54 us |   115.26 us |   123.56 us |  8,693.9 |   0.9766 |   0.1221 |        - |    2.63 KB |
 |  ExecuteScalarSync | netcore11 |    Core |  CoreCsProj |    78.23 us |  0.6074 us |  0.5384 us |  0.1439 us |    78.18 us |    77.43 us |    77.76 us |    78.60 us |    79.17 us | 12,783.5 |   0.2441 |        - |        - |    2.07 KB |
 |     ReadBlobsAsync | netcore11 |    Core |  CoreCsProj | 1,979.79 us | 39.3052 us | 46.7901 us | 10.2104 us | 1,973.36 us | 1,907.70 us | 1,944.53 us | 2,008.11 us | 2,093.86 us |    505.1 | 332.0313 | 332.0313 | 332.0313 |    2.42 KB |
 |      ReadBlobsSync | netcore11 |    Core |  CoreCsProj | 2,057.07 us | 40.1651 us | 44.6434 us | 10.2419 us | 2,054.63 us | 1,968.15 us | 2,028.39 us | 2,076.01 us | 2,155.78 us |    486.1 | 332.0313 | 332.0313 | 332.0313 | 1077.66 KB |
 |      ManyRowsAsync | netcore11 |    Core |  CoreCsProj | 4,926.42 us | 20.3558 us | 19.0409 us |  4.9163 us | 4,923.48 us | 4,879.28 us | 4,916.30 us | 4,942.66 us | 4,958.77 us |    203.0 |        - |        - |        - |    2.57 KB |
 |       ManyRowsSync | netcore11 |    Core |  CoreCsProj | 4,706.59 us | 59.2891 us | 46.2890 us | 13.3625 us | 4,699.55 us | 4,643.97 us | 4,676.47 us | 4,728.58 us | 4,816.78 us |    212.5 |        - |        - |        - |    3.49 KB |
 |  OpenFromPoolAsync | netcore20 |    Core |  CoreCsProj |   127.65 us |  2.4868 us |  2.5538 us |  0.6194 us |   127.01 us |   124.52 us |   125.36 us |   129.10 us |   133.05 us |  7,833.8 |   0.7324 |        - |        - |    3.82 KB |
 |   OpenFromPoolSync | netcore20 |    Core |  CoreCsProj |    83.16 us |  1.8638 us |  1.6522 us |  0.4416 us |    82.78 us |    81.75 us |    82.38 us |    83.30 us |    88.59 us | 12,024.8 |   0.1221 |        - |        - |    1.35 KB |
 | ExecuteScalarAsync | netcore20 |    Core |  CoreCsProj |   110.00 us |  1.3270 us |  1.0360 us |  0.2991 us |   109.97 us |   108.05 us |   109.26 us |   110.87 us |   111.34 us |  9,090.9 |   0.7324 |        - |        - |    4.27 KB |
 |  ExecuteScalarSync | netcore20 |    Core |  CoreCsProj |    73.73 us |  0.6154 us |  0.4805 us |  0.1387 us |    73.54 us |    73.24 us |    73.35 us |    74.10 us |    74.62 us | 13,563.2 |   0.2441 |        - |        - |    2.02 KB |
 |     ReadBlobsAsync | netcore20 |    Core |  CoreCsProj | 1,990.82 us | 39.3233 us | 36.7830 us |  9.4973 us | 1,997.23 us | 1,933.15 us | 1,954.72 us | 2,023.91 us | 2,046.16 us |    502.3 | 332.0313 | 332.0313 | 332.0313 |    4.06 KB |
 |      ReadBlobsSync | netcore20 |    Core |  CoreCsProj | 2,078.17 us | 40.9133 us | 36.2686 us |  9.6932 us | 2,070.53 us | 2,030.06 us | 2,056.64 us | 2,089.51 us | 2,140.05 us |    481.2 | 332.0313 | 332.0313 | 332.0313 | 1077.71 KB |
 |      ManyRowsAsync | netcore20 |    Core |  CoreCsProj | 4,203.31 us | 55.9763 us | 52.3603 us | 13.5194 us | 4,205.71 us | 4,126.63 us | 4,158.03 us | 4,250.86 us | 4,307.99 us |    237.9 |        - |        - |        - |    4.13 KB |
 |       ManyRowsSync | netcore20 |    Core |  CoreCsProj | 4,105.64 us | 36.1170 us | 32.0168 us |  8.5568 us | 4,105.70 us | 4,050.01 us | 4,080.73 us | 4,131.27 us | 4,160.12 us |    243.6 |        - |        - |        - |    3.38 KB |
