### PR TITLE
Fix small documentation errors

### DIFF
--- a/src/MySqlConnector/Core/ILoadBalancer.cs
+++ b/src/MySqlConnector/Core/ILoadBalancer.cs
@@ -6,7 +6,7 @@ namespace MySqlConnector.Core
 	internal interface ILoadBalancer
 	{
 		/// <summary>
-		/// Returns an <see cref="IEnumerable{string}"/> containing <paramref name="hosts"/> in the order they
+		/// Returns an <see cref="IEnumerable{String}"/> containing <paramref name="hosts"/> in the order they
 		/// should be tried to satisfy the load balancing policy.
 		/// </summary>
 		IEnumerable<string> LoadBalance(IReadOnlyList<string> hosts);

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlHelper.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlHelper.cs
@@ -9,7 +9,7 @@ namespace MySql.Data.MySqlClient
 		public static void ClearConnectionPools() => MySqlConnection.ClearAllPools();
 
 		/// <summary>
-		/// Escapes single and double quotes, and backslashes in <paramref name="input"/>.
+		/// Escapes single and double quotes, and backslashes in <paramref name="value"/>.
 		/// </summary>
 		public static string EscapeString(string value)
 		{

--- a/src/MySqlConnector/Protocol/Serialization/IByteHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/IByteHandler.cs
@@ -19,7 +19,7 @@ namespace MySqlConnector.Protocol.Serialization
 		/// <returns>A <see cref="ValueTask{Int32}"/>. Number of bytes read.</returns>
 		/// If reading failed, zero bytes will be returned. This
 		/// <see cref="ArraySegment{Byte}"/> will be valid to read from until the next time <see cref="ReadBytesAsync"/> or
-		/// <see cref="WriteBytesAsync"/> is called.</returns>
+		/// <see cref="WriteBytesAsync"/> is called.
 		ValueTask<int> ReadBytesAsync(ArraySegment<byte> buffer, IOBehavior ioBehavior);
 
 		/// <summary>


### PR DESCRIPTION
I just loaded the project up in [Rider](https://www.jetbrains.com/rider/) and it threw solution errors for these 3 documentation items.

The `IEnumerable{string}` -> `IEnumerable{String}` seemed odd to me; I expected the former to work.  In these 2 SO posts, all examples use the capitalized type name though: [Post 1](https://stackoverflow.com/questions/24475210/how-to-use-ienumerablestring-in-documenting-code), [Post 2](https://stackoverflow.com/questions/684982/referring-to-a-generic-type-of-a-generic-type-in-c-sharp-xml-documentation/797364#797364)