### PR TITLE
Fix underlying assumption of SessionTrack that not work well for MariaDB

### DIFF
--- a/src/MySqlConnector/Protocol/Payloads/HandshakeResponse41Payload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/HandshakeResponse41Payload.cs
@@ -24,7 +24,7 @@ namespace MySqlConnector.Protocol.Payloads
 				(cs.UseAffectedRows ? 0 : ProtocolCapabilities.FoundRows) |
 				(useCompression ? ProtocolCapabilities.Compress : ProtocolCapabilities.None) |
 				(serverCapabilities & ProtocolCapabilities.ConnectionAttributes) |
-				(serverCapabilities & ProtocolCapabilities.SessionTrack) |
+				ProtocolCapabilities.SessionTrack |
 				(serverCapabilities & ProtocolCapabilities.DeprecateEof) |
 				additionalCapabilities));
 			writer.Write(0x4000_0000);


### PR DESCRIPTION
The implies ProtocolCapabilities.SessionTrack is not correct for MariaDB, when MariaDB is behind a proxy like MaxScale.
MariaDB take such action
1. See the client support SessionTrack or not
2. If not, just set the flag SessionStateChanged to true and then write noting on the the packet. See https://github.com/MariaDB/server/blob/10.2/sql/protocol.cc#L272

So if MariaDB is under a proxy(proxy does not set the capacity), it will throw such exception 
```
MySql.Data.MySqlClient.MySqlException
  HResult=0x80004005
  Message=Failed to read the result set.
  Source=MySqlConnector
  StackTrace:
   at MySql.Data.MySqlClient.MySqlDataReader.ActivateResultSet(ResultSet resultSet) in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 90
   at MySql.Data.MySqlClient.MySqlDataReader.<ReadFirstResultSetAsync>d__92.MoveNext() in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 298
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MySql.Data.MySqlClient.MySqlDataReader.<CreateAsync>d__91.MoveNext() in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlDataReader.cs:line 289
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MySqlConnector.Core.TextCommandExecutor.<ExecuteReaderAsync>d__1.MoveNext() in C:\projects\mysqlconnector\src\MySqlConnector\Core\TextCommandExecutor.cs:line 37
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MySql.Data.MySqlClient.MySqlCommand.<ExecuteNonQueryAsync>d__60.MoveNext() in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlCommand.cs:line 261
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at MySql.Data.MySqlClient.MySqlCommand.ExecuteNonQuery() in C:\projects\mysqlconnector\src\MySqlConnector\MySql.Data.MySqlClient\MySqlCommand.cs:line 62
   at mysqlconnectortest.Program.Main(String[] args) in C:\Users\shuodl\source\repos\mysqlconnectortest\mysqlconnectortest\Program.cs:line 19

Inner Exception 1:
IndexOutOfRangeException: Index was outside the bounds of the array.
```

Here is a workaround for it.