### PR TITLE
Use ToString when value returned from GetValue is not a string type.

### DIFF
--- a/src/MySqlConnector/Core/Row.cs
+++ b/src/MySqlConnector/Core/Row.cs
@@ -225,7 +225,11 @@ namespace MySqlConnector.Core
 
 		public DateTimeOffset GetDateTimeOffset(int ordinal) => new DateTimeOffset(DateTime.SpecifyKind(GetDateTime(ordinal), DateTimeKind.Utc));
 
-		public string GetString(int ordinal) => (string) GetValue(ordinal);
+		public string GetString(int ordinal)
+		{
+			var value = GetValue(ordinal);
+			return value is string stringValue ? stringValue : value.ToString();
+		} 
 
 		public decimal GetDecimal(int ordinal) => (decimal) GetValue(ordinal);
 


### PR DESCRIPTION
#406 Changes Row.GetString to mimic the MySql.Data GetString by using ToString() for non-string type column.