### PR TITLE
Add ConnectionIdlePingTime setting

### DIFF
--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -118,6 +118,19 @@ Connection pooling is enabled by default. These options are used to configure it
     <td>If <code>true</code>, the connection state is reset when it is retrieved from the pool. The default value of <code>true</code> ensures that the connection is in the same state whether it's newly created or retrieved from the pool. A value of <code>false</code> avoids making an additional server round trip when obtaining a connection, but the connection state is not reset, meaning that session variables and other session state changes from any previous use of the connection are carried over.</td>
   </tr>
   <tr>
+    <td>Connection Idle Ping Time, Connection Idle Ping Time <em>(Experimental)</em></td>
+    <td>0</td>
+    <td>When a connection is retrieved from the pool, and <code>ConnectionReset</code> is <code>false</code>, the server
+      will be pinged if the connection has been idle in the pool for longer than <code>ConnectionIdlePingTime</code> seconds.
+      If pinging the server fails, a new connection will be opened automatically by the connection pool. This ensures that the
+      <code>MySqlConnection</code> is in a valid, open state after the call to <code>Open</code>/<code>OpenAsync</code>,
+      at the cost of an extra server roundtrip. For high-performance scenarios, you may wish to set <code>ConnectionIdlePingTime</code>
+      to a non-zero value to make the connection pool assume that recently-returned connections are still open. If the
+      connection is broken, it will throw from the first call to <code>ExecuteNonQuery</code>, <code>ExecuteReader</code>,
+      etc.; your code should handle that failure and retry the connection. This option has no effect if <code>ConnectionReset</code>
+      is <code>true</code>, as that will cause a connection reset packet to be sent to the server, making ping redundant.
+  </tr>
+  <tr>
     <td>Connection Idle Timeout, ConnectionIdleTimeout</td>
     <td>180</td>
     <td>The amount of time (in seconds) that a connection can remain idle in the pool. Any connection above <code>MinimumPoolSize</code> connections that is idle for longer than <code>ConnectionIdleTimeout</code> is subject to being closed by a background task. The background task runs every minute, or half of <code>ConnectionIdleTimeout</code>, whichever is more frequent. A value of zero (0) means pooled connections will never incur a ConnectionIdleTimeout, and if the pool grows to its maximum size, it will never get smaller.</td>

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -68,9 +68,13 @@ namespace MySqlConnector.Core
 						{
 							reuseSession = await session.TryResetConnectionAsync(ConnectionSettings, ioBehavior, cancellationToken).ConfigureAwait(false);
 						}
-						else
+						else if ((unchecked((uint) Environment.TickCount) - session.LastReturnedTicks) > ConnectionSettings.ConnectionIdlePingTime)
 						{
 							reuseSession = await session.TryPingAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
+						}
+						else
+						{
+							reuseSession = true;
 						}
 					}
 

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -42,6 +42,7 @@ namespace MySqlConnector.Core
 			Pooling = csb.Pooling;
 			ConnectionLifeTime = Math.Min(csb.ConnectionLifeTime, uint.MaxValue / 1000) * 1000;
 			ConnectionReset = csb.ConnectionReset;
+			ConnectionIdlePingTime = Math.Min(csb.ConnectionIdlePingTime, uint.MaxValue / 1000) * 1000;
 			ConnectionIdleTimeout = (int)csb.ConnectionIdleTimeout;
 			if (csb.MinimumPoolSize > csb.MaximumPoolSize)
 				throw new MySqlException("MaximumPoolSize must be greater than or equal to MinimumPoolSize");
@@ -92,6 +93,7 @@ namespace MySqlConnector.Core
 		public bool Pooling { get; }
 		public uint ConnectionLifeTime { get; }
 		public bool ConnectionReset { get; }
+		public uint ConnectionIdlePingTime { get; }
 		public int ConnectionIdleTimeout { get; }
 		public int MinimumPoolSize { get; }
 		public int MaximumPoolSize { get; }

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
@@ -98,6 +98,12 @@ namespace MySql.Data.MySqlClient
 			set => MySqlConnectionStringOption.ConnectionReset.SetValue(this, value);
 		}
 
+		public uint ConnectionIdlePingTime
+		{
+			get => MySqlConnectionStringOption.ConnectionIdlePingTime.GetValue(this);
+			set => MySqlConnectionStringOption.ConnectionIdlePingTime.SetValue(this, value);
+		}
+
 		public uint ConnectionIdleTimeout
 		{
 			get => MySqlConnectionStringOption.ConnectionIdleTimeout.GetValue(this);
@@ -270,6 +276,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> Pooling;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionLifeTime;
 		public static readonly MySqlConnectionStringOption<bool> ConnectionReset;
+		public static readonly MySqlConnectionStringOption<uint> ConnectionIdlePingTime;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionIdleTimeout;
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
@@ -371,6 +378,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(ConnectionReset = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Connection Reset", "ConnectionReset" },
 				defaultValue: true));
+
+			AddOption(ConnectionIdlePingTime = new MySqlConnectionStringOption<uint>(
+				keys: new[] { "Connection Idle Ping Time", "ConnectionIdlePingTime" },
+				defaultValue: 0));
 
 			AddOption(ConnectionIdleTimeout = new MySqlConnectionStringOption<uint>(
 				keys: new[] { "Connection Idle Timeout", "ConnectionIdleTimeout" },

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -29,6 +29,7 @@ namespace MySqlConnector.Tests
 			Assert.Equal("", csb.Database);
 			Assert.Equal(30u, csb.DefaultCommandTimeout);
 #if !BASELINE
+			Assert.Equal(0u, csb.ConnectionIdlePingTime);
 			Assert.Equal(180u, csb.ConnectionIdleTimeout);
 			Assert.False(csb.ForceSynchronous);
 			Assert.Null(csb.CACertificateFile);
@@ -76,6 +77,7 @@ namespace MySqlConnector.Tests
 					"Convert Zero Datetime=true;" +
 					"default command timeout=123;" +
 #if !BASELINE
+					"connection idle ping time=60;" +
 					"connectionidletimeout=30;" +
 					"forcesynchronous=true;" +
 					"ca certificate file=ca.pem;" +
@@ -108,6 +110,7 @@ namespace MySqlConnector.Tests
 			Assert.Equal("schema_name", csb.Database);
 			Assert.Equal(123u, csb.DefaultCommandTimeout);
 #if !BASELINE
+			Assert.Equal(60u, csb.ConnectionIdlePingTime);
 			Assert.Equal(30u, csb.ConnectionIdleTimeout);
 			Assert.True(csb.ForceSynchronous);
 			Assert.Equal("ca.pem", csb.CACertificateFile);


### PR DESCRIPTION
This allows clients to opt-out of pinging the server when a connection is retrieved from the pool, if it's been idle less than a certain amount of time. This removes a probably-unnecessary roundtrip to the server on recently-returned connections, which can improve throughput under heavy load.

### Before

Job | Runtime |     Toolchain |     Mean |     Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |
    Op/s |  Gen 0 | Allocated |
---------- |-------- |-------------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
net47 |     Clr |   CsProjnet47 | 184.6 us | 3.5489 us | 3.3197 us | 0.8571 us | 178.0 us | 181.9 us | 184.9 us | 186.5 us | 191.3 us | 5,416.6 | 1.7090 |  11.84 KB |
netcore20 |    Core | .NET Core 2.0 | 157.1 us | 0.7065 us | 0.6263 us | 0.1674 us | 156.0 us | 156.7 us | 157.1 us | 157.5 us | 158.4 us | 6,363.6 | 1.2207 |   3.13 KB |

### After 
 
Job | Runtime |     Toolchain |      Mean |     Error |    StdDev |    StdErr |       Min |        Q1 |    Median |        Q3 |
 Max |     Op/s |  Gen 0 | Allocated |
---------- |-------- |-------------- |----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|---------:|-------:|----------:|
net47 |     Clr |   CsProjnet47 | 115.20 us | 0.9376 us | 0.8771 us | 0.2265 us | 113.87 us | 114.69 us | 114.85 us | 115.97 us | 116.55 us |  8,680.5 | 1.0986 |    7.6 KB |
netcore20 |    Core | .NET Core 2.0 |  91.13 us | 0.4125 us | 0.3858 us | 0.0996 us |  90.56 us |  90.66 us |  91.21 us |  91.39 us |  91.83 us | 10,973.0 | 0.9766 |   5.03 KB |
 
 CC @sebastienros 