### PR TITLE
Make Enum params behave like official client.

### DIFF
--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlParameter.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlParameter.cs
@@ -226,7 +226,7 @@ namespace MySql.Data.MySqlClient
 			}
 			else if (Value is Enum)
 			{
-				writer.WriteUtf8("{0:d}".FormatInvariant(Value));
+				writer.WriteUtf8("'{0:G}'".FormatInvariant(Value));
 			}
 			else
 			{


### PR DESCRIPTION
Enums in the official client are serialized to string values.

https://github.com/mysql/mysql-connector-net/blob/5864e6b21a8b32f5154b53d1610278abb3cb1cee/Source/MySql.Data/extensions/NonRT/MySqlParameter.cs

https://dev.mysql.com/doc/dev/connector-net/6.10/html/T_MySql_Data_MySqlClient_MySqlDbType.htm