### PR TITLE
Add lock-free connection pool

### DIFF
--- a/docs/content/overview/version-history.md
+++ b/docs/content/overview/version-history.md
@@ -11,6 +11,13 @@ weight: 30
 Version History
 ===============
 
+### 0.50.0 Beta 1
+
+* **EXPERIMENTAL** New lock-free connection pool based on npgsql's implementation.
+  * **Breaking** The `MaximumPoolSize` connection string option is now limited to 4096.
+  * Pooled connections are not created proactively at startup to reach `MinimumPoolSize`; instead, the connection pool waits until the first time that connection is needed to create it.
+  * The background task to prune idle connections is now created if and only if there are more than `MinimumPoolSize` connections in the pool.
+
 ### 0.49.3
 
 * Use correct isolation level when starting a transaction for `System.Transactions.TransactionScope`: [#605](https://github.com/mysql-net/MySqlConnector/issues/605).

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -51,6 +51,10 @@ namespace MySqlConnector.Core
 				RecoverLeakedSessions();
 			}
 
+#if !NETSTANDARD1_3
+			Thread.Sleep(1);
+#endif
+
 			Log.Debug("Pool{0} checking for an available session", m_logArguments);
 			if (!TryAllocateFast(out var session))
 			{

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +17,21 @@ namespace MySqlConnector.Core
 {
 	internal sealed class ConnectionPool
 	{
+		// General
+		//
+		// * When we're at capacity (Busy==Max) further open attempts wait until someone releases.
+		//   This must happen in FIFO (first to block on open is the first to release), otherwise some attempts may get
+		//   starved and time out. This is why we use a ConcurrentQueue.
+		// * We must avoid a race condition whereby an open attempt starts waiting at the same time as another release
+		//   puts a connector back into the idle list. This would potentially make the waiter wait forever/time out.
+		//
+		// Rules
+		// * You *only* create a new connector if Total < Max.
+		// * You *only* go into waiting if Busy == Max (which also implies Idle == 0)
+		//
+		// Implementation taken from https://github.com/npgsql/npgsql/blob/6f5e936ba3cff2c71e914528a282fa0d7f683c78/src/Npgsql/ConnectorPool.cs
+		// This implementation should be kept up-to-date with changes in that code.
+
 		public int Id { get; }
 
 		public ConnectionSettings ConnectionSettings { get; }
@@ -27,35 +45,23 @@ namespace MySqlConnector.Core
 			// if all sessions are used, see if any have been leaked and can be recovered
 			// check at most once per second (although this isn't enforced via a mutex so multiple threads might block
 			// on the lock in RecoverLeakedSessions in high-concurrency situations
-			if (m_sessionSemaphore.CurrentCount == 0 && unchecked(((uint) Environment.TickCount) - m_lastRecoveryTime) >= 1000u)
+			if (m_state.Busy == m_maximumPoolSize && unchecked(((uint) Environment.TickCount) - m_lastRecoveryTime) >= 1000u)
 			{
-				Log.Info("Pool{0} is empty; recovering leaked sessions", m_logArguments);
+				Log.Debug("Pool{0} is empty; checking for leaked sessions", m_logArguments);
 				RecoverLeakedSessions();
 			}
 
-			if (ConnectionSettings.MinimumPoolSize > 0)
-				await CreateMinimumPooledSessions(ioBehavior, cancellationToken).ConfigureAwait(false);
+			Log.Debug("Pool{0} checking for an available session", m_logArguments);
+			if (!TryAllocateFast(out var session))
+			{
+				// create a new session (if the pool isn't full), or wait for one
+				session = await AllocateLong(connection, ioBehavior, cancellationToken).ConfigureAwait(false);
+			}
 
-			// wait for an open slot (until the cancellationToken is cancelled, which is typically due to timeout)
-			Log.Debug("Pool{0} waiting for an available session", m_logArguments);
-			if (ioBehavior == IOBehavior.Asynchronous)
-				await m_sessionSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-			else
-				m_sessionSemaphore.Wait(cancellationToken);
-
-			ServerSession session = null;
 			try
 			{
-				// check for a waiting session
-				lock (m_sessions)
-				{
-					if (m_sessions.Count > 0)
-					{
-						session = m_sessions.First.Value;
-						m_sessions.RemoveFirst();
-					}
-				}
-				if (session != null)
+				// if LastReturnedTicks==0, the session is newly created
+				if (session.LastReturnedTicks != 0)
 				{
 					Log.Debug("Pool{0} found an existing session; checking it for validity", m_logArguments);
 					bool reuseSession;
@@ -102,13 +108,14 @@ namespace MySqlConnector.Core
 							Log.Debug("Pool{0} returning pooled Session{1} to caller; LeasedSessionsCount={2}", m_logArguments[0], session.Id, leasedSessionsCountPooled);
 						return session;
 					}
+
+					// create a new session
+					session = new ServerSession(this, m_generation, Interlocked.Increment(ref m_lastSessionId));
+					if (Log.IsInfoEnabled())
+						Log.Info("Pool{0} no pooled session available; created new Session{1}", m_logArguments[0], session.Id);
+					await session.ConnectAsync(ConnectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
 				}
 
-				// create a new session
-				session = new ServerSession(this, m_generation, Interlocked.Increment(ref m_lastSessionId));
-				if (Log.IsInfoEnabled())
-					Log.Info("Pool{0} no pooled session available; created new Session{1}", m_logArguments[0], session.Id);
-				await session.ConnectAsync(ConnectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
 				AdjustHostConnectionCount(session, 1);
 				session.OwningConnection = new WeakReference<MySqlConnection>(connection);
 				int leasedSessionsCountNew;
@@ -123,21 +130,7 @@ namespace MySqlConnector.Core
 			}
 			catch (Exception ex)
 			{
-				if (session != null)
-				{
-					try
-					{
-						Log.Debug(ex, "Pool{0} disposing created Session{1} due to exception: {2}", m_logArguments[0], session.Id, ex.Message);
-						AdjustHostConnectionCount(session, -1);
-						await session.DisposeAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
-					}
-					catch (Exception unexpectedException)
-					{
-						Log.Error(unexpectedException, "Pool{0} unexpected error in GetSessionAsync: {1}", m_logArguments[0], unexpectedException.Message);
-					}
-				}
-
-				m_sessionSemaphore.Release();
+				HandleExceptionCreatingSession(ex, session);
 				throw;
 			}
 		}
@@ -161,48 +154,136 @@ namespace MySqlConnector.Core
 			if (Log.IsDebugEnabled())
 				Log.Debug("Pool{0} receiving Session{1} back", m_logArguments[0], session.Id);
 
-			try
+			lock (m_leasedSessions)
+				m_leasedSessions.Remove(session.Id);
+			session.OwningConnection = null;
+			var sessionHealth = GetSessionHealth(session);
+			if (sessionHealth != 0)
 			{
-				lock (m_leasedSessions)
-					m_leasedSessions.Remove(session.Id);
-				session.OwningConnection = null;
-				var sessionHealth = GetSessionHealth(session);
-				if (sessionHealth == 0)
-				{
-					lock (m_sessions)
-						m_sessions.AddFirst(session);
-				}
+				if (sessionHealth == 1)
+					Log.Warn("Pool{0} received invalid Session{1}; destroying it", m_logArguments[0], session.Id);
 				else
-				{
-					if (sessionHealth == 1)
-						Log.Warn("Pool{0} received invalid Session{1}; destroying it", m_logArguments[0], session.Id);
-					else
-						Log.Info("Pool{0} received expired Session{1}; destroying it", m_logArguments[0], session.Id);
-					AdjustHostConnectionCount(session, -1);
-					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
-				}
+					Log.Info("Pool{0} received expired Session{1}; destroying it", m_logArguments[0], session.Id);
+				AdjustHostConnectionCount(session, -1);
+				CloseSession(session, wasIdle: false);
+				return;
 			}
-			finally
+
+			var sw = new SpinWait();
+
+			while (true)
 			{
-				m_sessionSemaphore.Release();
+				var state = m_state.Copy();
+
+				// If there are any pending open attempts in progress hand the session off to them directly.
+				// Note that in this case, state changes (i.e. decrementing m_state.Waiting) happens at the allocating
+				// side.
+				if (state.Waiting > 0)
+				{
+					if (!m_waiting.TryDequeue(out var waitingOpenAttempt))
+					{
+						// _waitingCount has been increased, but there's nothing in the queue yet - someone is in the
+						// process of enqueuing an open attempt. Wait and retry.
+						sw.SpinOnce();
+						continue;
+					}
+
+					var tcs = waitingOpenAttempt.TaskCompletionSource;
+
+					// We have a pending open attempt. "Complete" it, handing off the session.
+					if (waitingOpenAttempt.IsAsync)
+					{
+						// If the waiting open attempt is asynchronous (i.e. OpenAsync()), we can't simply
+						// call SetResult on its TaskCompletionSource, since it would execute the open's
+						// continuation in our thread (the closing thread). Instead we schedule the completion
+						// to run in the thread pool via Task.Run().
+
+						// We copy tcs2 and especially connector2 to avoid allocations caused by the closure, see
+						// http://stackoverflow.com/questions/41507166/closure-heap-allocation-happening-at-start-of-method
+						var tcs2 = tcs;
+						var connector2 = session;
+
+						// TODO: When we drop support for .NET Framework 4.5, switch to RunContinuationsAsynchronously
+						Task.Run(() =>
+						{
+							if (!tcs2.TrySetResult(connector2))
+							{
+								// If the open attempt timed out, the Task's state will be set to Canceled and our
+								// TrySetResult fails.
+								// "Recursively" call Release() again, this will dequeue another open attempt and retry.
+								Debug.Assert(tcs2.Task.IsCanceled);
+								Return(connector2);
+							}
+						});
+					}
+					else if (!tcs.TrySetResult(session))  // Open attempt is sync
+					{
+						// If the open attempt timed out, the Task's state will be set to Canceled and our
+						// TrySetResult fails. Try again.
+						Debug.Assert(tcs.Task.IsCanceled);
+						continue;
+					}
+
+					return;
+				}
+
+				// There were no waiting attempts. However, there's a race condition where a new waiting attempt
+				// may occur as we're putting our session into the idle list. Decrement the busy
+				// count, while atomically make sure the waiting count isn't increased.
+				// Note that we also must update the state *before* putting the session back in the idle list.
+				var newState = state;
+				newState.Idle++;
+				newState.Busy--;
+				CheckInvariants(newState);
+				if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) != state.All)
+				{
+					// Our attempt to decrement the busy count failed, either because a waiting attempt has been added
+					// or busy has changed. Loop again and retry.
+					continue;
+				}
+
+				// If we're here, we successfully applied the new state above and can put the session back in the idle
+				// list (there were no pending open attempts).
+
+				var ticks = unchecked((uint) Environment.TickCount);
+				if (ticks == 0)
+					ticks = 1;
+				session.LastReturnedTicks = ticks;
+
+				// We start scanning for an empty slot in "random" places in the array, to avoid
+				// too much interlocked operations "contention" at the beginning.
+#if !NETSTANDARD1_3
+				var start = Thread.CurrentThread.ManagedThreadId % m_maximumPoolSize;
+#else
+				var start = 0;
+#endif
+
+				sw = new SpinWait();
+				while (true)
+				{
+					for (var i = start; i < m_idleSessions.Length; i++)
+					{
+						if (Interlocked.CompareExchange(ref m_idleSessions[i], session, null) is null)
+							return;
+					}
+
+					for (var i = 0; i < start; i++)
+					{
+						if (Interlocked.CompareExchange(ref m_idleSessions[i], session, null) is null)
+							return;
+					}
+					sw.SpinOnce();
+				}
 			}
 		}
 
-		public async Task ClearAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+		public Task ClearAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
-			// increment the generation of the connection pool
 			Log.Info("Pool{0} clearing connection pool", m_logArguments);
-			Interlocked.Increment(ref m_generation);
 			m_procedureCache = null;
 			RecoverLeakedSessions();
-			await CleanPoolAsync(ioBehavior, session => session.PoolGeneration != m_generation, false, cancellationToken).ConfigureAwait(false);
-		}
-
-		public async Task ReapAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
-		{
-			Log.Debug("Pool{0} reaping connection pool", m_logArguments);
-			RecoverLeakedSessions();
-			await CleanPoolAsync(ioBehavior, session => (unchecked((uint) Environment.TickCount) - session.LastReturnedTicks) / 1000 >= ConnectionSettings.ConnectionIdleTimeout, true, cancellationToken).ConfigureAwait(false);
+			Clear();
+			return Utility.CompletedTask;
 		}
 
 		/// <summary>
@@ -245,119 +326,6 @@ namespace MySqlConnector.Core
 				Log.Warn("Pool{0}: RecoveredSessionCount={1}", m_logArguments[0], recoveredSessions.Count);
 			foreach (var session in recoveredSessions)
 				session.ReturnToPool();
-		}
-
-		private async Task CleanPoolAsync(IOBehavior ioBehavior, Func<ServerSession, bool> shouldCleanFn, bool respectMinPoolSize, CancellationToken cancellationToken)
-		{
-			// synchronize access to this method as only one clean routine should be run at a time
-			if (ioBehavior == IOBehavior.Asynchronous)
-				await m_cleanSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-			else
-				m_cleanSemaphore.Wait(cancellationToken);
-
-			try
-			{
-				var waitTimeout = TimeSpan.FromMilliseconds(10);
-				while (true)
-				{
-					// if respectMinPoolSize is true, return if (leased sessions + waiting sessions <= minPoolSize)
-					if (respectMinPoolSize)
-						lock (m_sessions)
-							if (ConnectionSettings.MaximumPoolSize - m_sessionSemaphore.CurrentCount + m_sessions.Count <= ConnectionSettings.MinimumPoolSize)
-								return;
-
-					// try to get an open slot; if this fails, connection pool is full and sessions will be disposed when returned to pool
-					if (ioBehavior == IOBehavior.Asynchronous)
-					{
-						if (!await m_sessionSemaphore.WaitAsync(waitTimeout, cancellationToken).ConfigureAwait(false))
-							return;
-					}
-					else
-					{
-						if (!m_sessionSemaphore.Wait(waitTimeout, cancellationToken))
-							return;
-					}
-
-					try
-					{
-						// check for a waiting session
-						ServerSession session = null;
-						lock (m_sessions)
-						{
-							if (m_sessions.Count > 0)
-							{
-								session = m_sessions.Last.Value;
-								m_sessions.RemoveLast();
-							}
-						}
-						if (session == null)
-							return;
-
-						if (shouldCleanFn(session))
-						{
-							// session should be cleaned; dispose it and keep iterating
-							Log.Info("Pool{0} found Session{1} to clean up", m_logArguments[0], session.Id);
-							await session.DisposeAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
-						}
-						else
-						{
-							// session should not be cleaned; put it back in the queue and stop iterating
-							lock (m_sessions)
-								m_sessions.AddLast(session);
-							return;
-						}
-					}
-					finally
-					{
-						m_sessionSemaphore.Release();
-					}
-				}
-			}
-			finally
-			{
-				m_cleanSemaphore.Release();
-			}
-		}
-
-		private async Task CreateMinimumPooledSessions(IOBehavior ioBehavior, CancellationToken cancellationToken)
-		{
-			while (true)
-			{
-				lock (m_sessions)
-				{
-					// check if the desired minimum number of sessions have been created
-					if (ConnectionSettings.MaximumPoolSize - m_sessionSemaphore.CurrentCount + m_sessions.Count >= ConnectionSettings.MinimumPoolSize)
-						return;
-				}
-
-				// acquire the semaphore, to ensure that the maximum number of sessions isn't exceeded; if it can't be acquired,
-				// we have reached the maximum number of sessions and no more need to be created
-				if (ioBehavior == IOBehavior.Asynchronous)
-				{
-					if (!await m_sessionSemaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false))
-						return;
-				}
-				else
-				{
-					if (!m_sessionSemaphore.Wait(0, cancellationToken))
-						return;
-				}
-
-				try
-				{
-					var session = new ServerSession(this, m_generation, Interlocked.Increment(ref m_lastSessionId));
-					Log.Info("Pool{0} created Session{1} to reach minimum pool size", m_logArguments[0], session.Id);
-					await session.ConnectAsync(ConnectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
-					AdjustHostConnectionCount(session, 1);
-					lock (m_sessions)
-						m_sessions.AddFirst(session);
-				}
-				finally
-				{
-					// connection is in pool; semaphore shouldn't be held any more
-					m_sessionSemaphore.Release();
-				}
-			}
 		}
 
 		public static ConnectionPool GetPool(string connectionString)
@@ -403,7 +371,6 @@ namespace MySqlConnector.Core
 			if (pool == newPool)
 			{
 				s_mruCache = new ConnectionStringPool(connectionString, pool);
-				pool.StartReaperTask();
 
 				// if we won the race to create the new pool, also store it under the original connection string
 				if (connectionString != normalizedConnectionString)
@@ -440,9 +407,11 @@ namespace MySqlConnector.Core
 			ConnectionSettings = cs;
 			SslProtocols = Utility.GetDefaultSslProtocols();
 			m_generation = 0;
-			m_cleanSemaphore = new SemaphoreSlim(1);
-			m_sessionSemaphore = new SemaphoreSlim(cs.MaximumPoolSize);
-			m_sessions = new LinkedList<ServerSession>();
+			m_maximumPoolSize = cs.MaximumPoolSize;
+			m_minimumPoolSize = cs.MinimumPoolSize;
+			m_pruningInterval = TimeSpan.FromSeconds(Math.Max(1, Math.Min(60, ConnectionSettings.ConnectionIdleTimeout / 2)));
+			m_idleSessions = new ServerSession[m_maximumPoolSize];
+			m_waiting = new ConcurrentQueue<OpenAttempt>();
 			m_leasedSessions = new Dictionary<string, ServerSession>();
 			if (cs.LoadBalance == MySqlLoadBalance.LeastConnections)
 			{
@@ -461,31 +430,6 @@ namespace MySqlConnector.Core
 			m_logArguments = new object[] { "{0}".FormatInvariant(Id) };
 			if (Log.IsInfoEnabled())
 				Log.Info("Pool{0} creating new connection pool for ConnectionString: {1}", m_logArguments[0], cs.ConnectionStringBuilder.GetConnectionString(includePassword: false));
-		}
-
-		private void StartReaperTask()
-		{
-			if (ConnectionSettings.ConnectionIdleTimeout > 0)
-			{
-				var reaperInterval = TimeSpan.FromSeconds(Math.Max(1, Math.Min(60, ConnectionSettings.ConnectionIdleTimeout / 2)));
-				m_reaperTask = Task.Run(async () =>
-				{
-					while (true)
-					{
-						var task = Task.Delay(reaperInterval);
-						try
-						{
-							using (var source = new CancellationTokenSource(reaperInterval))
-								await ReapAsync(IOBehavior.Asynchronous, source.Token).ConfigureAwait(false);
-						}
-						catch
-						{
-							// do nothing; we'll try to reap again
-						}
-						await task.ConfigureAwait(false);
-					}
-				});
-			}
 		}
 
 		private void AdjustHostConnectionCount(ServerSession session, int delta)
@@ -522,6 +466,41 @@ namespace MySqlConnector.Core
 			public ConnectionPool Pool { get; }
 		}
 
+		private readonly struct OpenAttempt
+		{
+			public OpenAttempt(TaskCompletionSource<ServerSession> taskCompletionSource, bool isAsync)
+			{
+				TaskCompletionSource = taskCompletionSource;
+				IsAsync = isAsync;
+			}
+
+			public readonly TaskCompletionSource<ServerSession> TaskCompletionSource;
+			public readonly bool IsAsync;
+		}
+
+		[StructLayout(LayoutKind.Explicit)]
+		private struct PoolState
+		{
+			[FieldOffset(0)]
+			public short Idle;
+			[FieldOffset(2)]
+			public short Busy;
+			[FieldOffset(4)]
+			public short Waiting;
+			[FieldOffset(0)]
+			public long All;
+
+			public int Total => Idle + Busy;
+
+			public PoolState Copy() => new PoolState { All = Volatile.Read(ref All) };
+
+			public override string ToString()
+			{
+				var state = Copy();
+				return $"[{state.Total} total, {state.Idle} idle, {state.Busy} busy, {state.Waiting} waiting]";
+			}
+		}
+
 #if !NETSTANDARD1_3
 		static ConnectionPool()
 		{
@@ -532,6 +511,358 @@ namespace MySqlConnector.Core
 		static void OnAppDomainShutDown(object sender, EventArgs e) => ClearPoolsAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 #endif
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		private bool TryAllocateFast(out ServerSession session)
+		{
+			// We start scanning for an idle session in "random" places in the array, to avoid
+			// too much interlocked operations "contention" at the beginning.
+#if !NETSTANDARD1_3
+			var start = Thread.CurrentThread.ManagedThreadId % m_maximumPoolSize;
+#else
+			var start = 0;
+#endif
+
+			// Idle may indicate that there are idle connectors, with the subsequent scan failing to find any.
+			// This can happen because of race conditions with Release(), which updates Idle before actually putting
+			// the session in the list, or because of other allocation attempts, which remove the session from
+			// the idle list before updating Idle.
+			// Loop until either m_state.Idle is 0 or you manage to remove a session.
+			session = null;
+			while (Volatile.Read(ref m_state.Idle) > 0)
+			{
+				for (var i = start; session is null && i < m_maximumPoolSize; i++)
+				{
+					// First check without an Interlocked operation, it's faster
+					if (m_idleSessions[i] is null)
+						continue;
+
+					// If we saw a session in this slot, atomically exchange it with a null.
+					// Either we get a session out which we can use, or we get null because
+					// someone has taken it in the meanwhile. Either way put a null in its place.
+					session = Interlocked.Exchange(ref m_idleSessions[i], null);
+				}
+
+				for (var i = 0; session is null && i < start; i++)
+				{
+					// Same as above
+					if (m_idleSessions[i] is null)
+						continue;
+					session = Interlocked.Exchange(ref m_idleSessions[i], null);
+				}
+
+				if (session is null)
+					return false;
+
+				// We successfully extracted an idle session, update state
+				var sw = new SpinWait();
+				while (true)
+				{
+					var state = m_state.Copy();
+					var newState = state;
+					newState.Busy++;
+					newState.Idle--;
+					CheckInvariants(newState);
+					if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) == state.All)
+						return true;
+					sw.SpinOnce();
+				}
+			}
+
+			session = null;
+			return false;
+		}
+
+		private async ValueTask<ServerSession> AllocateLong(MySqlConnection connection, IOBehavior ioBehavior, CancellationToken cancellationToken)
+		{
+			// No idle session was found in the pool.
+			// We now loop until one of three things happen:
+			// 1. The pool isn't at max capacity (Total < Max), so we can create a new physical connection.
+			// 2. The pool is at maximum capacity and there are no idle connectors (Busy == Max),
+			// so we enqueue an open attempt into the waiting queue, so that the next release will unblock it.
+			// 3. An session makes it into the idle list (race condition with another Release().
+			while (true)
+			{
+				ServerSession session;
+				var state = m_state.Copy();
+				var newState = state;
+
+				if (state.Total < m_maximumPoolSize)
+				{
+					// We're under the pool's max capacity, try to "allocate" a slot for a new physical connection.
+					newState.Busy++;
+					CheckInvariants(newState);
+					if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) != state.All)
+					{
+						// Our attempt to increment the busy count failed, Loop again and retry.
+						continue;
+					}
+
+					// We've managed to increase the busy counter, open a physical connection
+					session = new ServerSession(this, m_generation, Interlocked.Increment(ref m_lastSessionId));
+					if (Log.IsInfoEnabled())
+						Log.Info("Pool{0} no pooled session available; created new Session{1}", m_logArguments[0], session.Id);
+
+					try
+					{
+						await session.ConnectAsync(ConnectionSettings, m_loadBalancer, ioBehavior, cancellationToken).ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						HandleExceptionCreatingSession(ex, session);
+						throw;
+					}
+
+					// Start the pruning timer if we're above MinPoolSize
+					if (m_pruningTimer is null && newState.Total > m_minimumPoolSize)
+					{
+						Log.Debug("Pool{0} starting pruning timer", m_logArguments);
+						var newPruningTimer = new Timer(PruneIdleConnectors, null, Timeout.Infinite, Timeout.Infinite);
+						if (Interlocked.CompareExchange(ref m_pruningTimer, newPruningTimer, null) is null)
+						{
+							newPruningTimer.Change(m_pruningInterval, m_pruningInterval);
+						}
+						else
+						{
+							// Someone beat us to it
+							newPruningTimer.Dispose();
+						}
+					}
+
+					return session;
+				}
+
+				if (state.Busy == m_maximumPoolSize)
+				{
+					// Pool is exhausted. Increase the waiting count while atomically making sure the busy count
+					// doesn't decrease (otherwise we have a new idle session).
+					newState.Waiting++;
+					CheckInvariants(newState);
+					if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) != state.All)
+					{
+						// Our attempt to increment the waiting count failed, either because a session became idle (busy
+						// changed) or the waiting count changed. Loop again and retry.
+						continue;
+					}
+
+					// At this point the waiting count is non-zero, so new release calls are blocking on the waiting
+					// queue. This avoids a race condition where we wait while another session is put back in the
+					// idle list - we know the idle list is empty and will stay empty.
+					Log.Debug("Pool{0} waiting for an available session", m_logArguments);
+
+					try
+					{
+						// Enqueue an open attempt into the waiting queue so that the next release attempt will unblock us.
+						var tcs = new TaskCompletionSource<ServerSession>();
+						m_waiting.Enqueue(new OpenAttempt(tcs, ioBehavior == IOBehavior.Asynchronous));
+
+						try
+						{
+							using (cancellationToken.Register(() => tcs.SetCanceled()))
+							{
+								if (ioBehavior == IOBehavior.Asynchronous)
+									await tcs.Task.ConfigureAwait(false);
+								else
+									tcs.Task.GetAwaiter().GetResult();
+							}
+						}
+						catch (Exception)
+						{
+							// We're here if the cancellation token was triggered (possibly due to timeout)
+							// Transition our Task to cancelled, so that the next time someone releases
+							// a connection they'll skip over it.
+							tcs.TrySetCanceled();
+
+							// There's still a chance of a race condition, whereby the task was transitioned to
+							// completed in the meantime.
+							if (tcs.Task.Status != TaskStatus.RanToCompletion)
+								throw;
+						}
+
+						Debug.Assert(tcs.Task.IsCompleted);
+						session = tcs.Task.Result;
+
+						// Our task completion may contain a null in order to unblock us, allowing us to try
+						// allocating again.
+						if (session is null)
+						{
+							Log.Debug("Pool{0} waiting received null session; trying again", m_logArguments);
+							continue;
+						}
+
+						return session;
+					}
+					finally
+					{
+						// The allocation attempt succeeded or timed out, decrement the waiting count
+						var sw = new SpinWait();
+						while (true)
+						{
+							state = m_state.Copy();
+							newState = state;
+							newState.Waiting--;
+							CheckInvariants(newState);
+							if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) == state.All)
+								break;
+							sw.SpinOnce();
+						}
+					}
+				}
+
+				// We didn't create a new session or start waiting, which means there's a new idle session, try
+				// getting it
+				Debug.Assert(state.Idle > 0);
+				if (TryAllocateFast(out session))
+					return session;
+			}
+
+			// Cannot be here
+		}
+
+		private void HandleExceptionCreatingSession(Exception ex, ServerSession session)
+		{
+			if (session != null)
+			{
+				try
+				{
+					Log.Debug(ex, "Pool{0} disposing created Session{1} due to exception: {2}", m_logArguments[0], session.Id, ex.Message);
+					AdjustHostConnectionCount(session, -1);
+					session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
+				}
+				catch (Exception unexpectedException)
+				{
+					Log.Error(unexpectedException, "Pool{0} unexpected error in GetSessionAsync: {1}", m_logArguments[0], unexpectedException.Message);
+				}
+			}
+
+			// physical open failed, decrement busy back down
+			var sw = new SpinWait();
+			while (true)
+			{
+				var state = m_state.Copy();
+				var newState = state;
+				newState.Busy--;
+				if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) != state.All)
+				{
+					// Our attempt to increment the busy count failed, Loop again and retry.
+					sw.SpinOnce();
+					continue;
+				}
+
+				break;
+			}
+
+			// There may be waiters because we raised the busy count (and failed). Release one waiter if there is one.
+			if (m_waiting.TryDequeue(out var waitingOpenAttempt))
+			{
+				var tcs = waitingOpenAttempt.TaskCompletionSource;
+
+				// We have a pending open attempt. "Complete" it, handing off the session.
+				if (waitingOpenAttempt.IsAsync)
+				{
+					// If the waiting open attempt is asynchronous (i.e. OpenAsync()), we can't simply
+					// call SetResult on its TaskCompletionSource, since it would execute the open's
+					// continuation in our thread (the closing thread). Instead we schedule the completion
+					// to run in the thread pool via Task.Run().
+
+					// TODO: When we drop support for .NET Framework 4.5, switch to RunContinuationsAsynchronously
+#pragma warning disable 4014
+					Task.Run(() =>
+					{
+						if (!tcs.TrySetResult(null))
+						{
+							// TODO: Release more??
+						}
+					});
+#pragma warning restore 4014
+				}
+				else if (!tcs.TrySetResult(null)) // Open attempt is sync
+				{
+					// TODO: Release more??
+				}
+			}
+		}
+
+		private void CloseSession(ServerSession session, bool wasIdle)
+		{
+			try
+			{
+				session.DisposeAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
+
+				var sw = new SpinWait();
+				while (true)
+				{
+					var state = m_state.Copy();
+					var newState = state;
+					if (wasIdle)
+						newState.Idle--;
+					else
+						newState.Busy--;
+					CheckInvariants(newState);
+					if (Interlocked.CompareExchange(ref m_state.All, newState.All, state.All) == state.All)
+						break;
+					sw.SpinOnce();
+				}
+			}
+			catch (Exception e)
+			{
+				Log.Warn("Exception while closing outdated session", e, session.Id);
+			}
+
+			while (m_pruningTimer != null && m_state.Total <= m_minimumPoolSize)
+			{
+				var oldTimer = m_pruningTimer;
+				if (object.ReferenceEquals(Interlocked.CompareExchange(ref m_pruningTimer, null, oldTimer), oldTimer))
+				{
+					oldTimer.Dispose();
+					break;
+				}
+			}
+		}
+
+		private void PruneIdleConnectors(object _)
+		{
+			var idleLifetime = ConnectionSettings.ConnectionIdleTimeout;
+
+			for (var i = 0; i < m_idleSessions.Length; i++)
+			{
+				if (m_state.Total <= m_minimumPoolSize)
+					return;
+
+				var session = m_idleSessions[i];
+				if (session is null || ((unchecked((uint) Environment.TickCount) - session.LastReturnedTicks) / 1000) < idleLifetime)
+					continue;
+				if (Interlocked.CompareExchange(ref m_idleSessions[i], null, session) == session)
+					CloseSession(session, wasIdle: true);
+			}
+		}
+
+		private void Clear()
+		{
+			for (var i = 0; i < m_idleSessions.Length; i++)
+			{
+				var connector = Interlocked.Exchange(ref m_idleSessions[i], null);
+				if (connector != null)
+					CloseSession(connector, wasIdle: true);
+			}
+
+			Interlocked.Increment(ref m_generation);
+		}
+
+		[Conditional("DEBUG")]
+		private void CheckInvariants(PoolState state)
+		{
+			if (state.Total > m_maximumPoolSize)
+				throw new InvalidOperationException($"Pool is over capacity (Total={state.Total}, Max={m_maximumPoolSize})");
+			if (state.Waiting > 0 && state.Idle > 0)
+				throw new InvalidOperationException($"Can't have waiters ({state.Waiting}) while there are idle connections ({state.Idle}");
+			if (state.Idle < 0)
+				throw new InvalidOperationException("Idle is negative");
+			if (state.Busy < 0)
+				throw new InvalidOperationException("Busy is negative");
+			if (state.Waiting < 0)
+				throw new InvalidOperationException("Waiting is negative");
+		}
+
 		static readonly IMySqlConnectorLogger Log = MySqlConnectorLogManager.CreateLogger(nameof(ConnectionPool));
 		static readonly ConcurrentDictionary<string, ConnectionPool> s_pools = new ConcurrentDictionary<string, ConnectionPool>();
 
@@ -539,16 +870,24 @@ namespace MySqlConnector.Core
 		static ConnectionStringPool s_mruCache;
 
 		int m_generation;
-		readonly SemaphoreSlim m_cleanSemaphore;
-		readonly SemaphoreSlim m_sessionSemaphore;
-		readonly LinkedList<ServerSession> m_sessions;
+		readonly int m_maximumPoolSize;
+		readonly int m_minimumPoolSize;
+		readonly ServerSession[] m_idleSessions;
+		readonly ConcurrentQueue<OpenAttempt> m_waiting;
 		readonly Dictionary<string, ServerSession> m_leasedSessions;
 		readonly ILoadBalancer m_loadBalancer;
 		readonly Dictionary<string, int> m_hostSessions;
 		readonly object[] m_logArguments;
-		Task m_reaperTask;
+		readonly TimeSpan m_pruningInterval;
+		Timer m_pruningTimer;
 		uint m_lastRecoveryTime;
 		int m_lastSessionId;
 		Dictionary<string, CachedProcedure> m_procedureCache;
+		PoolState m_state;
+
+		/// <summary>
+		/// Maximum number of possible connections in any single pool.
+		/// </summary>
+		internal const int PoolSizeLimit = 4096;
 	}
 }

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -101,7 +101,7 @@ namespace MySqlConnector.Core
 						int leasedSessionsCountPooled;
 						lock (m_leasedSessions)
 						{
-							m_leasedSessions.Add(session.Id, session);
+							m_leasedSessions.Add(session);
 							leasedSessionsCountPooled = m_leasedSessions.Count;
 						}
 						if (Log.IsDebugEnabled())
@@ -121,7 +121,7 @@ namespace MySqlConnector.Core
 				int leasedSessionsCountNew;
 				lock (m_leasedSessions)
 				{
-					m_leasedSessions.Add(session.Id, session);
+					m_leasedSessions.Add(session);
 					leasedSessionsCountNew = m_leasedSessions.Count;
 				}
 				if (Log.IsDebugEnabled())
@@ -155,7 +155,7 @@ namespace MySqlConnector.Core
 				Log.Debug("Pool{0} receiving Session{1} back", m_logArguments[0], session.Id);
 
 			lock (m_leasedSessions)
-				m_leasedSessions.Remove(session.Id);
+				m_leasedSessions.Remove(session);
 			session.OwningConnection = null;
 			var sessionHealth = GetSessionHealth(session);
 			if (sessionHealth != 0)
@@ -312,7 +312,7 @@ namespace MySqlConnector.Core
 			lock (m_leasedSessions)
 			{
 				m_lastRecoveryTime = unchecked((uint) Environment.TickCount);
-				foreach (var session in m_leasedSessions.Values)
+				foreach (var session in m_leasedSessions)
 				{
 					if (!session.OwningConnection.TryGetTarget(out var _))
 						recoveredSessions.Add(session);
@@ -410,7 +410,7 @@ namespace MySqlConnector.Core
 			m_pruningInterval = TimeSpan.FromSeconds(Math.Max(1, Math.Min(60, ConnectionSettings.ConnectionIdleTimeout / 2)));
 			m_idleSessions = new ServerSession[m_maximumPoolSize];
 			m_waiting = new ConcurrentQueue<OpenAttempt>();
-			m_leasedSessions = new Dictionary<string, ServerSession>();
+			m_leasedSessions = new List<ServerSession>();
 			if (cs.LoadBalance == MySqlLoadBalance.LeastConnections)
 			{
 				m_hostSessions = new Dictionary<string, int>();
@@ -865,7 +865,7 @@ namespace MySqlConnector.Core
 		readonly int m_minimumPoolSize;
 		readonly ServerSession[] m_idleSessions;
 		readonly ConcurrentQueue<OpenAttempt> m_waiting;
-		readonly Dictionary<string, ServerSession> m_leasedSessions;
+		readonly List<ServerSession> m_leasedSessions;
 		readonly ILoadBalancer m_loadBalancer;
 		readonly Dictionary<string, int> m_hostSessions;
 		readonly object[] m_logArguments;

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -58,6 +58,8 @@ namespace MySqlConnector.Core
 			ConnectionIdleTimeout = (int) csb.ConnectionIdleTimeout;
 			if (csb.MinimumPoolSize > csb.MaximumPoolSize)
 				throw new MySqlException("MaximumPoolSize must be greater than or equal to MinimumPoolSize");
+			if (csb.MaximumPoolSize > ConnectionPool.PoolSizeLimit)
+				throw new MySqlException("MaximumPoolSize must be less than or equal to {0}".FormatInvariant(ConnectionPool.PoolSizeLimit));
 			MinimumPoolSize = (int) csb.MinimumPoolSize;
 			MaximumPoolSize = (int) csb.MaximumPoolSize;
 

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -54,7 +54,7 @@ namespace MySqlConnector.Core
 		public uint CreatedTicks { get; }
 		public ConnectionPool Pool { get; }
 		public int PoolGeneration { get; }
-		public uint LastReturnedTicks { get; private set; }
+		public uint LastReturnedTicks { get; set; }
 		public string DatabaseOverride { get; set; }
 		public string HostName { get; private set; }
 		public IPAddress IPAddress => (m_tcpClient?.Client.RemoteEndPoint as IPEndPoint)?.Address;
@@ -63,16 +63,7 @@ namespace MySqlConnector.Core
 		public bool SupportsSessionTrack => m_supportsSessionTrack;
 		public bool ProcAccessDenied { get; set; }
 
-		public void ReturnToPool()
-		{
-			if (Log.IsDebugEnabled())
-			{
-				m_logArguments[1] = Pool?.Id;
-				Log.Debug("Session{0} returning to Pool{1}", m_logArguments);
-			}
-			LastReturnedTicks = unchecked((uint) Environment.TickCount);
-			Pool?.Return(this);
-		}
+		public void ReturnToPool() => Pool?.Return(this);
 
 		public bool IsConnected
 		{

--- a/tests/MySqlConnector.Tests/ConnectionTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionTests.cs
@@ -101,7 +101,7 @@ namespace MySqlConnector.Tests
 			using (var connection = new MySqlConnection(m_csb.ConnectionString))
 			{
 				await connection.OpenAsync();
-				Assert.Equal(size, m_server.ActiveConnections);
+				Assert.Equal(1, m_server.ActiveConnections);
 			}
 		}
 


### PR DESCRIPTION
Implements a lock-free connection pool based on npgsql's implementation, along with some potential optimisations (that need to be tested) for MySqlConnector-specific features, such more LIFO-like behaviour and recovering leaked `MySqlConnection`s.