### PR TITLE
Have the same casts in GetDecimal as in GetDouble

### DIFF
--- a/src/MySqlConnector/Core/Row.cs
+++ b/src/MySqlConnector/Core/Row.cs
@@ -350,7 +350,13 @@ namespace MySqlConnector.Core
 
 		public string GetString(int ordinal) => (string) GetValue(ordinal);
 
-		public decimal GetDecimal(int ordinal) => (decimal) GetValue(ordinal);
+		public decimal GetDecimal(int ordinal)
+		{
+			var value = GetValue(ordinal);
+			return value is float floatValue ? (decimal) floatValue :
+				value is double decimalValue ? (decimal) decimalValue :
+				(decimal) value;
+		}
 
 		public double GetDouble(int ordinal)
 		{

--- a/tests/Conformance.Tests/GetValueConversionTests.cs
+++ b/tests/Conformance.Tests/GetValueConversionTests.cs
@@ -159,6 +159,24 @@ namespace Conformance.Tests
 		public override void GetDateTime_for_minimum_DateTime() => TestGetValue(DbType.Date, ValueKind.Minimum, x => x.GetDateTime(0), new DateTime(1000, 1, 1));
 		public override void GetDateTime_for_minimum_DateTime_with_GetFieldValue() => TestGetValue(DbType.Date, ValueKind.Minimum, x => x.GetDateTime(0), new DateTime(1000, 1, 1));
 
+		// GetDecimal() allows conversions from float/double
+		public override void GetDecimal_throws_for_zero_Single() => TestGetValue(DbType.Single, ValueKind.Zero, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_zero_Single_with_GetFieldValue() => TestGetValue(DbType.Single, ValueKind.Zero, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_one_Single() => TestGetValue(DbType.Single, ValueKind.One, x => x.GetDecimal(0), 1m);
+		public override void GetDecimal_throws_for_one_Single_with_GetFieldValue() => TestGetValue(DbType.Single, ValueKind.One, x => x.GetDecimal(0), 1m);
+		public override void GetDecimal_throws_for_minimum_Single() => TestGetValue(DbType.Single, ValueKind.Minimum, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_minimum_Single_with_GetFieldValue() => TestGetValue(DbType.Single, ValueKind.Minimum, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_maximum_Single() => TestException(DbType.Single, ValueKind.Maximum, x => x.GetDecimal(0), typeof(OverflowException));
+		public override void GetDecimal_throws_for_maximum_Single_with_GetFieldValue() => TestException(DbType.Single, ValueKind.Maximum, x => x.GetDecimal(0), typeof(OverflowException));
+		public override void GetDecimal_throws_for_zero_Double() => TestGetValue(DbType.Double, ValueKind.Zero, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_zero_Double_with_GetFieldValue() => TestGetValue(DbType.Double, ValueKind.Zero, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_one_Double() => TestGetValue(DbType.Double, ValueKind.One, x => x.GetDecimal(0), 1m);
+		public override void GetDecimal_throws_for_one_Double_with_GetFieldValue() => TestGetValue(DbType.Double, ValueKind.One, x => x.GetDecimal(0), 1m);
+		public override void GetDecimal_throws_for_minimum_Double() => TestGetValue(DbType.Double, ValueKind.Minimum, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_minimum_Double_with_GetFieldValue() => TestGetValue(DbType.Double, ValueKind.Minimum, x => x.GetDecimal(0), 0m);
+		public override void GetDecimal_throws_for_maximum_Double() => TestException(DbType.Double, ValueKind.Maximum, x => x.GetDecimal(0), typeof(OverflowException));
+		public override void GetDecimal_throws_for_maximum_Double_with_GetFieldValue() => TestException(DbType.Double, ValueKind.Maximum, x => x.GetDecimal(0), typeof(OverflowException));
+
 		// The GetFloat() implementation allows for conversions from double to float.
 		// The minimum tests for float and double do not test for the smallest possible value (as the tests for integer values do),
 		// but test for the largest value smaller than 0 (Epsilon).


### PR DESCRIPTION
Support casts to `decimal` from `float`/`double`.

Rationale:
It is already supported for the other way.  
Casting from `decimal` to `float`/`double` could result in data loss.  
If that is supported, so why not the other way, where there's no data loss?