### PR TITLE
Add a client parameter to specify SSL version(s).

### DIFF
--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -34,6 +34,7 @@ namespace MySqlConnector.Core
 
 			// SSL/TLS Options
 			SslMode = csb.SslMode;
+			SslProtocols = csb.SslProtocols;
 			CertificateFile = csb.CertificateFile;
 			CertificatePassword = csb.CertificatePassword;
 			CACertificateFile = csb.CACertificateFile;
@@ -84,6 +85,7 @@ namespace MySqlConnector.Core
 
 		// SSL/TLS Options
 		public MySqlSslMode SslMode { get; }
+		public System.Security.Authentication.SslProtocols SslProtocols { get; }
 		public string CertificateFile { get; }
 		public string CertificatePassword { get; }
 		public string CACertificateFile { get; }

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -425,6 +425,7 @@ namespace MySql.Data.MySqlClient
 		internal bool SslIsAuthenticated => m_session.SslIsAuthenticated;
 
 		internal bool SslIsMutuallyAuthenticated => m_session.SslIsMutuallyAuthenticated;
+		internal System.Security.Authentication.SslProtocols SslProtocol => m_session.SslProtocol;
 
 		internal void SetState(ConnectionState newState)
 		{

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
@@ -355,9 +355,16 @@ namespace MySql.Data.MySqlClient
 				keys: new[] { "SSL Mode", "SslMode" },
 				defaultValue: MySqlSslMode.Preferred));
 
+			var sslProtocolsDefault = System.Security.Authentication.SslProtocols.Tls |
+				 System.Security.Authentication.SslProtocols.Tls11;
+			if (!Utility.IsWindows())
+			{
+				sslProtocolsDefault |= System.Security.Authentication.SslProtocols.Tls12;
+			}
+
 			AddOption(SslProtocols = new MySqlConnectionStringOption<SslProtocols>(
 				keys: new[] { "SSL Protocols", "SslProtocols" },
-				defaultValue: System.Security.Authentication.SslProtocols.Tls | System.Security.Authentication.SslProtocols.Tls11));
+				defaultValue: sslProtocolsDefault));
 
 			AddOption(CertificateFile = new MySqlConnectionStringOption<string>(
 				keys: new[] { "CertificateFile", "Certificate File" },

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Globalization;
+using System.Security.Authentication;
 using MySqlConnector.Utilities;
 
 namespace MySql.Data.MySqlClient
@@ -59,6 +60,12 @@ namespace MySql.Data.MySqlClient
 		{
 			get => MySqlConnectionStringOption.SslMode.GetValue(this);
 			set => MySqlConnectionStringOption.SslMode.SetValue(this, value);
+		}
+
+		public SslProtocols SslProtocols
+		{
+			get => MySqlConnectionStringOption.SslProtocols.GetValue(this);
+			set => MySqlConnectionStringOption.SslProtocols.SetValue(this, value);
 		}
 
 		public string CertificateFile
@@ -262,6 +269,7 @@ namespace MySql.Data.MySqlClient
 
 		// SSL/TLS Options
 		public static readonly MySqlConnectionStringOption<MySqlSslMode> SslMode;
+		public static readonly MySqlConnectionStringOption<SslProtocols> SslProtocols;
 		public static readonly MySqlConnectionStringOption<string> CertificateFile;
 		public static readonly MySqlConnectionStringOption<string> CertificatePassword;
 		public static readonly MySqlConnectionStringOption<string> CACertificateFile;
@@ -346,6 +354,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(SslMode = new MySqlConnectionStringOption<MySqlSslMode>(
 				keys: new[] { "SSL Mode", "SslMode" },
 				defaultValue: MySqlSslMode.Preferred));
+
+			AddOption(SslProtocols = new MySqlConnectionStringOption<SslProtocols>(
+				keys: new[] { "SSL Protocols", "SslProtocols" },
+				defaultValue: System.Security.Authentication.SslProtocols.Tls | System.Security.Authentication.SslProtocols.Tls11));
 
 			AddOption(CertificateFile = new MySqlConnectionStringOption<string>(
 				keys: new[] { "CertificateFile", "Certificate File" },
@@ -501,6 +513,18 @@ namespace MySql.Data.MySqlClient
 						return (T) val;
 				}
 				throw new InvalidOperationException("Value '{0}' not supported for option '{1}'.".FormatInvariant(objectValue, typeof(T).Name));
+			}
+
+			if (typeof(T) == typeof(SslProtocols) && objectValue is string sslProtocolsString)
+			{
+				try
+				{
+					return (T) Enum.Parse(typeof(T), sslProtocolsString, true);
+				}
+				catch (Exception)
+				{
+					throw new InvalidOperationException("Value '{0}' not supported for option '{1}'.".FormatInvariant(objectValue, typeof(T).Name));
+				}
 			}
 
 			return (T) Convert.ChangeType(objectValue, typeof(T), CultureInfo.InvariantCulture);

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Authentication;
 using MySql.Data.MySqlClient;
 using Xunit;
 
@@ -82,6 +83,7 @@ namespace MySqlConnector.Tests
 					"allow public key retrieval = true;" +
 					"server rsa public key file=rsa.pem;" +
 					"load balance=random;" +
+					"ssl protocols = Tls11,Tls12;" +
 #endif
 					"Keep Alive=90;" +
 					"minpoolsize=5;" +
@@ -114,6 +116,7 @@ namespace MySqlConnector.Tests
 			Assert.True(csb.AllowPublicKeyRetrieval);
 			Assert.Equal("rsa.pem", csb.ServerRsaPublicKeyFile);
 			Assert.Equal(MySqlLoadBalance.Random, csb.LoadBalance);
+			Assert.Equal(SslProtocols.Tls11 | SslProtocols.Tls12, csb.SslProtocols);
 #endif
 			Assert.Equal(90u, csb.Keepalive);
 			Assert.Equal(15u, csb.MaximumPoolSize);

--- a/tests/SideBySide/SslTests.cs
+++ b/tests/SideBySide/SslTests.cs
@@ -37,6 +37,23 @@ namespace SideBySide
 			}
 		}
 
+#if !BASELINE
+		[SkippableFact(ConfigSettings.RequiresSsl)]
+		public async Task ConnectTls1_0()
+		{
+			var csb = AppConfig.CreateConnectionStringBuilder();
+			csb.SslMode = MySqlSslMode.Preferred;
+			csb.SslProtocols = System.Security.Authentication.SslProtocols.Tls;
+			csb.CertificateFile = null;
+			csb.CertificatePassword = null;
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+				await connection.OpenAsync();
+				Assert.True(csb.SslProtocols.HasFlag(connection.SslProtocol));
+			}
+		}
+#endif
+
 		[SkippableTheory(ConfigSettings.RequiresSsl | ConfigSettings.KnownClientCertificate)]
 		[InlineData("ssl-client.pfx", null, null)]
 		[InlineData("ssl-client-pw-test.pfx", "test", null)]


### PR DESCRIPTION
Prior to this patch, TLS1.2 was always disabled on Windows client, and
enabled elsewhere,  but this was not correct.

The ability to use TLS1.2 depends entirely on the way how *server* was
built.

If server was built with YASSL, TLS1.2 negotation would fail due to YaSSL
bug described here https://jira.mariadb.org/browse/MDEV-12190
(no graceful version downgrade)

If the server was built with OpenSSL, TLS1.2 negotiation would succeed,
or gracefully downgrades for older versions of OpenSSL.

FIX:
This patch allows users to specify the SSL version(s) in the connection
string with SslProtocols parameter. Default value for it,
which works with all versions of server, is TLS|TLS11.
User can overwrite it with e.g TLS12, if required.