### PR TITLE
NLogLoggerProvider - NLog 4.5.0 with NetStandard Support

### DIFF
--- a/MySqlConnector.sln
+++ b/MySqlConnector.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.Micr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.Serilog", "src\MySqlConnector.Logging.Serilog\MySqlConnector.Logging.Serilog.csproj", "{38806B85-6526-4A81-9905-45D3411B0AE2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MySqlConnector.Logging.NLog", "src\MySqlConnector.Logging.NLog\MySqlConnector.Logging.NLog.csproj", "{92015BEE-563A-4595-9243-0510D2B8767F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{38806B85-6526-4A81-9905-45D3411B0AE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38806B85-6526-4A81-9905-45D3411B0AE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{38806B85-6526-4A81-9905-45D3411B0AE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92015BEE-563A-4595-9243-0510D2B8767F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92015BEE-563A-4595-9243-0510D2B8767F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92015BEE-563A-4595-9243-0510D2B8767F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92015BEE-563A-4595-9243-0510D2B8767F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MySqlConnector.Logging.NLog/MySqlConnector.Logging.NLog.csproj
+++ b/src/MySqlConnector.Logging.NLog/MySqlConnector.Logging.NLog.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <Title>MySqlConnector Logging Adapter for NLog</Title>
+    <Description>Writes lightly-structured MySqlConnector logging output to NLog.</Description>
+    <Copyright>Copyright 2017 Bradley Grainger</Copyright>
+    <Authors>Bradley Grainger</Authors>
+    <PackageTags>mysql;mysqlconnector;async;ado.net;database;netcore;NLog;logging</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MySqlConnector\MySqlConnector.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/MySqlConnector.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/MySqlConnector.Logging.NLog/NLogLoggerProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Globalization;
+using NLog;
+
+namespace MySqlConnector.Logging
+{
+	public sealed class NLogLoggerProvider : IMySqlConnectorLoggerProvider
+	{
+		public IMySqlConnectorLogger CreateLogger(string name) => new NLogLogger(LogManager.GetLogger("MySqlConnector." + name));
+
+		static readonly Type s_loggerType = typeof(NLogLogger);
+
+		private class NLogLogger : IMySqlConnectorLogger
+		{
+			public NLogLogger(Logger logger) => m_logger = logger;
+
+			public bool IsEnabled(MySqlConnectorLogLevel level) => m_logger.IsEnabled(GetLevel(level));
+
+			public void Log(MySqlConnectorLogLevel level, string message, object[] args = null, Exception exception = null)
+			{
+				LogLevel logLevel = GetLevel(level);
+				if (m_logger.IsEnabled(logLevel))
+				{
+					m_logger.Log(s_loggerType, LogEventInfo.Create(logLevel, m_logger.Name, exception, CultureInfo.InvariantCulture, message, args));
+				}
+			}
+
+			private static LogLevel GetLevel(MySqlConnectorLogLevel level)
+			{
+				switch (level)
+				{
+				case MySqlConnectorLogLevel.Trace:
+					return LogLevel.Trace;
+				case MySqlConnectorLogLevel.Debug:
+					return LogLevel.Debug;
+				case MySqlConnectorLogLevel.Info:
+					return LogLevel.Info;
+				case MySqlConnectorLogLevel.Warn:
+					return LogLevel.Warn;
+				case MySqlConnectorLogLevel.Error:
+					return LogLevel.Error;
+				case MySqlConnectorLogLevel.Fatal:
+					return LogLevel.Fatal;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(level), level, "Invalid value for 'level'.");
+				}
+			}
+
+			readonly Logger m_logger;
+		}
+	}
+}


### PR DESCRIPTION
NLog 4.5.0 supports structured logging like Serilog, but not sure if it is a good idea to repeat its search-replace logic for nicer property-names.

Right now it works just like the log4net provider.