### PR TITLE
SqlBulkCopy throws exception when output byte buffer is too small

### DIFF
--- a/src/MySqlConnector/Utilities/Utility.cs
+++ b/src/MySqlConnector/Utilities/Utility.cs
@@ -44,6 +44,14 @@ namespace MySqlConnector.Utilities
 #endif
 		}
 
+		public static unsafe int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+		{
+			fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))
+			{
+				return encoding.GetByteCount(charsPtr, chars.Length);
+			}
+		}
+
 		public static unsafe int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
 		{
 			fixed (char* charsPtr = &MemoryMarshal.GetReference(chars))

--- a/tests/MySqlConnector.Tests/MySqlBulkCopyTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlBulkCopyTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Text;
+using MySql.Data.MySqlClient;
+using Xunit;
+
+namespace MySqlConnector.Tests
+{
+	public class MySqlBulkCopyTests
+	{
+		[Fact]
+		public void WriteStringDoesNotWriteWhenBufferIsTooSmall()
+		{
+			var value = "input string value";
+
+			var valueByteCount = Encoding.UTF8.GetByteCount(value);
+			var output = new byte[valueByteCount - 1];
+
+			Assert.False(MySqlBulkCopy.WriteString(value, output.AsSpan(), out var bytesWritten));
+			Assert.Equal(0, bytesWritten);
+		}
+
+		[Fact]
+		public void WriteStringDoesNotWriteWhenBufferIsFull()
+		{
+			var value = "input string value";
+
+			var valueByteCount = Encoding.UTF8.GetByteCount(value);
+			var output = new byte[valueByteCount];
+
+			Assert.False(MySqlBulkCopy.WriteString(value, output.AsSpan(), out var bytesWritten));
+			Assert.Equal(0, bytesWritten);
+		}
+
+		[Fact]
+		public void WriteStringDoesWriteEncodedString()
+		{
+			var value = "input string value";
+
+			var valueByteCount = Encoding.UTF8.GetByteCount(value);
+			var output = new byte[valueByteCount + 1];
+
+			Assert.True(MySqlBulkCopy.WriteString(value, output.AsSpan(), out var bytesWritten));
+			Assert.Equal(valueByteCount, bytesWritten);
+
+			var decodedValue = Encoding.UTF8.GetString(output.AsSpan(0, bytesWritten));
+			Assert.Equal(value, decodedValue);
+		}
+	}
+}


### PR DESCRIPTION
This pull requests resolves an issue I encountered when bulk-copying data: Output byte buffer is too small when writing string values.

The code used [Encoding.GetBytes()](https://github.com/mysql-net/MySqlConnector/blob/8e9ea2739d2a119825c7afd90d45f693561c3c83/src/MySqlConnector/MySql.Data.MySqlClient/MySqlBulkCopy.cs#L378) which throws this exception when the output buffer is unable to hold the encoded value-bytes.

In this PR I added a GetByteCount call to prevent this Exception.

Note: I also considered rewriting the code to [Encoding.GetEncoder().Convert()](https://docs.microsoft.com/en-us/dotnet/api/system.text.encoder.convert?view=netcore-3.1#System_Text_Encoder_Convert_System_ReadOnlySpan_System_Char__System_Span_System_Byte__System_Boolean_System_Int32__System_Int32__System_Boolean__). I've chosen to stick to the GetBytes method to prevent regression issues, despite the introduced performance decrease.