### PR TITLE
Add Serilog logging adapter. Fixes #463.

### DIFF
--- a/MySqlConnector.sln
+++ b/MySqlConnector.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.log4
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.Microsoft.Extensions.Logging", "src\MySqlConnector.Logging.Microsoft.Extensions.Logging\MySqlConnector.Logging.Microsoft.Extensions.Logging.csproj", "{6A3F1732-F874-463E-9BB8-21690E7B8ED0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.Serilog", "src\MySqlConnector.Logging.Serilog\MySqlConnector.Logging.Serilog.csproj", "{38806B85-6526-4A81-9905-45D3411B0AE2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{6A3F1732-F874-463E-9BB8-21690E7B8ED0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6A3F1732-F874-463E-9BB8-21690E7B8ED0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6A3F1732-F874-463E-9BB8-21690E7B8ED0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{38806B85-6526-4A81-9905-45D3411B0AE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38806B85-6526-4A81-9905-45D3411B0AE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38806B85-6526-4A81-9905-45D3411B0AE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38806B85-6526-4A81-9905-45D3411B0AE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MySqlConnector.Logging.Serilog/MySqlConnector.Logging.Serilog.csproj
+++ b/src/MySqlConnector.Logging.Serilog/MySqlConnector.Logging.Serilog.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <Title>MySqlConnector Logging Adapter for Serilog</Title>
+    <Description>Writes lightly-structured MySqlConnector logging output to Serilog.</Description>
+    <Copyright>Copyright 2017 Bradley Grainger</Copyright>
+    <Authors>Marc Lewandowski</Authors>
+    <PackageTags>mysql;mysqlconnector;async;ado.net;database;netcore;serilog;logging</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MySqlConnector\MySqlConnector.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
+++ b/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Serilog;
+using Serilog.Events;
+
+namespace MySqlConnector.Logging
+{
+    public sealed class SerilogLoggerProvider : IMySqlConnectorLoggerProvider
+    {
+        public SerilogLoggerProvider(bool attemptProperties) => m_attemptProperties = attemptProperties;
+
+        public IMySqlConnectorLogger CreateLogger(string name)
+        {
+            return new SerilogLogger(name, m_attemptProperties);
+        }
+
+        private class SerilogLogger : IMySqlConnectorLogger
+        {
+            public SerilogLogger(string name, bool attemptProperties)
+            {
+                m_name = name;
+                m_logger = Serilog.Log.ForContext("SourceContext", "MySqlConnector." + name);
+                m_attemptProperties = attemptProperties;
+            }
+
+            public bool IsEnabled(MySqlConnectorLogLevel level) => m_logger.IsEnabled(GetLevel(level));
+
+            public void Log(MySqlConnectorLogLevel level, string message, object[] args = null, Exception exception = null)
+            {
+                if (args == null || args.Length == 0)
+                    m_logger.Write(GetLevel(level), exception, message);
+                else
+                {
+                    // rewrite message as template
+                    var template = tokenReplacer.Replace(message, $"{{{m_name}A$1}}");
+                    m_logger.Write(GetLevel(level), exception, template, args);
+                }
+            }
+
+            private static LogEventLevel GetLevel(MySqlConnectorLogLevel level)
+            {
+                switch (level)
+                {
+                    case MySqlConnectorLogLevel.Trace:
+                        return LogEventLevel.Verbose;
+                    case MySqlConnectorLogLevel.Debug:
+                        return LogEventLevel.Debug;
+                    case MySqlConnectorLogLevel.Info:
+                        return LogEventLevel.Information;
+                    case MySqlConnectorLogLevel.Warn:
+                        return LogEventLevel.Warning;
+                    case MySqlConnectorLogLevel.Error:
+                        return LogEventLevel.Error;
+                    case MySqlConnectorLogLevel.Fatal:
+                        return LogEventLevel.Fatal;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(level), level, "Invalid value for 'level'.");
+                }
+            }
+
+            static readonly Regex tokenReplacer = new Regex(@"\{(\d+)\}", RegexOptions.Compiled);
+            
+            readonly ILogger m_logger;
+            readonly bool m_attemptProperties;
+            readonly string m_name;
+        }
+
+        readonly bool m_attemptProperties;
+    }
+}

--- a/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
+++ b/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.RegularExpressions;
 using Serilog;
 using Serilog.Events;
@@ -7,20 +7,19 @@ namespace MySqlConnector.Logging
 {
     public sealed class SerilogLoggerProvider : IMySqlConnectorLoggerProvider
     {
-        public SerilogLoggerProvider(bool attemptProperties) => m_attemptProperties = attemptProperties;
+		public SerilogLoggerProvider() { }
 
         public IMySqlConnectorLogger CreateLogger(string name)
         {
-            return new SerilogLogger(name, m_attemptProperties);
+            return new SerilogLogger(name);
         }
 
         private class SerilogLogger : IMySqlConnectorLogger
         {
-            public SerilogLogger(string name, bool attemptProperties)
+            public SerilogLogger(string name)
             {
                 m_name = name;
                 m_logger = Serilog.Log.ForContext("SourceContext", "MySqlConnector." + name);
-                m_attemptProperties = attemptProperties;
             }
 
             public bool IsEnabled(MySqlConnectorLogLevel level) => m_logger.IsEnabled(GetLevel(level));
@@ -61,10 +60,8 @@ namespace MySqlConnector.Logging
             static readonly Regex tokenReplacer = new Regex(@"\{(\d+)\}", RegexOptions.Compiled);
             
             readonly ILogger m_logger;
-            readonly bool m_attemptProperties;
             readonly string m_name;
         }
 
-        readonly bool m_attemptProperties;
     }
 }

--- a/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
+++ b/src/MySqlConnector.Logging.Serilog/SerilogLoggerProvider.cs
@@ -30,9 +30,9 @@ namespace MySqlConnector.Logging
                     m_logger.Write(GetLevel(level), exception, message);
                 else
                 {
-                    // rewrite message as template
-                    var template = tokenReplacer.Replace(message, $"{{{m_name}A$1}}");
-                    m_logger.Write(GetLevel(level), exception, template, args);
+					// rewrite message as template
+					var template = tokenReplacer.Replace(message, "$1{MySql$2$3}$4");
+					m_logger.Write(GetLevel(level), exception, template, args);
                 }
             }
 
@@ -57,9 +57,9 @@ namespace MySqlConnector.Logging
                 }
             }
 
-            static readonly Regex tokenReplacer = new Regex(@"\{(\d+)\}", RegexOptions.Compiled);
-            
-            readonly ILogger m_logger;
+			static readonly Regex tokenReplacer = new Regex(@"((\w+)?\s?(?:=|:)?\s?'?)\{(?:\d+)(\:\w+)?\}('?)", RegexOptions.Compiled);
+
+			readonly ILogger m_logger;
             readonly string m_name;
         }
 

--- a/src/MySqlConnector/Core/TextCommandExecutor.cs
+++ b/src/MySqlConnector/Core/TextCommandExecutor.cs
@@ -61,7 +61,7 @@ namespace MySqlConnector.Core
 		{
 			cancellationToken.ThrowIfCancellationRequested();
 			if (Log.IsDebugEnabled())
-				Log.Debug("Session{0} Execute{1}: {2}", m_command.Connection.Session.Id, ioBehavior == IOBehavior.Asynchronous ? "Async" : "", commandText);
+				Log.Debug("Session{0} ExecuteBehavior {1} CommandText: {2}", m_command.Connection.Session.Id, ioBehavior, commandText);
 			var payload = CreateQueryPayload(commandText, parameterCollection);
 			using (m_command.RegisterCancel(cancellationToken))
 			{


### PR DESCRIPTION
Adds "light" structuring to the messages, transforming them into Serilog templates by concatenating the logger name and argument index, and lets Serilog use the arguments as Properties.

**This is not ideal.** This method loses the identity of a Property between classes, so it undercuts filtering or relating events between classes by the common Property. E.g., Session ID will have the same value but different names across `TextCommandExecutor`, `ServerSession` and `ConnectionPool`.

This could be overcome by hand-creating a map from name-index to Property-name. That seems pretty fragile, though.

Is the trade-off worth it? Are the argument lists relatively static? Could there be a way to "signal" changes so the Serilog adapter could be automatically update? Any better ideas?

Also, there's no automated tests for this. However, that's the same as the other adapters and it is very straightforward.