### PR TITLE
Use the best TLS version by default

### DIFF
--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;use compression=true;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password",
+      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password,Tls12",
       "MySqlBulkLoaderLocalCsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.TSV",
       "CertificatesPath": "../../../../../.ci/server/certs"

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;UseCompression=true;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password",
+      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password,Tls12",
       "MySqlBulkLoaderLocalCsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=mysqltest;password='test;key=\"val';port=3306;database=mysqltest;ssl mode=none;Use Affected Rows=true;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password",
+      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password,Tls12",
       "MySqlBulkLoaderLocalCsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=127.0.0.1;user id=ssltest;password=test;port=3306;database=mysqltest;ssl mode=required;certificate file=../../../../../.ci/server/certs/ssl-client.pfx;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password",
+      "UnsupportedFeatures": "RsaEncryption,CachingSha2Password,Tls12",
       "MySqlBulkLoaderLocalCsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../TestData/LoadData_UTF8_BOM_Unix.TSV",
       "CertificatesPath": "../../../../../.ci/server/certs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ services: docker
 env:
   - IMAGE=mysql:5.6
     NAME=mysql
-    OMIT_FEATURES=Json,Sha256Password,RsaEncryption,LargePackets,CachingSha2Password,SessionTrack
+    OMIT_FEATURES=Json,Sha256Password,RsaEncryption,LargePackets,CachingSha2Password,SessionTrack,Tls11,Tls12
   - IMAGE=mysql:5.7
     NAME=mysql
-    OMIT_FEATURES=RsaEncryption,CachingSha2Password
+    OMIT_FEATURES=RsaEncryption,CachingSha2Password,Tls12
   - IMAGE=mysql:8.0
     NAME=mysql
     OMIT_FEATURES=None

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
@@ -16,6 +17,8 @@ namespace MySqlConnector.Core
 		public int Id { get; }
 
 		public ConnectionSettings ConnectionSettings { get; }
+
+		public SslProtocols SslProtocols { get; set; }
 
 		public async ValueTask<ServerSession> GetSessionAsync(MySqlConnection connection, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -411,6 +414,7 @@ namespace MySqlConnector.Core
 		private ConnectionPool(ConnectionSettings cs)
 		{
 			ConnectionSettings = cs;
+			SslProtocols = Utility.GetDefaultSslProtocols();
 			m_generation = 0;
 			m_cleanSemaphore = new SemaphoreSlim(1);
 			m_sessionSemaphore = new SemaphoreSlim(cs.MaximumPoolSize);

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Net.Sockets;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 using MySqlConnector.Core;
@@ -425,6 +426,8 @@ namespace MySql.Data.MySqlClient
 		internal bool SslIsAuthenticated => m_session.SslIsAuthenticated;
 
 		internal bool SslIsMutuallyAuthenticated => m_session.SslIsMutuallyAuthenticated;
+
+		internal SslProtocols SslProtocol => m_session.SslProtocol;
 
 		internal void SetState(ConnectionState newState)
 		{

--- a/tests/SideBySide/ServerFeatures.cs
+++ b/tests/SideBySide/ServerFeatures.cs
@@ -16,5 +16,7 @@ namespace SideBySide
 		Timeout = 128,
 		ErrorCodes = 256,
 		KnownCertificateAuthority = 512,
+		Tls11 = 1024,
+		Tls12 = 2048,
 	}
 }


### PR DESCRIPTION
Specifying `SslProtocols.None` allows the .NET Framework to choose the best TLS version supported by the OS (on .NET 4.7 and later).

However, negotiating TLS 1.2 with a Windows Schannel client against a yaSSL-based MySQL Server will fail (see #101); automatically try with a lower TLS version if it's possible we're in this scenario.

This replaces #450, which moved specifying the TLS version into a connection string setting. In this PR, the library tries to do the best thing possible, at the cost (for Windows clients only) of extra TLS connection time for MySQL < 8.0 and/or .NET Framework < 4.7.