### PR TITLE
GetBoolean might be called on a decimal

### DIFF
--- a/src/MySqlConnector/Core/Row.cs
+++ b/src/MySqlConnector/Core/Row.cs
@@ -61,6 +61,8 @@ namespace MySqlConnector.Core
 				return (long) value != 0;
 			if (value is ulong)
 				return (ulong) value != 0;
+			if (value is decimal)
+				return (decimal) value != 0;
 			return (bool) value;
 		}
 

--- a/tests/Conformance.Tests/GetValueConversionTests.cs
+++ b/tests/Conformance.Tests/GetValueConversionTests.cs
@@ -11,7 +11,7 @@ namespace Conformance.Tests
 		{
 		}
 
-		// GetBoolean allows conversions from any integral type for backwards compatibility
+		// GetBoolean allows conversions from any integral type and decimal for backwards compatibility
 		public override void GetBoolean_throws_for_maximum_Byte() => TestGetValue(DbType.Byte, ValueKind.Maximum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_maximum_Int16() => TestGetValue(DbType.Int16, ValueKind.Maximum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_maximum_Int32() => TestGetValue(DbType.Int32, ValueKind.Maximum, x => x.GetBoolean(0), true);
@@ -20,6 +20,7 @@ namespace Conformance.Tests
 		public override void GetBoolean_throws_for_maximum_UInt16() => TestGetValue(DbType.UInt16, ValueKind.Maximum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_maximum_UInt32() => TestGetValue(DbType.UInt32, ValueKind.Maximum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_maximum_UInt64() => TestGetValue(DbType.UInt64, ValueKind.Maximum, x => x.GetBoolean(0), true);
+		public override void GetBoolean_throws_for_maximum_Decimal() => TestGetValue(DbType.Decimal, ValueKind.Maximum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_minimum_Byte() => TestGetValue(DbType.Byte, ValueKind.Minimum, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_minimum_Int16() => TestGetValue(DbType.Int16, ValueKind.Minimum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_minimum_Int32() => TestGetValue(DbType.Int32, ValueKind.Minimum, x => x.GetBoolean(0), true);
@@ -28,6 +29,7 @@ namespace Conformance.Tests
 		public override void GetBoolean_throws_for_minimum_UInt16() => TestGetValue(DbType.UInt16, ValueKind.Minimum, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_minimum_UInt32() => TestGetValue(DbType.UInt32, ValueKind.Minimum, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_minimum_UInt64() => TestGetValue(DbType.UInt64, ValueKind.Minimum, x => x.GetBoolean(0), false);
+		public override void GetBoolean_throws_for_minimum_Decimal() => TestGetValue(DbType.Decimal, ValueKind.Minimum, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_one_Byte() => TestGetValue(DbType.Byte, ValueKind.One, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_one_Int16() => TestGetValue(DbType.Int16, ValueKind.One, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_one_Int32() => TestGetValue(DbType.Int32, ValueKind.One, x => x.GetBoolean(0), true);
@@ -36,6 +38,7 @@ namespace Conformance.Tests
 		public override void GetBoolean_throws_for_one_UInt16() => TestGetValue(DbType.UInt16, ValueKind.One, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_one_UInt32() => TestGetValue(DbType.UInt32, ValueKind.One, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_one_UInt64() => TestGetValue(DbType.UInt64, ValueKind.One, x => x.GetBoolean(0), true);
+		public override void GetBoolean_throws_for_one_Decimal() => TestGetValue(DbType.Decimal, ValueKind.One, x => x.GetBoolean(0), true);
 		public override void GetBoolean_throws_for_zero_Byte() => TestGetValue(DbType.Byte, ValueKind.Zero, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_zero_Int16() => TestGetValue(DbType.Int16, ValueKind.Zero, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_zero_Int32() => TestGetValue(DbType.Int32, ValueKind.Zero, x => x.GetBoolean(0), false);
@@ -44,6 +47,7 @@ namespace Conformance.Tests
 		public override void GetBoolean_throws_for_zero_UInt16() => TestGetValue(DbType.UInt16, ValueKind.Zero, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_zero_UInt32() => TestGetValue(DbType.UInt32, ValueKind.Zero, x => x.GetBoolean(0), false);
 		public override void GetBoolean_throws_for_zero_UInt64() => TestGetValue(DbType.UInt64, ValueKind.Zero, x => x.GetBoolean(0), false);
+		public override void GetBoolean_throws_for_zero_Decimal() => TestGetValue(DbType.Decimal, ValueKind.Zero, x => x.GetBoolean(0), false);
 
 		// GetByte allows integral conversions
 		public override void GetByte_throws_for_maximum_Int16() => TestException(DbType.Int16, ValueKind.Maximum, x => x.GetByte(0), typeof(OverflowException));


### PR DESCRIPTION
The following test (and 1 more) currently fails in Pomelo.MySql:
https://github.com/aspnet/EntityFrameworkCore/blob/817aaea6ca1a24a29e8e9f3a7b2dd3748956d942/test/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs#L1503-L1519

It gets translated to:
```sql
SELECT COALESCE(`w0`.`IsAutomatic`, FALSE)
FROM `Weapons` AS `w`
LEFT JOIN `Weapons` AS `w0` ON `w`.`SynergyWithId` = `w0`.`Id`
ORDER BY `w`.`Id`
```
It seems that `COALESCE` is returning a `decimal` for `IsAutomatic`, though the column is actually of type `bit(1)`. The code expects a `bool` and calls `GetBoolean`, which then throws.

This fix allows the explicit conversion from `decimal` to `bool` within `Row.GetBoolean()`.

This is not critical, so we don't need a quick release for this.