### PR TITLE
Change MySqlConnector.Performance SDK to Microsoft.NET.Sdk.Web

### DIFF
--- a/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
+++ b/tests/MySqlConnector.Performance/MySqlConnector.Performance.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -27,12 +27,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="config.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <AppConfig Include="appsettings.json" />
+    <AppConfig Include="config.json" />
   </ItemGroup>
+
+  <Target Name="CopyDirsAfterBuild" AfterTargets="Build">
+    <Copy 
+      SourceFiles="@(AppConfig)" 
+      DestinationFolder="$(OutDir)\%(RecursiveDir)" 
+      SkipUnchangedFiles="true" 
+      OverwriteReadOnlyFiles="true" 
+      Retries="3"
+      RetryDelayMilliseconds="300"/>
+  </Target>
+  <Target Name="CopyDirsAfterPublish" AfterTargets="Publish">
+    <Copy 
+      SourceFiles="@(AppConfig)" 
+      DestinationFolder="$(PublishDir)\%(RecursiveDir)" 
+      SkipUnchangedFiles="true" 
+      OverwriteReadOnlyFiles="true" 
+      Retries="3"
+      RetryDelayMilliseconds="300"/>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Here is another fun issue in .NET Core 2.1: https://github.com/aspnet/Mvc/issues/7882#issuecomment-395880248

Apparently since this now references `Microsoft.AspNetCore.All`, we are supposed to use `<Project Sdk="Microsoft.NET.Sdk.Web">`.  However, the following MSBuild Task does not work in `<Project Sdk="Microsoft.NET.Sdk.Web">`:

```
  <ItemGroup>
    <None Update="appsettings.json">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
    <None Update="config.json">
      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
    </None>
  </ItemGroup>
```

This MSBuild Task _does_ work in `<Project Sdk="Microsoft.NET.Sdk">`, which is why I initially changed the project SDK.  Our `MySqlConnector.Performance` project seems to work fine with either Project SDK, but a similar project in Pomelo had it's routes stopped working with `<Project Sdk="Microsoft.NET.Sdk">` and required the change to `<Project Sdk="Microsoft.NET.Sdk.Web">`

In the interest of following Microsoft's migration notes, I've changed `MySqlConnector.Performance` to use `<Project Sdk="Microsoft.NET.Sdk.Web">`, and I've added a different msbuild task that accomplishes the same output as the `<CopyToOutputDirectory>` task.