### PR TITLE
Implement server load balancing

### DIFF
--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -191,6 +191,22 @@ These are the other options that MySqlConnector supports.  They are set to sensi
     Due to limitations in .NET Core, Unix-based Operating Systems will always use the OS Default keepalive settings.</td>
   </tr>
   <tr>
+    <td>Load Balance, LoadBalance</td>
+    <td>RoundRobin</td>
+    <td><p>The load-balancing strategy to use when <code>Host</code> contains multiple, comma-delimited, host names.
+      The options include:</p>
+      <dl>
+        <dt>RoundRobin</dt>
+        <dd>Each new connection opened for this connection pool uses the next host name (sequentially with wraparound). Requires <code>Pooling=True</code>. This is the default if <code>Pooling=True</code>.</dd>
+        <dt>InOrder</dt>
+        <dd>Each new connection tries the hosts in order, starting with the first one. This is the default if <code>Pooling=False</code>.</dd>
+        <dt>Random</dt>
+        <dd>Servers are tried in a random order.</dd>
+        <dt>FewestConnections</dt>
+        <dd>Servers are tried in ascending order of number of currently-open connections in this connection pool. Requires <code>Pooling=True</code>.
+      </dl>
+  </tr>
+  <tr>
     <td>Old Guids, OldGuids</td>
     <td>false</td>
     <td> The backend representation of a GUID type was changed from BINARY(16) to CHAR(36). This was done to allow developers to use the server function UUID() to populate a GUID table - UUID() generates a 36-character string. Developers of older applications can add 'Old Guids=true' to the connection string to use a GUID of data type BINARY(16).</td>

--- a/docs/content/tutorials/migrating-from-connector-net.md
+++ b/docs/content/tutorials/migrating-from-connector-net.md
@@ -36,6 +36,12 @@ MySqlConnector has some different default connection string options:
     <td>MySqlConnector takes an extra command to reset pooled connections by default so that the connection is always in a known state</td>
   </tr>
   <tr>
+    <td><code>LoadBalance</code></td>
+    <td>Default is <code>RoundRobin</code></td>
+    <td>(not configurable, effective default is <code>InOrder</code>)</td>
+    <td>Connector/NET currently has [a bug](https://bugs.mysql.com/bug.php?id=81650) that prevents multiple host names being used.</td>
+  </tr>
+  <tr>
     <td><code>ServerRSAPublicKeyFile</code></td>
     <td>(no default)</td>
     <td>(not configurable)</td>

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -318,11 +318,11 @@ namespace MySql.Data.MySqlClient
 			if (cs.LoadBalance == MySqlLoadBalance.FewestConnections)
 			{
 				m_hostSessions = new Dictionary<string, int>();
-				foreach (var hostName in cs.Hostnames)
+				foreach (var hostName in cs.HostNames)
 					m_hostSessions[hostName] = 0;
 			}
 			m_loadBalancer = cs.ConnectionType != ConnectionType.Tcp ? null :
-				cs.Hostnames.Count == 1 || cs.LoadBalance == MySqlLoadBalance.InOrder ? InOrderLoadBalancer.Instance :
+				cs.HostNames.Count == 1 || cs.LoadBalance == MySqlLoadBalance.InOrder ? InOrderLoadBalancer.Instance :
 				cs.LoadBalance == MySqlLoadBalance.Random ? RandomLoadBalancer.Instance :
 				cs.LoadBalance == MySqlLoadBalance.FewestConnections ? new FewestConnectionsLoadBalancer(this) :
 				(ILoadBalancer) new RoundRobinLoadBalancer();

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.Protocol.Serialization;
@@ -64,6 +65,7 @@ namespace MySql.Data.MySqlClient
 					if (!reuseSession)
 					{
 						// session is either old or cannot communicate with the server
+						AdjustHostConnectionCount(session, -1);
 						await session.DisposeAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 					}
 					else
@@ -78,7 +80,8 @@ namespace MySql.Data.MySqlClient
 
 				// create a new session
 				session = new MySqlSession(this, m_generation, Interlocked.Increment(ref m_lastId));
-				await session.ConnectAsync(m_connectionSettings, ioBehavior, cancellationToken).ConfigureAwait(false);
+				await session.ConnectAsync(m_connectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
+				AdjustHostConnectionCount(session, 1);
 				session.OwningConnection = new WeakReference<MySqlConnection>(connection);
 				lock (m_leasedSessions)
 					m_leasedSessions.Add(session.Id, session);
@@ -114,10 +117,15 @@ namespace MySql.Data.MySqlClient
 					m_leasedSessions.Remove(session.Id);
 				session.OwningConnection = null;
 				if (SessionIsHealthy(session))
+				{
 					lock (m_sessions)
 						m_sessions.AddFirst(session);
+				}
 				else
+				{
+					AdjustHostConnectionCount(session, -1);
 					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
+				}
 			}
 			finally
 			{
@@ -260,7 +268,8 @@ namespace MySql.Data.MySqlClient
 				try
 				{
 					var session = new MySqlSession(this, m_generation, Interlocked.Increment(ref m_lastId));
-					await session.ConnectAsync(m_connectionSettings, ioBehavior, cancellationToken).ConfigureAwait(false);
+					await session.ConnectAsync(m_connectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
+					AdjustHostConnectionCount(session, 1);
 					lock (m_sessions)
 						m_sessions.AddFirst(session);
 				}
@@ -306,6 +315,39 @@ namespace MySql.Data.MySqlClient
 			m_sessionSemaphore = new SemaphoreSlim(cs.MaximumPoolSize);
 			m_sessions = new LinkedList<MySqlSession>();
 			m_leasedSessions = new Dictionary<int, MySqlSession>();
+			if (cs.LoadBalance == MySqlLoadBalance.FewestConnections)
+			{
+				m_hostSessions = new Dictionary<string, int>();
+				foreach (var hostName in cs.Hostnames)
+					m_hostSessions[hostName] = 0;
+			}
+			m_loadBalancer = cs.ConnectionType != ConnectionType.Tcp ? null :
+				cs.Hostnames.Count == 1 || cs.LoadBalance == MySqlLoadBalance.InOrder ? InOrderLoadBalancer.Instance :
+				cs.LoadBalance == MySqlLoadBalance.Random ? RandomLoadBalancer.Instance :
+				cs.LoadBalance == MySqlLoadBalance.FewestConnections ? new FewestConnectionsLoadBalancer(this) :
+				(ILoadBalancer) new RoundRobinLoadBalancer();
+		}
+
+		private void AdjustHostConnectionCount(MySqlSession session, int delta)
+		{
+			if (m_hostSessions != null)
+			{
+				lock (m_hostSessions)
+					m_hostSessions[session.HostName] += delta;
+			}
+		}
+
+		private sealed class FewestConnectionsLoadBalancer : ILoadBalancer
+		{
+			public FewestConnectionsLoadBalancer(ConnectionPool pool) => m_pool = pool;
+
+			public IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts)
+			{
+				lock (m_pool.m_hostSessions)
+					return m_pool.m_hostSessions.OrderBy(x => x.Value).Select(x => x.Key).ToList();
+			}
+
+			readonly ConnectionPool m_pool;
 		}
 
 		static readonly ConcurrentDictionary<string, ConnectionPool> s_pools = new ConcurrentDictionary<string, ConnectionPool>();
@@ -336,6 +378,8 @@ namespace MySql.Data.MySqlClient
 		readonly LinkedList<MySqlSession> m_sessions;
 		readonly ConnectionSettings m_connectionSettings;
 		readonly Dictionary<int, MySqlSession> m_leasedSessions;
+		readonly ILoadBalancer m_loadBalancer;
+		readonly Dictionary<string, int> m_hostSessions;
 		int m_lastId;
 		uint m_lastRecoveryTime;
 	}

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -356,8 +356,12 @@ namespace MySql.Data.MySqlClient
 					}
 					else
 					{
+						// only "in order" and "random" load balancers supported without connection pooling
+						var loadBalancer = m_connectionSettings.LoadBalance == MySqlLoadBalance.Random && m_connectionSettings.Hostnames.Count > 1 ?
+							RandomLoadBalancer.Instance : InOrderLoadBalancer.Instance;
+
 						var session = new MySqlSession();
-						await session.ConnectAsync(m_connectionSettings, ioBehavior, linkedSource.Token).ConfigureAwait(false);
+						await session.ConnectAsync(m_connectionSettings, loadBalancer, ioBehavior, linkedSource.Token).ConfigureAwait(false);
 						return session;
 					}
 				}

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -188,7 +188,7 @@ namespace MySql.Data.MySqlClient
 		public override ConnectionState State => m_connectionState;
 
 		public override string DataSource => (m_connectionSettings.ConnectionType == ConnectionType.Tcp
-			? string.Join(",", m_connectionSettings.Hostnames)
+			? string.Join(",", m_connectionSettings.HostNames)
 			: m_connectionSettings.UnixSocket) ?? "";
 
 		public override string ServerVersion => m_session.ServerVersion.OriginalString;
@@ -357,7 +357,7 @@ namespace MySql.Data.MySqlClient
 					else
 					{
 						// only "in order" and "random" load balancers supported without connection pooling
-						var loadBalancer = m_connectionSettings.LoadBalance == MySqlLoadBalance.Random && m_connectionSettings.Hostnames.Count > 1 ?
+						var loadBalancer = m_connectionSettings.LoadBalance == MySqlLoadBalance.Random && m_connectionSettings.HostNames.Count > 1 ?
 							RandomLoadBalancer.Instance : InOrderLoadBalancer.Instance;
 
 						var session = new MySqlSession();

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -47,6 +47,12 @@ namespace MySql.Data.MySqlClient
 			set => MySqlConnectionStringOption.Database.SetValue(this, value);
 		}
 
+		public MySqlLoadBalance LoadBalance
+		{
+			get => MySqlConnectionStringOption.LoadBalance.GetValue(this);
+			set => MySqlConnectionStringOption.LoadBalance.SetValue(this, value);
+		}
+
 		// SSL/TLS Options
 		public MySqlSslMode SslMode
 		{
@@ -251,6 +257,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<string> UserID;
 		public static readonly MySqlConnectionStringOption<string> Password;
 		public static readonly MySqlConnectionStringOption<string> Database;
+		public static readonly MySqlConnectionStringOption<MySqlLoadBalance> LoadBalance;
 
 		// SSL/TLS Options
 		public static readonly MySqlConnectionStringOption<MySqlSslMode> SslMode;
@@ -329,6 +336,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(Database = new MySqlConnectionStringOption<string>(
 				keys: new[] { "Database", "Initial Catalog" },
 				defaultValue: ""));
+
+			AddOption(LoadBalance = new MySqlConnectionStringOption<MySqlLoadBalance>(
+				keys: new[] { "LoadBalance", "Load Balance" },
+				defaultValue: MySqlLoadBalance.RoundRobin));
 
 			// SSL/TLS Options
 			AddOption(SslMode = new MySqlConnectionStringOption<MySqlSslMode>(
@@ -469,6 +480,16 @@ namespace MySql.Data.MySqlClient
 					return (T) (object) true;
 				if (string.Equals(booleanString, "no", StringComparison.OrdinalIgnoreCase))
 					return (T) (object) false;
+			}
+
+			if (typeof(T) == typeof(MySqlLoadBalance) && objectValue is string loadBalanceString)
+			{
+				foreach (var val in Enum.GetValues(typeof(T)))
+				{
+					if (string.Equals(loadBalanceString, val.ToString(), StringComparison.OrdinalIgnoreCase))
+						return (T) val;
+				}
+				throw new InvalidOperationException("Value '{0}' not supported for option '{1}'.".FormatInvariant(objectValue, typeof(T).Name));
 			}
 
 			if (typeof(T) == typeof(MySqlSslMode) && objectValue is string sslModeString)

--- a/src/MySqlConnector/MySqlClient/MySqlLoadBalance.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlLoadBalance.cs
@@ -1,0 +1,25 @@
+namespace MySql.Data.MySqlClient
+{
+	public enum MySqlLoadBalance
+	{
+		/// <summary>
+		/// Servers are tried sequentially, across multiple calls to <see cref="MySqlConnection.Open"/>.
+		/// </summary>
+		RoundRobin,
+
+		/// <summary>
+		/// Servers are tried in order, starting with the first one, for each call to <see cref="MySqlConnection.Open"/>.
+		/// </summary>
+		InOrder,
+
+		/// <summary>
+		/// Servers are tried in random order.
+		/// </summary>
+		Random,
+
+		/// <summary>
+		/// Servers are tried in ascending order of number of currently-open connections.
+		/// </summary>
+		FewestConnections,
+	}
+}

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -23,6 +23,7 @@ namespace MySql.Data.Serialization
 			{
 				ConnectionType = ConnectionType.Tcp;
 				Hostnames = csb.Server.Split(',');
+				LoadBalance = csb.LoadBalance;
 				Port = (int) csb.Port;
 			}
 			UserID = csb.UserID;
@@ -65,7 +66,8 @@ namespace MySql.Data.Serialization
 		// Base Options
 		public string ConnectionString { get; }
 		public ConnectionType ConnectionType { get; }
-		public IEnumerable<string> Hostnames { get; }
+		public IReadOnlyList<string> Hostnames { get; }
+		public MySqlLoadBalance LoadBalance { get; }
 		public int Port { get; }
 		public string UnixSocket { get; }
 		public string UserID { get; }
@@ -125,6 +127,5 @@ namespace MySql.Data.Serialization
 				return m_connectionTimeoutMilliseconds.Value;
 			}
 		}
-
 	}
 }

--- a/src/MySqlConnector/Serialization/ConnectionSettings.cs
+++ b/src/MySqlConnector/Serialization/ConnectionSettings.cs
@@ -22,7 +22,7 @@ namespace MySql.Data.Serialization
 			else
 			{
 				ConnectionType = ConnectionType.Tcp;
-				Hostnames = csb.Server.Split(',');
+				HostNames = csb.Server.Split(',');
 				LoadBalance = csb.LoadBalance;
 				Port = (int) csb.Port;
 			}
@@ -66,7 +66,7 @@ namespace MySql.Data.Serialization
 		// Base Options
 		public string ConnectionString { get; }
 		public ConnectionType ConnectionType { get; }
-		public IReadOnlyList<string> Hostnames { get; }
+		public IReadOnlyList<string> HostNames { get; }
 		public MySqlLoadBalance LoadBalance { get; }
 		public int Port { get; }
 		public string UnixSocket { get; }

--- a/src/MySqlConnector/Serialization/ILoadBalancer.cs
+++ b/src/MySqlConnector/Serialization/ILoadBalancer.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+
+namespace MySql.Data.Serialization
+{
+	internal interface ILoadBalancer
+	{
+		/// <summary>
+		/// Returns an <see cref="IEnumerable{string}"/> containing <paramref name="hosts"/> in the order they
+		/// should be tried to satisfy the load balancing policy.
+		/// </summary>
+		IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts);
+	}
+
+	internal sealed class InOrderLoadBalancer : ILoadBalancer
+	{
+		public static ILoadBalancer Instance { get; } = new InOrderLoadBalancer();
+
+		public IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts) => hosts;
+
+		private InOrderLoadBalancer()
+		{
+		}
+	}
+
+	internal sealed class RandomLoadBalancer : ILoadBalancer
+	{
+		public static ILoadBalancer Instance { get; } = new RandomLoadBalancer();
+
+		public IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts)
+		{
+			// from https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+			var shuffled = new List<string>(hosts);
+			for (var i = hosts.Count - 1; i >= 1; i--)
+			{
+				int j;
+				lock (m_random)
+					j = m_random.Next(i + 1);
+				if (i != j)
+				{
+					var temp = shuffled[i];
+					shuffled[i] = shuffled[j];
+					shuffled[j] = temp;
+				}
+			}
+			return shuffled;
+		}
+
+		private RandomLoadBalancer() => m_random = new Random();
+
+		readonly Random m_random;
+	}
+
+	internal sealed class RoundRobinLoadBalancer : ILoadBalancer
+	{
+		public RoundRobinLoadBalancer() => m_lock = new object();
+
+		public IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts)
+		{
+			int start;
+			lock (m_lock)
+				start = (int) (m_counter++ % hosts.Count);
+
+			var shuffled = new List<string>(hosts.Count);
+			for (var i = start; i < hosts.Count; i++)
+				shuffled.Add(hosts[i]);
+			for (var i = 0; i < start; i++)
+				shuffled.Add(hosts[i]);
+			return shuffled;
+		}
+
+		readonly object m_lock;
+		uint m_counter;
+	}
+}

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -544,23 +544,23 @@ namespace MySql.Data.Serialization
 
 		private async Task<bool> OpenTcpSocketAsync(ConnectionSettings cs, ILoadBalancer loadBalancer, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			var hostNames = loadBalancer.LoadBalance(cs.Hostnames);
-			foreach (var hostname in hostNames)
+			var hostNames = loadBalancer.LoadBalance(cs.HostNames);
+			foreach (var hostName in hostNames)
 			{
 				IPAddress[] ipAddresses;
 				try
 				{
 #if NETSTANDARD1_3
 // Dns.GetHostAddresses isn't available until netstandard 2.0: https://github.com/dotnet/corefx/pull/11950
-					ipAddresses = await Dns.GetHostAddressesAsync(hostname).ConfigureAwait(false);
+					ipAddresses = await Dns.GetHostAddressesAsync(hostName).ConfigureAwait(false);
 #else
 					if (ioBehavior == IOBehavior.Asynchronous)
 					{
-						ipAddresses = await Dns.GetHostAddressesAsync(hostname).ConfigureAwait(false);
+						ipAddresses = await Dns.GetHostAddressesAsync(hostName).ConfigureAwait(false);
 					}
 					else
 					{
-						ipAddresses = Dns.GetHostAddresses(hostname);
+						ipAddresses = Dns.GetHostAddresses(hostName);
 					}
 #endif
 				}
@@ -621,7 +621,7 @@ namespace MySql.Data.Serialization
 						continue;
 					}
 
-					HostName = hostname;
+					HostName = hostName;
 					m_tcpClient = tcpClient;
 					m_socket = m_tcpClient.Client;
 					m_networkStream = m_tcpClient.GetStream();

--- a/tests/MySqlConnector.Tests/LoadBalancerTests.cs
+++ b/tests/MySqlConnector.Tests/LoadBalancerTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using MySql.Data.Serialization;
+using Xunit;
+
+namespace MySqlConnector.Tests
+{
+	public class LoadBalancerTests
+	{
+		[Fact]
+		public void InOrder()
+		{
+			var loadBalancer = InOrderLoadBalancer.Instance;
+			var input = new[] { "a", "b", "c", "d" };
+			Assert.Equal(new[] { "a", "b", "c", "d" }, loadBalancer.LoadBalance(input));
+			Assert.Same(input, loadBalancer.LoadBalance(input));
+		}
+
+		[Fact]
+		public void RoundRobin()
+		{
+			var loadBalancer = new RoundRobinLoadBalancer();
+			var input = new[] { "a", "b", "c", "d" };
+			Assert.Equal(new[] { "a", "b", "c", "d" }, loadBalancer.LoadBalance(input));
+			Assert.Equal(new[] { "b", "c", "d", "a" }, loadBalancer.LoadBalance(input));
+			Assert.Equal(new[] { "c", "d", "a", "b" }, loadBalancer.LoadBalance(input));
+			Assert.Equal(new[] { "d", "a", "b", "c" }, loadBalancer.LoadBalance(input));
+			Assert.Equal(new[] { "a", "b", "c", "d" }, loadBalancer.LoadBalance(input));
+		}
+
+		[Fact]
+		public void Random()
+		{
+			var loadBalancer = new RoundRobinLoadBalancer();
+			var input = new[] { "a", "b", "c", "d" };
+			for (int i = 0; i < 10; i++)
+			{
+				var output = loadBalancer.LoadBalance(input);
+				Assert.NotSame(input, output);
+				Assert.Equal(input.Length, output.Count());
+				Assert.Equal(input, output.OrderBy(x => x));
+			}
+		}
+	}
+}

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -32,6 +32,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(180u, csb.ConnectionIdleTimeout);
 			Assert.False(csb.ForceSynchronous);
 			Assert.Null(csb.CACertificateFile);
+			Assert.Equal(MySqlLoadBalance.RoundRobin, csb.LoadBalance);
 #endif
 			Assert.Equal(0u, csb.Keepalive);
 			Assert.Equal(100u, csb.MaximumPoolSize);
@@ -80,6 +81,7 @@ namespace MySql.Data.Tests
 					"ca certificate file=ca.pem;" +
 					"allow public key retrieval = true;" +
 					"server rsa public key file=rsa.pem;" +
+					"load balance=random;" +
 #endif
 					"Keep Alive=90;" +
 					"minpoolsize=5;" +
@@ -111,6 +113,7 @@ namespace MySql.Data.Tests
 			Assert.Equal("ca.pem", csb.CACertificateFile);
 			Assert.True(csb.AllowPublicKeyRetrieval);
 			Assert.Equal("rsa.pem", csb.ServerRsaPublicKeyFile);
+			Assert.Equal(MySqlLoadBalance.Random, csb.LoadBalance);
 #endif
 			Assert.Equal(90u, csb.Keepalive);
 			Assert.Equal(15u, csb.MaximumPoolSize);

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'Baseline' ">
     <PackageReference Include="MySql.Data" Version="6.9.9" />
-    <Compile Remove="ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;NormalizeTests.cs;TypeMapperTests.cs;Utf8Tests.cs" />
+    <Compile Remove="ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;LoadBalancerTests.cs;NormalizeTests.cs;TypeMapperTests.cs;Utf8Tests.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">


### PR DESCRIPTION
Fixes #226.

Implements a `LoadBalance` connection string option with four settings:

* `RoundRobin` (default) - each server is tried in turn across all calls to `Open`
* `InOrder` - servers are tried in order, starting from the first, for each call to `Open`
* `Random` - servers are tried randomly
* `FewestConnections` - a connection is opened to the server with the fewest open connections in this connection pool (requires `Pooling=true`)