### PR TITLE
Sort out happy flows for fastest execution for expected types

### DIFF
--- a/src/MySqlConnector/Core/Row.cs
+++ b/src/MySqlConnector/Core/Row.cs
@@ -353,22 +353,38 @@ namespace MySqlConnector.Core
 		public decimal GetDecimal(int ordinal)
 		{
 			var value = GetValue(ordinal);
-			return value is float floatValue ? (decimal) floatValue :
-				value is double decimalValue ? (decimal) decimalValue :
-				(decimal) value;
+			if (value is decimal) // happy flow
+				return (decimal) value;
+
+			if (value is double doubleValue)
+				return (decimal) doubleValue;
+
+			if (value is float floatValue)
+				return (decimal) floatValue;
+
+			return (decimal) value;
 		}
 
 		public double GetDouble(int ordinal)
 		{
 			var value = GetValue(ordinal);
-			return value is float floatValue ? floatValue :
-				value is decimal decimalValue ? (double) decimalValue :
-				(double) value;
+			if (value is double) // happy flow
+				return (double) value;
+
+			if (value is float floatValue)
+				return floatValue;
+
+			if (value is decimal decimalValue)
+				return (double) decimalValue;
+
+			return (double) value;
 		}
 
 		public float GetFloat(int ordinal)
 		{
 			var value = GetValue(ordinal);
+			if (value is float) // happy flow
+				return (float) value;
 
 			// Loss of precision is expected, significant loss of information is not.
 			// Use explicit range checks to guard against that.


### PR DESCRIPTION
* double for GetDouble
* float for GetFloat
* decimal for GetDecimal

I set up a fiddle https://dotnetfiddle.net/ZIoKbK to demonstrate the performance differences.
This shows that for the "happy flow" the current implementation is slower by almost 100% than the suggested one.

In int types this is already sorted out.

This avoids the use of the ternary operator, which results in perceived more lines of code, but clearer execution path and more consistent with the implementation of `GetInt__`.