### PR TITLE
Reduce allocations in common paths

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -197,7 +197,7 @@ namespace MySqlConnector.Core
 					{
 						Log.Info("{0} sending QUIT command", m_logArguments);
 						m_payloadHandler.StartNewConversation();
-						await m_payloadHandler.WritePayloadAsync(QuitPayload.Create().ArraySegment, ioBehavior).ConfigureAwait(false);
+						await m_payloadHandler.WritePayloadAsync(QuitPayload.Instance.ArraySegment, ioBehavior).ConfigureAwait(false);
 					}
 					catch (IOException)
 					{
@@ -514,7 +514,7 @@ namespace MySqlConnector.Core
 			try
 			{
 				Log.Debug("{0} pinging server", m_logArguments);
-				await SendAsync(PingPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
+				await SendAsync(PingPayload.Instance, ioBehavior, cancellationToken).ConfigureAwait(false);
 				var payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 				OkPayload.Create(payload);
 				Log.Info("{0} successfully pinged server", m_logArguments);

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -319,13 +319,12 @@ namespace MySqlConnector.Core
 				{
 					m_logArguments[1] = ServerVersion.OriginalString;
 					Log.Debug("{0} ServerVersion {1} supports reset connection; sending reset connection request", m_logArguments);
-					await SendAsync(ResetConnectionPayload.Create(), ioBehavior, cancellationToken).ConfigureAwait(false);
+					await SendAsync(ResetConnectionPayload.Instance, ioBehavior, cancellationToken).ConfigureAwait(false);
 					var payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 					OkPayload.Create(payload);
 
 					// the "reset connection" packet also resets the connection charset, so we need to change that back to our default
-					payload = QueryPayload.Create("SET NAMES utf8mb4 COLLATE utf8mb4_bin;");
-					await SendAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
+					await SendAsync(s_setNamesUtf8mb4Payload, ioBehavior, cancellationToken).ConfigureAwait(false);
 					payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 					OkPayload.Create(payload);
 				}
@@ -1151,6 +1150,7 @@ namespace MySqlConnector.Core
 		static int s_lastId;
 		static byte[] s_connectionAttributes;
 		static readonly IMySqlConnectorLogger Log = MySqlConnectorLogManager.CreateLogger(nameof(ServerSession));
+		static readonly PayloadData s_setNamesUtf8mb4Payload = QueryPayload.Create("SET NAMES utf8mb4 COLLATE utf8mb4_bin;");
 
 		readonly object m_lock;
 		readonly object[] m_logArguments;

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -432,7 +432,12 @@ namespace MySql.Data.MySqlClient
 			{
 				var previousState = m_connectionState;
 				m_connectionState = newState;
-				OnStateChange(new StateChangeEventArgs(previousState, newState));
+				var eventArgs =
+					previousState == ConnectionState.Closed && newState == ConnectionState.Connecting ? s_stateChangeClosedConnecting :
+					previousState == ConnectionState.Connecting && newState == ConnectionState.Open ? s_stateChangeConnectingOpen :
+					previousState == ConnectionState.Open && newState == ConnectionState.Closed ? s_stateChangeOpenClosed :
+					new StateChangeEventArgs(previousState, newState);
+				OnStateChange(eventArgs);
 			}
 		}
 
@@ -497,6 +502,9 @@ namespace MySql.Data.MySqlClient
 		}
 
 		static readonly IMySqlConnectorLogger Log = MySqlConnectorLogManager.CreateLogger(nameof(MySqlConnection));
+		static readonly StateChangeEventArgs s_stateChangeClosedConnecting = new StateChangeEventArgs(ConnectionState.Closed, ConnectionState.Connecting);
+		static readonly StateChangeEventArgs s_stateChangeConnectingOpen = new StateChangeEventArgs(ConnectionState.Connecting, ConnectionState.Open);
+		static readonly StateChangeEventArgs s_stateChangeOpenClosed = new StateChangeEventArgs(ConnectionState.Open, ConnectionState.Closed);
 
 		string m_connectionString;
 		ConnectionSettings m_connectionSettings;

--- a/src/MySqlConnector/Protocol/Payloads/OkPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/OkPayload.cs
@@ -68,6 +68,14 @@ namespace MySqlConnector.Protocol.Payloads
 				// ignore human-readable string in both cases
 			}
 
+			if (affectedRowCount == 0 && lastInsertId == 0 && warningCount == 0 && newSchema == null)
+			{
+				if (serverStatus == ServerStatus.AutoCommit)
+					return s_autoCommitOk;
+				if (serverStatus == (ServerStatus.AutoCommit | ServerStatus.SessionStateChanged))
+					return s_autoCommitSessionStateChangedOk;
+			}
+
 			return new OkPayload(affectedRowCount, lastInsertId, serverStatus, warningCount, newSchema);
 		}
 
@@ -79,5 +87,8 @@ namespace MySqlConnector.Protocol.Payloads
 			WarningCount = warningCount;
 			NewSchema = newSchema;
 		}
+
+		static readonly OkPayload s_autoCommitOk = new OkPayload(0, 0, ServerStatus.AutoCommit, 0, null);
+		static readonly OkPayload s_autoCommitSessionStateChangedOk = new OkPayload(0, 0, ServerStatus.AutoCommit | ServerStatus.SessionStateChanged, 0, null);
 	}
 }

--- a/src/MySqlConnector/Protocol/Payloads/PingPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/PingPayload.cs
@@ -2,6 +2,6 @@ namespace MySqlConnector.Protocol.Payloads
 {
 	internal sealed class PingPayload
 	{
-		public static PayloadData Create() => new PayloadData(new[] { (byte) CommandKind.Ping });
+		public static PayloadData Instance { get; } = new PayloadData(new[] { (byte) CommandKind.Ping });
 	}
 }

--- a/src/MySqlConnector/Protocol/Payloads/QuitPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/QuitPayload.cs
@@ -2,6 +2,6 @@ namespace MySqlConnector.Protocol.Payloads
 {
 	internal sealed class QuitPayload
 	{
-		public static PayloadData Create() => new PayloadData(new[] { (byte) CommandKind.Quit });
+		public static PayloadData Instance { get; } = new PayloadData(new[] { (byte) CommandKind.Quit });
 	}
 }

--- a/src/MySqlConnector/Protocol/Payloads/ResetConnectionPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/ResetConnectionPayload.cs
@@ -2,6 +2,6 @@ namespace MySqlConnector.Protocol.Payloads
 {
 	internal sealed class ResetConnectionPayload
 	{
-		public static PayloadData Create() => new PayloadData(new[] { (byte) CommandKind.ResetConnection });
+		public static PayloadData Instance { get; } = new PayloadData(new[] { (byte) CommandKind.ResetConnection });
 	}
 }


### PR DESCRIPTION
```
BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.248)
Intel Xeon W-2155 CPU 3.30GHz, 1 CPU, 20 logical cores and 10 physical cores
Frequency=3234375 Hz, Resolution=309.1787 ns, Timer=TSC
  [Host]    : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  net47     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2633.0
  netcore20 : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
```

Connection String: `server=127.0.0.1;user id=mysqltest;password='test;key=\"val';database=hello_world;ssl mode=none;Default Command Timeout=0;Connection Timeout=0;Connection Reset=true`

## Before

Job | Runtime |     Toolchain |     Mean |    Error |   StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |-------- |-------------- |---------:|---------:|---------:|----------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
net47 |     Clr |   CsProjnet47 | 290.6 us | 2.295 us | 2.147 us | 0.5543 us | 286.2 us | 289.6 us | 290.3 us | 292.1 us | 294.2 us | 3,441.5 | 2.4414 |  16.18 KB |
netcore20 |    Core | .NET Core 2.0 | 161.2 us | 1.282 us | 1.200 us | 0.3097 us | 158.7 us | 160.1 us | 161.6 us | 161.8 us | 162.9 us | 6,202.7 | 1.7090 |   4.52 KB |

## After

Job | Runtime |     Toolchain |     Mean |    Error |   StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
---------- |-------- |-------------- |---------:|---------:|---------:|----------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
net47 |     Clr |   CsProjnet47 | 289.0 us | 2.312 us | 2.162 us | 0.5583 us | 286.2 us | 287.3 us | 288.7 us | 290.2 us | 293.4 us | 3,459.8 | 2.4414 |  15.06 KB |
netcore20 |    Core | .NET Core 2.0 | 163.1 us | 2.095 us | 1.959 us | 0.5059 us | 158.8 us | 162.3 us | 162.9 us | 164.7 us | 166.8 us | 6,130.2 | 1.7090 |   3.76 KB |

Memory usage is 93% of previous (.NET 4.7), 83% of previous (.NET Core).