### PR TITLE
Support auth_gssapi authentication.

### DIFF
--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -79,6 +79,7 @@ namespace MySqlConnector.Core
 			Keepalive = csb.Keepalive;
 			PersistSecurityInfo = csb.PersistSecurityInfo;
 			ServerRsaPublicKeyFile = csb.ServerRsaPublicKeyFile;
+			ServerSPN = csb.ServerSPN;
 			TreatTinyAsBoolean = csb.TreatTinyAsBoolean;
 			UseAffectedRows = csb.UseAffectedRows;
 			UseCompression = csb.UseCompression;
@@ -157,6 +158,7 @@ namespace MySqlConnector.Core
 		public uint Keepalive { get; }
 		public bool PersistSecurityInfo { get; }
 		public string ServerRsaPublicKeyFile { get; }
+		public string ServerSPN { get; }
 		public bool TreatTinyAsBoolean { get; }
 		public bool UseAffectedRows { get; }
 		public bool UseCompression { get; }

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -501,7 +501,7 @@ namespace MySqlConnector.Core
 				}
 
 			case "auth_gssapi_client":
-				return await AuthGSSAPI.AuthenticateAsync(switchRequest.Data, this, ioBehavior, cancellationToken).ConfigureAwait(false);
+				return await AuthGSSAPI.AuthenticateAsync(cs, switchRequest.Data, this, ioBehavior, cancellationToken).ConfigureAwait(false);
 
 			case "mysql_old_password":
 				Log.Error("Session{0} is requesting AuthenticationMethod '{1}' which is not supported", m_logArguments);

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -500,6 +500,9 @@ namespace MySqlConnector.Core
 					return await SendClearPasswordAsync(cs, ioBehavior, cancellationToken).ConfigureAwait(false);
 				}
 
+			case "auth_gssapi_client":
+				return await AuthGSSAPI.AuthenticateAsync(switchRequest.Data, this, ioBehavior, cancellationToken).ConfigureAwait(false);
+
 			case "mysql_old_password":
 				Log.Error("Session{0} is requesting AuthenticationMethod '{1}' which is not supported", m_logArguments);
 				throw new NotSupportedException("'MySQL Server is requesting the insecure pre-4.1 auth mechanism (mysql_old_password). The user password must be upgraded; see https://dev.mysql.com/doc/refman/5.7/en/account-upgrades.html.");

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnectionStringBuilder.cs
@@ -261,6 +261,12 @@ namespace MySql.Data.MySqlClient
 			set => MySqlConnectionStringOption.ServerRsaPublicKeyFile.SetValue(this, value);
 		}
 
+		public string ServerSPN
+		{
+			get => MySqlConnectionStringOption.ServerSPN.GetValue(this);
+			set => MySqlConnectionStringOption.ServerSPN.SetValue(this, value);
+		}
+
 		public bool TreatTinyAsBoolean
 		{
 			get => MySqlConnectionStringOption.TreatTinyAsBoolean.GetValue(this);
@@ -371,6 +377,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> OldGuids;
 		public static readonly MySqlConnectionStringOption<bool> PersistSecurityInfo;
 		public static readonly MySqlConnectionStringOption<string> ServerRsaPublicKeyFile;
+		public static readonly MySqlConnectionStringOption<string> ServerSPN;
 		public static readonly MySqlConnectionStringOption<bool> TreatTinyAsBoolean;
 		public static readonly MySqlConnectionStringOption<bool> UseAffectedRows;
 		public static readonly MySqlConnectionStringOption<bool> UseCompression;
@@ -563,6 +570,10 @@ namespace MySql.Data.MySqlClient
 
 			AddOption(ServerRsaPublicKeyFile = new MySqlConnectionStringOption<string>(
 				keys: new[] { "ServerRSAPublicKeyFile", "Server RSA Public Key File" },
+				defaultValue: null));
+
+			AddOption(ServerSPN = new MySqlConnectionStringOption<string>(
+				keys: new[] { "Server SPN", "ServerSPN" },
 				defaultValue: null));
 
 			AddOption(TreatTinyAsBoolean = new MySqlConnectionStringOption<bool>(

--- a/src/MySqlConnector/Protocol/Serialization/AuthGSSAPI.cs
+++ b/src/MySqlConnector/Protocol/Serialization/AuthGSSAPI.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -216,13 +217,13 @@ namespace MySqlConnector.Protocol.Serialization
 			var reader = new ByteArrayReader(switchRequest.AsSpan());
 			return Encoding.UTF8.GetString(reader.ReadNullOrEofTerminatedByteString());
 		}
-		public static async Task<PayloadData> AuthenticateAsync(byte[] switchRequestPayloadData,
+		public static async Task<PayloadData> AuthenticateAsync(ConnectionSettings cs, byte[] switchRequestPayloadData,
 			ServerSession session, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
 			using (var innerStream = new NegotiateToMySqlConverterStream(session, ioBehavior, cancellationToken))
 			using (var negotiateStream = new NegotiateStream(innerStream))
 			{
-				var targetName = GetServicePrincipalName(switchRequestPayloadData);
+				var targetName =cs.ServerSPN ?? GetServicePrincipalName(switchRequestPayloadData);
 #if NETSTANDARD1_3
 				await negotiateStream.AuthenticateAsClientAsync(CredentialCache.DefaultNetworkCredentials, targetName).ConfigureAwait(false);
 #else
@@ -235,6 +236,13 @@ namespace MySqlConnector.Protocol.Serialization
 					await negotiateStream.AuthenticateAsClientAsync(CredentialCache.DefaultNetworkCredentials, targetName).ConfigureAwait(false);
 				}
 #endif
+				if (cs.ServerSPN != null && !negotiateStream.IsMutuallyAuthenticated)
+				{
+					// Negotiate used NTLM fallback, server name cannot be verified.
+					throw new AuthenticationException(String.Format(
+						"GSSAPI : Unable to verify server principal name using authentication type {0}",
+						negotiateStream.RemoteIdentity?.AuthenticationType));
+				}
 				if (innerStream.MySQLProtocolPayload.ArraySegment.Array != null)
 					// return already pre-read OK packet.
 					return innerStream.MySQLProtocolPayload;

--- a/src/MySqlConnector/Protocol/Serialization/AuthGSSAPI.cs
+++ b/src/MySqlConnector/Protocol/Serialization/AuthGSSAPI.cs
@@ -1,0 +1,237 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector.Core;
+using MySqlConnector.Utilities;
+
+namespace MySqlConnector.Protocol.Serialization
+{
+	internal class NegotiateStreamConstants
+	{
+		public const int HeaderLength = 5;
+		public const byte MajorVersion = 1;
+		public const byte MinorVersion = 0;
+		public const byte HandshakeDone = 0x14;
+		public const byte HandshakeError = 0x15;
+		public const byte HandshakeInProgress = 0x16;
+		public const ushort MaxPayloadLength = ushort.MaxValue;
+	}
+
+	/// <summary>
+	/// Helper class to translate NegotiateStream framing for SPNEGO token
+	/// into MySQL protocol packets.
+	///
+	/// Serves as underlying stream for System.Net.NegotiateStream
+	/// to perform MariaDB's auth_gssapi_client authentication.
+	///
+	/// NegotiateStream protocol is described in e.g here
+	/// https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-NNS/[MS-NNS].pdf
+	/// We only use Handshake Messages for authentication.
+	/// </summary>
+
+	internal class NegotiateToMySqlConverterStream : Stream
+	{
+		bool m_clientHandshakeDone;
+
+		MemoryStream m_readBuffer;
+		MemoryStream m_writeBuffer;
+		int m_writePayloadLength;
+		ServerSession m_serverSession;
+		IOBehavior m_ioBehavior;
+		CancellationToken m_cancellationToken;
+
+		public PayloadData MySQLProtocolPayload { get; private set; }
+		public NegotiateToMySqlConverterStream(ServerSession serverSession, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			m_serverSession = serverSession;
+			m_readBuffer = new MemoryStream();
+			m_writeBuffer = new MemoryStream();
+			m_ioBehavior = ioBehavior;
+			m_cancellationToken = cancellationToken;
+		}
+
+		static void CreateNegotiateStreamMessageHeader(byte[] buffer, int offset, byte messageId, long payloadLength)
+		{
+			buffer[offset] =  messageId;
+			buffer[offset+1] = NegotiateStreamConstants.MajorVersion;
+			buffer[offset+2] = NegotiateStreamConstants.MinorVersion;
+			buffer[offset+3] = (byte) (payloadLength >> 8);
+			buffer[offset+4] = (byte) (payloadLength & 0xff);
+		}
+		public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			var bytesRead = 0;
+
+			if (m_readBuffer.Length == m_readBuffer.Position)
+			{
+				if (count < NegotiateStreamConstants.HeaderLength)
+					throw new InvalidDataException("Unexpected call to read less then NegotiateStream header");
+
+				if (m_clientHandshakeDone)
+				{
+					// NegotiateStream protocol expects server to send "handshake done"
+					// empty message at the end of handshake.
+					CreateNegotiateStreamMessageHeader(buffer, offset, NegotiateStreamConstants.HandshakeDone, 0);
+					return NegotiateStreamConstants.HeaderLength;
+				}
+				// Read and cache packet from server.
+				var payload = await m_serverSession.ReceiveReplyAsync(m_ioBehavior, cancellationToken);
+				var segment = payload.ArraySegment;
+
+				if (segment.Count > NegotiateStreamConstants.MaxPayloadLength)
+					throw new InvalidDataException(String.Format("Payload too big for NegotiateStream - {0} bytes", segment.Count));
+
+				// Check the first byte of the incoming packet.
+				// It can be an OK packet indicating end of server processing,
+				// or it can be 0x01 prefix we must strip off - 0x01 server masks special bytes, e.g 0xff, 0xfe in the payload
+				// during pluggable authentication packet exchanges.
+				var segmentOffset = segment.Offset;
+				var segmentCount = segment.Count;
+
+				switch (segment.Array[segment.Offset])
+				{
+				case 0x0:
+					MySQLProtocolPayload = payload;
+					CreateNegotiateStreamMessageHeader(buffer, offset, NegotiateStreamConstants.HandshakeDone, 0);
+					return NegotiateStreamConstants.HeaderLength;
+				case 0x1:
+					segmentOffset++;
+					segmentCount--;
+					break;
+				}
+
+				m_readBuffer = new MemoryStream(segment.Array, segmentOffset, segmentCount);
+				CreateNegotiateStreamMessageHeader(buffer, offset, NegotiateStreamConstants.HandshakeInProgress, m_readBuffer.Length);
+				bytesRead = NegotiateStreamConstants.HeaderLength;
+				offset += bytesRead;
+				count -= bytesRead;
+			}
+			if (count > 0)
+			{
+				// Return cached data.
+				bytesRead += m_readBuffer.Read(buffer, offset, count);
+			}
+			return bytesRead;
+		}
+
+		public override int Read(byte[] buffer, int offset, int count) => ReadAsync(buffer, offset, count, m_cancellationToken).Result;
+
+		public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		{
+			if (m_writePayloadLength == 0)
+			{
+				// The message header was not read yet.
+				if (count < NegotiateStreamConstants.HeaderLength)
+					// For simplicity, we expect header to be written in one go
+					throw new InvalidDataException("Cannot parse NegotiateStream handshake message header");
+
+				// Parse NegotiateStream handshake header
+				var messageId = buffer[offset+0];
+				var majorProtocolVersion = buffer[offset+1];
+				var minorProtocolVersion = buffer[offset+2];
+				var payloadSizeLow = buffer[offset+4];
+				var payloadSizeHigh = buffer[offset+3];
+
+
+				if (majorProtocolVersion != NegotiateStreamConstants.MajorVersion ||
+					minorProtocolVersion !=  NegotiateStreamConstants.MinorVersion)
+				{
+					throw new FormatException(
+						String.Format("Unknown version of NegotiateStream protocol {0}.{1}, expected {2}.{3}",
+						majorProtocolVersion, minorProtocolVersion,
+						NegotiateStreamConstants.MajorVersion, NegotiateStreamConstants.MinorVersion));
+				}
+				if (messageId != NegotiateStreamConstants.HandshakeDone &&
+					messageId != NegotiateStreamConstants.HandshakeError &&
+					messageId != NegotiateStreamConstants.HandshakeInProgress)
+				{
+					throw new FormatException(
+						String.Format("Invalid NegotiateStream MessageId 0x{0:X2}", messageId));
+				}
+
+				m_writePayloadLength = (int) payloadSizeLow + ((int) payloadSizeHigh << 8);
+				if (messageId == NegotiateStreamConstants.HandshakeDone)
+					m_clientHandshakeDone = true;
+
+				count -= NegotiateStreamConstants.HeaderLength;
+			}
+
+			if (count == 0)
+				return;
+
+			if (count + m_writeBuffer.Length > m_writePayloadLength)
+				throw new InvalidDataException("Attempt to write more than a single message");
+
+			PayloadData payload;
+			if (count <  m_writePayloadLength)
+			{
+				m_writeBuffer.Write(buffer, offset, count);
+				if (m_writeBuffer.Length < m_writePayloadLength)
+					// The message is only partially written
+					return;
+
+				var payloadBytes = m_writeBuffer.ToArray();
+				payload = new PayloadData(new ArraySegment<byte>(payloadBytes, 0, (int) m_writeBuffer.Length));
+				m_writeBuffer.SetLength(0);
+			}
+			else
+			{
+				// full payload provided
+				payload = new PayloadData(new ArraySegment<byte>(buffer, offset, m_writePayloadLength));
+			}
+			await m_serverSession.SendReplyAsync(payload, m_ioBehavior, cancellationToken);
+			// Need to parse NegotiateStream header next time
+			m_writePayloadLength = 0;
+		}
+
+		public override void Write(byte[] buffer, int offset, int count) => WriteAsync(buffer, offset, count, m_cancellationToken).Wait();
+
+		public override bool CanRead => true;
+
+		public override bool CanSeek => false;
+
+		public override bool CanWrite => true;
+
+		public override long Length => throw new NotImplementedException();
+
+		public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+		public override void Flush()
+		{
+		}
+
+		public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+		public override void SetLength(long value) => throw new NotImplementedException();
+
+	}
+	internal class AuthGSSAPI
+	{
+		private static string GetServicePrincipalName(byte[] switchRequest)
+		{
+			var reader = new ByteArrayReader(switchRequest.AsSpan());
+			return Encoding.UTF8.GetString(reader.ReadNullOrEofTerminatedByteString());
+		}
+		public static async Task<PayloadData> AuthenticateAsync(byte[] switchRequestPayloadData,
+			ServerSession session, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			using (var innerStream = new NegotiateToMySqlConverterStream(session, ioBehavior, cancellationToken))
+			using (var negotiateStream = new NegotiateStream(innerStream))
+			{
+				var targetName = GetServicePrincipalName(switchRequestPayloadData);
+				await negotiateStream.AuthenticateAsClientAsync(CredentialCache.DefaultNetworkCredentials, targetName);
+
+				if (innerStream.MySQLProtocolPayload.ArraySegment.Array != null)
+					// return already pre-read OK packet.
+					return innerStream.MySQLProtocolPayload;
+
+				// Read final OK packet from server
+				return await session.ReceiveReplyAsync(ioBehavior, cancellationToken);
+			}
+		}
+	}
+}

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -58,6 +58,7 @@ namespace MySqlConnector.Tests
 #if !BASELINE
 			Assert.Null(csb.ServerRsaPublicKeyFile);
 #endif
+			Assert.Null(csb.ServerSPN);
 #if !BASELINE
 			Assert.Equal(MySqlSslMode.Preferred, csb.SslMode);
 #else
@@ -121,6 +122,7 @@ namespace MySqlConnector.Tests
 					"Port=1234;" +
 					"protocol=pipe;" +
 					"pwd=Pass1234;" +
+					"server spn=mariadb/host.example.com@EXAMPLE.COM;" +
 					"Treat Tiny As Boolean=false;" +
 					"ssl mode=verifyca;" +
 					"Uid=username;" +
@@ -168,6 +170,7 @@ namespace MySqlConnector.Tests
 			Assert.False(csb.Pooling);
 			Assert.Equal(1234u, csb.Port);
 			Assert.Equal("db-server", csb.Server);
+			Assert.Equal("mariadb/host.example.com@EXAMPLE.COM", csb.ServerSPN);
 			Assert.False(csb.TreatTinyAsBoolean);
 			Assert.Equal(MySqlSslMode.VerifyCA, csb.SslMode);
 			Assert.False(csb.UseAffectedRows);

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -38,6 +38,8 @@ namespace SideBySide
 
 		public static string GSSAPIUser => Config.GetValue<string>("Data:GSSAPIUser");
 
+		public static bool HasKerberos => Config.GetValue<bool>("Data:HasKerberos");
+
 		public static string SecondaryDatabase => Config.GetValue<string>("Data:SecondaryDatabase");
 
 		private static ServerFeatures UnsupportedFeatures => (ServerFeatures) Enum.Parse(typeof(ServerFeatures), Config.GetValue<string>("Data:UnsupportedFeatures"));

--- a/tests/SideBySide/AppConfig.cs
+++ b/tests/SideBySide/AppConfig.cs
@@ -36,6 +36,8 @@ namespace SideBySide
 
 		public static string PasswordlessUser => Config.GetValue<string>("Data:PasswordlessUser");
 
+		public static string GSSAPIUser => Config.GetValue<string>("Data:GSSAPIUser");
+
 		public static string SecondaryDatabase => Config.GetValue<string>("Data:SecondaryDatabase");
 
 		private static ServerFeatures UnsupportedFeatures => (ServerFeatures) Enum.Parse(typeof(ServerFeatures), Config.GetValue<string>("Data:UnsupportedFeatures"));
@@ -69,6 +71,14 @@ namespace SideBySide
 			return csb;
 		}
 
+		public static MySqlConnectionStringBuilder CreateGSSAPIConnectionStringBuilder()
+		{
+			var csb = CreateConnectionStringBuilder();
+			csb.UserID = GSSAPIUser;
+			csb.Database = null;
+			return csb;
+		}
+	
 		// tests can run much slower in CI environments
 		public static int TimeoutDelayFactor { get; } = Environment.GetEnvironmentVariable("APPVEYOR") == "True" || Environment.GetEnvironmentVariable("TRAVIS") == "true" ? 6 : 1;
 	}

--- a/tests/SideBySide/ConfigSettings.cs
+++ b/tests/SideBySide/ConfigSettings.cs
@@ -17,6 +17,7 @@ namespace SideBySide
 		TcpConnection = 0x200,
 		SecondaryDatabase = 0x400,
 		KnownClientCertificate = 0x800,
-		GSSAPIUser = 0x1000
+		GSSAPIUser = 0x1000,
+		HasKerberos = 0x2000
 	}
 }

--- a/tests/SideBySide/ConfigSettings.cs
+++ b/tests/SideBySide/ConfigSettings.cs
@@ -17,5 +17,6 @@ namespace SideBySide
 		TcpConnection = 0x200,
 		SecondaryDatabase = 0x400,
 		KnownClientCertificate = 0x800,
+		GSSAPIUser = 0x1000
 	}
 }

--- a/tests/SideBySide/ConnectAsync.cs
+++ b/tests/SideBySide/ConnectAsync.cs
@@ -300,6 +300,26 @@ namespace SideBySide
 			}
 		}
 
+		// To create a MariaDB GSSAPI user for a current user
+		// - install plugin if not already done , e.g mysql -uroot -e "INSTALL SONAME 'auth_gssapi'"
+		// create MariaDB's gssapi user
+		// a) Windows, easy way
+		//    mysql -uroot -e "CREATE USER  %USERNAME% IDENTIFIED WITH gssapi"
+		// b) more involved , Windows, outside of domain
+		//    mysql -uroot -e "CREATE USER gssapi_user IDENTIFIED WITH gssapi as '%USERDOMAIN%\%USERNAME%'"
+		// c) Windows, inside domain
+		//    mysql -uroot -e "CREATE USER gssapi_user IDENTIFIED WITH gssapi as '%USERNAME%@%USERDNSDOMAIN%'"
+		// d) Linux, domain (or Kerberos Realm) user
+		//    NAME=`klist|grep 'Default principal' |awk '{print $3}'` mysql -uroot -e "CREATE USER gssapi_user IDENTIFIED WITH gssapi AS '$NAME'"
+		[SkippableFact(ConfigSettings.GSSAPIUser)]
+		public async Task AuthGSSAPI()
+		{
+			var csb = AppConfig.CreateGSSAPIConnectionStringBuilder();
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+				await connection.OpenAsync();
+			}
+		}
 #if !BASELINE
 		[Fact]
 		public async Task PingNoConnection()

--- a/tests/SideBySide/TestUtilities.cs
+++ b/tests/SideBySide/TestUtilities.cs
@@ -91,6 +91,9 @@ namespace SideBySide
 			if (configSettings.HasFlag(ConfigSettings.PasswordlessUser) && string.IsNullOrWhiteSpace(AppConfig.PasswordlessUser))
 				return "Requires PasswordlessUser in config.json";
 
+			if (configSettings.HasFlag(ConfigSettings.GSSAPIUser) && string.IsNullOrWhiteSpace(AppConfig.GSSAPIUser))
+				return "Requires GSSAPIUser in config.json";
+
 			if (configSettings.HasFlag(ConfigSettings.CsvFile) && string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderCsvFile))
 				return "Requires MySqlBulkLoaderCsvFile in config.json";
 

--- a/tests/SideBySide/TestUtilities.cs
+++ b/tests/SideBySide/TestUtilities.cs
@@ -94,6 +94,9 @@ namespace SideBySide
 			if (configSettings.HasFlag(ConfigSettings.GSSAPIUser) && string.IsNullOrWhiteSpace(AppConfig.GSSAPIUser))
 				return "Requires GSSAPIUser in config.json";
 
+			if (configSettings.HasFlag(ConfigSettings.HasKerberos) && !AppConfig.HasKerberos)
+				return "Requires HasKerberos in config.json";
+
 			if (configSettings.HasFlag(ConfigSettings.CsvFile) && string.IsNullOrWhiteSpace(AppConfig.MySqlBulkLoaderCsvFile))
 				return "Requires MySqlBulkLoaderCsvFile in config.json";
 


### PR DESCRIPTION
This patch adds support for MariaDB's gssapi authentication plugin, passwordless authentication on Windows (in both domain and standalone machine environments), as well as on Linux, in Kerberos realm environment.

More information on authentication plugin https://mariadb.com/kb/en/library/authentication-plugin-gssapi

The patch uses .NET NegotiateStream to authenticate. It uses an auxiliary stream to convert NegotiateStream framing for SPNEGO/NTLM payloads into MySQL packet framing with the same payloads.


Things to note

* Currently,  the client "trusts" service principal name that server sends, and passes it as targetName in NegotiateStream.AuthenticateAsClientAsync.  Ideally , to support mutual authentication between client and server , service principal name should be an optional connection parameter.  If set, driver would ignore the string sent by the server. I did not add this into the patch,  but, if we agree it is a good idea, I can be easily added later.

*  On Linux, NegotiateStream implementation currently only works correctly with  service principle names (that's the dotnet implementation of it) . Most importantly , it  does not understand UPNs user principle names , like machine$@domain.com, which are typically in use by MariaDB servers running inside Windows AD.

Thus by default, connection from a Linux client to Windows server would fail (.NET runtime turns machine$@domain.com into funny name  machine$/domain.com, which KDC won't find).
 
There is however a  simple workaround on the server side, to allow Linux client to connect  Windows server, would be to set  server parameter --gssapi-principal-name=HOST/fqdn@DOMAIN.COM (host SPN, usually added whenever machine joins the domain). 
