### PR TITLE
Improve connection pooling

### DIFF
--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -17,7 +17,7 @@ namespace MySqlConnector.Core
 
 		public ConnectionSettings ConnectionSettings { get; }
 
-		public async Task<ServerSession> GetSessionAsync(MySqlConnection connection, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		public async ValueTask<ServerSession> GetSessionAsync(MySqlConnection connection, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -10,6 +10,7 @@ namespace MySqlConnector.Core
 	{
 		public ConnectionSettings(MySqlConnectionStringBuilder csb)
 		{
+			ConnectionStringBuilder = csb;
 			ConnectionString = csb.ConnectionString;
 
 			// Base Options
@@ -63,6 +64,12 @@ namespace MySqlConnector.Core
 			UseAffectedRows = csb.UseAffectedRows;
 			UseCompression = csb.UseCompression;
 		}
+
+		/// <summary>
+		/// The <see cref="MySqlConnectionStringBuilder" /> that was used to create this <see cref="ConnectionSettings" />.!--
+		/// This object must not be mutated.
+		/// </summary>
+		public MySqlConnectionStringBuilder ConnectionStringBuilder { get; }
 
 		// Base Options
 		public string ConnectionString { get; }

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -154,10 +154,9 @@ namespace MySql.Data.MySqlClient
 
 		public override void Open() => OpenAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
-		public override Task OpenAsync(CancellationToken cancellationToken) =>
-			OpenAsync(AsyncIOBehavior, cancellationToken);
+		public override Task OpenAsync(CancellationToken cancellationToken) => OpenAsync(default, cancellationToken);
 
-		private async Task OpenAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		private async Task OpenAsync(IOBehavior? ioBehavior, CancellationToken cancellationToken)
 		{
 			VerifyNotDisposed();
 			if (State != ConnectionState.Closed)
@@ -191,23 +190,28 @@ namespace MySql.Data.MySqlClient
 
 		public override string ConnectionString
 		{
-			get => m_connectionStringBuilder.GetConnectionString(!m_hasBeenOpened || m_connectionSettings.PersistSecurityInfo);
+			get
+			{
+				if (!m_hasBeenOpened)
+					return m_connectionString;
+				var connectionStringBuilder = GetConnectionSettings().ConnectionStringBuilder;
+				return connectionStringBuilder.GetConnectionString(connectionStringBuilder.PersistSecurityInfo);
+			}
 			set
 			{
 				if (m_hasBeenOpened)
 					throw new InvalidOperationException("Cannot change connection string on a connection that has already been opened.");
-				m_connectionStringBuilder = new MySqlConnectionStringBuilder(value);
-				m_connectionSettings = new ConnectionSettings(m_connectionStringBuilder);
+				m_connectionString = value;
 			}
 		}
 
-		public override string Database => m_session?.DatabaseOverride ?? m_connectionSettings.Database;
+		public override string Database => m_session?.DatabaseOverride ?? GetConnectionSettings().Database;
 
 		public override ConnectionState State => m_connectionState;
 
-		public override string DataSource => (m_connectionSettings.ConnectionType == ConnectionType.Tcp
-			? string.Join(",", m_connectionSettings.HostNames)
-			: m_connectionSettings.UnixSocket) ?? "";
+		public override string DataSource => (GetConnectionSettings().ConnectionType == ConnectionType.Tcp
+			? string.Join(",", GetConnectionSettings().HostNames)
+			: GetConnectionSettings().UnixSocket) ?? "";
 
 		public override string ServerVersion => m_session.ServerVersion.OriginalString;
 
@@ -225,7 +229,7 @@ namespace MySql.Data.MySqlClient
 			if (connection == null)
 				throw new ArgumentNullException(nameof(connection));
 
-			var pool = ConnectionPool.GetPool(connection.m_connectionSettings);
+			var pool = ConnectionPool.GetPool(connection.m_connectionString);
 			if (pool != null)
 				await pool.ClearAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 		}
@@ -288,7 +292,7 @@ namespace MySql.Data.MySqlClient
 			try
 			{
 				// open a dedicated connection to the server to kill the active query
-				var csb = new MySqlConnectionStringBuilder(m_connectionStringBuilder.GetConnectionString(includePassword: true));
+				var csb = new MySqlConnectionStringBuilder(m_connectionString);
 				csb.Pooling = false;
 				if (m_session.IPAddress != null)
 					csb.Server = m_session.IPAddress.ToString();
@@ -343,10 +347,10 @@ namespace MySql.Data.MySqlClient
 		internal MySqlTransaction CurrentTransaction { get; set; }
 		internal bool AllowUserVariables => m_connectionSettings.AllowUserVariables;
 		internal bool ConvertZeroDateTime => m_connectionSettings.ConvertZeroDateTime;
-		internal int DefaultCommandTimeout => m_connectionSettings.DefaultCommandTimeout;
+		internal int DefaultCommandTimeout => GetConnectionSettings().DefaultCommandTimeout;
 		internal bool OldGuids => m_connectionSettings.OldGuids;
 		internal bool TreatTinyAsBoolean => m_connectionSettings.TreatTinyAsBoolean;
-		internal IOBehavior AsyncIOBehavior => m_connectionSettings.ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
+		internal IOBehavior AsyncIOBehavior => GetConnectionSettings().ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
 
 		internal MySqlSslMode SslMode => m_connectionSettings.SslMode;
 
@@ -367,8 +371,12 @@ namespace MySql.Data.MySqlClient
 			m_activeReader = null;
 		}
 
-		private async Task<ServerSession> CreateSessionAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		private async Task<ServerSession> CreateSessionAsync(IOBehavior? ioBehavior, CancellationToken cancellationToken)
 		{
+			var pool = ConnectionPool.GetPool(m_connectionString);
+			m_connectionSettings = pool?.ConnectionSettings ?? new ConnectionSettings(new MySqlConnectionStringBuilder(m_connectionString));
+			var actualIOBehavior = ioBehavior ?? (m_connectionSettings.ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous);
+
 			var connectTimeout = m_connectionSettings.ConnectionTimeout == 0 ? Timeout.InfiniteTimeSpan : TimeSpan.FromMilliseconds(m_connectionSettings.ConnectionTimeoutMilliseconds);
 			using (var timeoutSource = new CancellationTokenSource(connectTimeout))
 			using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutSource.Token))
@@ -376,11 +384,10 @@ namespace MySql.Data.MySqlClient
 				try
 				{
 					// get existing session from the pool if possible
-					if (m_connectionSettings.Pooling)
+					if (pool != null)
 					{
-						var pool = ConnectionPool.GetPool(m_connectionSettings);
 						// this returns an open session
-						return await pool.GetSessionAsync(this, ioBehavior, linkedSource.Token).ConfigureAwait(false);
+						return await pool.GetSessionAsync(this, actualIOBehavior, linkedSource.Token).ConfigureAwait(false);
 					}
 					else
 					{
@@ -390,7 +397,7 @@ namespace MySql.Data.MySqlClient
 
 						var session = new ServerSession();
 						Log.Info("Created new non-pooled Session{0}", session.Id);
-						await session.ConnectAsync(m_connectionSettings, loadBalancer, ioBehavior, linkedSource.Token).ConfigureAwait(false);
+						await session.ConnectAsync(m_connectionSettings, loadBalancer, actualIOBehavior, linkedSource.Token).ConfigureAwait(false);
 						return session;
 					}
 				}
@@ -472,9 +479,16 @@ namespace MySql.Data.MySqlClient
 			}
 		}
 
+		private ConnectionSettings GetConnectionSettings()
+		{
+			if (m_connectionSettings == null)
+				m_connectionSettings = new ConnectionSettings(new MySqlConnectionStringBuilder(m_connectionString));
+			return m_connectionSettings;
+		}
+
 		static readonly IMySqlConnectorLogger Log = MySqlConnectorLogManager.CreateLogger(nameof(MySqlConnection));
 
-		MySqlConnectionStringBuilder m_connectionStringBuilder;
+		string m_connectionString;
 		ConnectionSettings m_connectionSettings;
 		ServerSession m_session;
 		ConnectionState m_connectionState;

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -371,7 +371,7 @@ namespace MySql.Data.MySqlClient
 			m_activeReader = null;
 		}
 
-		private async Task<ServerSession> CreateSessionAsync(IOBehavior? ioBehavior, CancellationToken cancellationToken)
+		private async ValueTask<ServerSession> CreateSessionAsync(IOBehavior? ioBehavior, CancellationToken cancellationToken)
 		{
 			var pool = ConnectionPool.GetPool(m_connectionString);
 			m_connectionSettings = pool?.ConnectionSettings ?? new ConnectionSettings(new MySqlConnectionStringBuilder(m_connectionString));

--- a/tests/Conformance.Tests/ConnectionTests.cs
+++ b/tests/Conformance.Tests/ConnectionTests.cs
@@ -10,6 +10,11 @@ namespace Conformance.Tests
 		{
 		}
 
+		[Fact(Skip = "Throws MySqlException when it attempts to connect.")]
+		public override void Set_ConnectionString_throws_when_invalid()
+		{
+		}
+
 		[Fact(Skip = "Throws MySqlException when it attempts to connect, not InvalidOperationException before connecting")]
 		public override void Open_throws_when_no_connection_string()
 		{


### PR DESCRIPTION
Defer creation of `MySqlConnectionStringBuilder` and `ConnectionSettings` until it is known that a new ConnectionPool needs to be created.

```
BenchmarkDotNet=v0.10.12, OS=macOS 10.13.3 (17D47) [Darwin 17.4.0]
Intel Core i7-3740QM CPU 2.70GHz (Ivy Bridge), 1 CPU, 8 logical cores and 4 physical cores
.NET Core SDK=2.1.4
  [Host]    : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
  netcore20 : .NET Core 2.0.5 (Framework 4.6.0.0), 64bit RyuJIT
```

### Before

Method |     Mean |     Error |    StdDev |   StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
  OpenSync | 772.8 us | 15.246 us | 30.448 us | 4.350 us | 715.7 us | 749.7 us | 781.6 us | 791.1 us | 850.3 us | 1,294.0 | 0.9766 |   5.56 KB |
 OpenAsync | 799.9 us |  7.779 us |  7.277 us | 1.879 us | 790.5 us | 793.8 us | 798.0 us | 804.5 us | 816.6 us | 1,250.2 | 2.9297 |   8.05 KB |

### After reducing allocations

Method |     Mean |    Error |   StdDev |   StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
  OpenSync | 749.5 us | 14.80 us | 23.47 us | 4.085 us | 719.0 us | 728.5 us | 753.2 us | 766.2 us | 809.5 us | 1,334.3 |      - |   1.39 KB |
 OpenAsync | 835.3 us | 16.09 us | 15.05 us | 3.885 us | 814.1 us | 823.0 us | 832.3 us | 846.3 us | 863.1 us | 1,197.1 | 1.9531 |   3.89 KB |

### Adding ConcurrentDictionary

Method |     Mean |     Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
  OpenSync | 730.2 us | 12.010 us | 10.029 us | 2.7814 us | 711.7 us | 723.7 us | 728.7 us | 739.8 us | 748.1 us | 1,369.4 |      - |   1.39 KB |
 OpenAsync | 802.8 us |  2.294 us |  1.916 us | 0.5314 us | 800.2 us | 801.1 us | 802.4 us | 804.3 us | 806.5 us | 1,245.7 | 1.9531 |   3.89 KB |

### GetSessionAsync returns ValueTask

Method |     Mean |     Error |    StdDev |   StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
  OpenSync | 748.5 us | 14.867 us | 23.146 us | 4.092 us | 722.6 us | 730.3 us | 745.9 us | 759.0 us | 823.0 us | 1,336.0 |      - |   1.32 KB |
 OpenAsync | 747.2 us |  8.242 us |  6.882 us | 1.909 us | 737.9 us | 742.1 us | 745.2 us | 751.4 us | 763.6 us | 1,338.3 | 1.9531 |   3.91 KB |

### Add single-entry MRU cache

Method |     Mean |    Error |   StdDev |   StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
  OpenSync | 724.5 us | 13.57 us | 15.62 us | 3.493 us | 696.6 us | 720.3 us | 725.3 us | 732.3 us | 757.3 us | 1,380.3 |      - |   1.32 KB |
 OpenAsync | 818.8 us | 16.22 us | 15.93 us | 3.982 us | 805.9 us | 809.5 us | 811.5 us | 821.1 us | 867.7 us | 1,221.3 | 1.9531 |   3.91 KB |
