### PR TITLE
CI: Use windows MySQL docker image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
 - job: windows_build
   displayName: 'Windows Build'
   pool:
-    vmimage: 'vs2017-win2016'
+    vmimage: 'windows-2019'
   steps:
   - template: '.ci/build-steps.yml'
   - task: DotNetCoreCLI@2
@@ -46,21 +46,33 @@ jobs:
 - job: windows_baseline
   displayName: 'Baseline'
   pool:
-    vmimage: 'vs2017-win2016'
+    vmimage: 'windows-2019'
   steps:
   - script: |
-      mkdir C:\mysql
-      CD /D C:\mysql
-      curl -fsS --retry 3 --retry-connrefused -o mysql.msi https://cdn.mysql.com/archives/mysql-installer/mysql-installer-community-8.0.15.0.msi
-      msiexec /q /log install.txt /i mysql.msi datadir=C:\mysql installdir=C:\mysql
-      call "C:\Program Files (x86)\MySQL\MySQL Installer for Windows\MySQLInstallerConsole.exe" community install server;8.0.15;x64:*:port=3306;rootpasswd=test;servicename=MySQL -silent
+      docker run -d  --name "mysql" -e "MYSQL_ROOT_PASSWORD=test" -p "3306:3306" pomelofoundation/mysql-windows:8-ltsc2019
       netsh advfirewall firewall add rule name="Allow mysql" dir=in action=allow edge=yes remoteip=any protocol=TCP localport=3306
     displayName: Install MySQL Server
+  - pwsh: |
+      $started=$false
+      for ($i=0; $i -le 180; $i++) {
+        docker exec mysql mysqladmin -h localhost -P 3306 -u root -ptest status
+        if ($LastExitCode -eq 0) {
+          $started=$true
+          break;
+        }
+        Start-Sleep 1
+      }
+      if (!$started) {
+        Write-Error "mysql container failed to start in 180 seconds"
+        exit 1
+      }
+    displayName: Wait for MySQL Server to Start
+    errorActionPreference: continue
   - script: |
-      "C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql" -uroot -ptest -e "SET GLOBAL local_infile=1; SET GLOBAL log_bin_trust_function_creators=1;"
-      "C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql" -uroot -ptest < $(Build.Repository.LocalPath)\.ci\server\init.sql
-      "C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql" -uroot -ptest < $(Build.Repository.LocalPath)\.ci\server\init_sha256.sql
-      "C:\Program Files\MySQL\MySQL Server 8.0\bin\mysql" -uroot -ptest < $(Build.Repository.LocalPath)\.ci\server\init_caching_sha2.sql
+      docker exec -i mysql mysql -h localhost -P 3306 -u root -ptest -e "SET GLOBAL local_infile=1; SET GLOBAL log_bin_trust_function_creators=1;"
+      docker exec -i mysql mysql -h localhost -P 3306 -u root -ptest < $(Build.Repository.LocalPath)\.ci\server\init.sql
+      docker exec -i mysql mysql -h localhost -P 3306 -u root -ptest < $(Build.Repository.LocalPath)\.ci\server\init_sha256.sql
+      docker exec -i mysql mysql -h localhost -P 3306 -u root -ptest < $(Build.Repository.LocalPath)\.ci\server\init_caching_sha2.sql
     displayName: Configure MySQL Server
   - task: CopyFiles@2
     displayName: 'Copy config.json'
@@ -121,7 +133,7 @@ jobs:
   dependsOn: windows_build
   displayName: 'Windows Unit Tests'
   pool:
-    vmimage: 'vs2017-win2016'
+    vmimage: 'windows-2019'
   steps:
   - template: '.ci/mysqlconnector-tests-steps.yml'
 


### PR DESCRIPTION
I created a Windows Docker Image for Pomelo for CI.

Opening this in the chance you want to use it as well.  Only real benefit is that it's an immutable image coming from DockerHub as opposed to a download link from oracle.

Windows Docker Images do come with a downside.  Azure Build Agents only support process isolation (not hyper-v Isolation) so images [compatibility](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility) is tied to the Host OS.  This specific image works with Windows Server 2019.  The Docker Image is open source at [PomeloFoundation/MySql-Windows-Docker](https://github.com/PomeloFoundation/MySql-Windows-Docker) and it will be easy to update for new versions of Windows Server.

Base layers from `mcr.microsoft.com/windows/servercore:ltsc2019` are [cached](https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md#docker-images) on the Azure DevOps Windows 2019 build server already, so it will not incur the ~2GB download penalty for that base image.  It will just download the layers that contain MySQL and configuration.