### PR TITLE
Optimise reset connection

### DIFF
--- a/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
@@ -23,6 +23,8 @@ namespace MySqlConnector.Protocol.Serialization
 			m_sequenceNumber = 0;
 		}
 
+		public void SetNextSequenceNumber(int sequenceNumber) => m_sequenceNumber = sequenceNumber;
+
 		public IByteHandler ByteHandler
 		{
 			get => m_byteHandler;


### PR DESCRIPTION
Send the reset connection packet and the follow-up `SET NAMES` query at once, reducing the number of server round trips. This is about 1.5× to 2× faster (for the default behaviour of `ConnectionReset=true`).

### Before

Method |       Job | Runtime |     Toolchain |     Mean |     Error |    StdDev |   StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
------------------ |---------- |-------- |-------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
 OpenFromPoolAsync |     net47 |     Clr |   CsProjnet47 | 799.5 us | 17.277 us | 31.592 us | 4.875 us | 756.5 us | 773.5 us | 793.3 us | 814.2 us | 887.9 us | 1,250.8 | 0.9766 |    8295 B |
  OpenFromPoolSync |     net47 |     Clr |   CsProjnet47 | 434.5 us |  7.980 us |  6.664 us | 1.848 us | 423.2 us | 429.2 us | 435.6 us | 438.3 us | 447.8 us | 2,301.3 |      - |     668 B |
 OpenFromPoolAsync | netcore20 |    Core | .NET Core 2.0 | 451.7 us |  8.873 us | 12.439 us | 2.394 us | 427.0 us | 443.4 us | 451.7 us | 458.3 us | 479.4 us | 2,213.6 |      - |    3470 B |
  OpenFromPoolSync | netcore20 |    Core | .NET Core 2.0 | 470.6 us |  9.321 us | 15.574 us | 2.596 us | 440.2 us | 459.5 us | 467.0 us | 480.1 us | 504.9 us | 2,125.1 |      - |     640 B |

### After

Method |       Job | Runtime |     Toolchain |     Mean |    Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |    Op/s |  Gen 0 | Allocated |
------------------ |---------- |-------- |-------------- |---------:|---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
 OpenFromPoolAsync |     net47 |     Clr |   CsProjnet47 | 368.7 us | 7.322 us | 17.822 us | 2.1302 us | 334.7 us | 353.8 us | 369.5 us | 379.1 us | 414.3 us | 2,712.4 | 0.4883 |    6292 B |
  OpenFromPoolSync |     net47 |     Clr |   CsProjnet47 | 279.9 us | 4.240 us |  3.541 us | 0.9820 us | 276.1 us | 277.1 us | 279.0 us | 281.9 us | 288.6 us | 3,572.3 |      - |     668 B |
 OpenFromPoolAsync | netcore20 |    Core | .NET Core 2.0 | 342.1 us | 7.034 us | 12.502 us | 1.9768 us | 317.4 us | 334.3 us | 342.1 us | 348.7 us | 372.0 us | 2,923.4 | 0.4883 |    3479 B |
  OpenFromPoolSync | netcore20 |    Core | .NET Core 2.0 | 284.0 us | 6.408 us | 10.706 us | 1.7844 us | 270.7 us | 275.7 us | 280.5 us | 292.2 us | 318.3 us | 3,520.5 |      - |     640 B |