### PR TITLE
Update performance tests to netcoreapp2.1

### DIFF
--- a/tests/MySqlConnector.Performance/AppConfig.cs
+++ b/tests/MySqlConnector.Performance/AppConfig.cs
@@ -1,14 +1,18 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 namespace MySqlConnector.Performance
 {
 	public static class AppConfig
 	{
-		public static IConfigurationRoot Config = new ConfigurationBuilder()
-			.SetBasePath(Directory.GetCurrentDirectory())
+		public static IConfigurationRoot Config => LazyConfig.Value;
+
+		private static readonly Lazy<IConfigurationRoot> LazyConfig = new Lazy<IConfigurationRoot>(() => new ConfigurationBuilder()
+			.SetBasePath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location))
 			.AddJsonFile("appsettings.json")
 			.AddJsonFile("config.json")
-			.Build();
+			.Build());
 	}
 }

--- a/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
+++ b/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MySqlConnector.Performance</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -12,16 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0-*" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0-*" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' != 'Baseline' ">
@@ -29,10 +20,19 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(Configuration)' == 'Baseline' ">
-    <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
+    <PackageReference Include="MySql.Data" Version="8.0.11" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Baseline' ">
     <DefineConstants>BASELINE</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/tests/MySqlConnector.Performance/Program.cs
+++ b/tests/MySqlConnector.Performance/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using MySqlConnector.Performance.Commands;
 
@@ -11,17 +12,20 @@ namespace MySqlConnector.Performance
 			AppDb.Initialize();
 			if (args.Length == 0)
 			{
-				var host = new WebHostBuilder()
-					.UseUrls("http://*:5000")
-					.UseKestrel()
-					.UseStartup<Startup>()
-					.Build();
-				host.Run();
+				BuildWebHost(args).Run();
 			}
 			else
 			{
 				Environment.Exit(CommandRunner.Run(args));
 			}
+		}
+
+		public static IWebHost BuildWebHost(string[] args)
+		{
+			return WebHost.CreateDefaultBuilder(args)
+				.UseUrls("http://*:5000")
+				.UseStartup<Startup>()
+				.Build();
 		}
 	}
 }


### PR DESCRIPTION
I will update the [Concurrency Benchmark Results](https://github.com/mysql-net/MySqlConnector/wiki/Concurrency-Benchmark-Results) with the newest versions of `MySqlConnector` and `MySql.Data` on .NET Core 2.1 after merging