### PR TITLE
Allows the use of snapshot isolation level on transactions

### DIFF
--- a/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
+++ b/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
@@ -29,9 +29,9 @@ namespace MySqlConnector.Core
 				_ => "repeatable read",
 			};
 
-			var cosistentSnapshotText = Transaction.IsolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
-			using var cmd = new MySqlCommand($"set transaction isolation level {isolationLevel}; start transation{cosistentSnapshotText}", Connection);
-			cmd.ExecuteNonQuery();
+			var consistentSnapshotText = Transaction.IsolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
+			using (var cmd = new MySqlCommand($"set transaction isolation level {isolationLevel}; start transaction{consistentSnapshotText};", Connection))
+				cmd.ExecuteNonQuery();
 		}
 
 		protected override void OnPrepare(PreparingEnlistment enlistment)

--- a/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
+++ b/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
@@ -21,7 +21,7 @@ namespace MySqlConnector.Core
 				IsolationLevel.ReadCommitted => "read committed",
 				IsolationLevel.ReadUncommitted => "read uncommitted",
 				IsolationLevel.RepeatableRead => "repeatable read",
-				IsolationLevel.Snapshot => throw new NotSupportedException("IsolationLevel.{0} is not supported.".FormatInvariant(Transaction.IsolationLevel)),
+				IsolationLevel.Snapshot => "repeatable read",
 				IsolationLevel.Chaos => throw new NotSupportedException("IsolationLevel.{0} is not supported.".FormatInvariant(Transaction.IsolationLevel)),
 
 				// "In terms of the SQL:1992 transaction isolation levels, the default InnoDB level is REPEATABLE READ." - http://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-model.html
@@ -29,7 +29,8 @@ namespace MySqlConnector.Core
 				_ => "repeatable read",
 			};
 
-			using var cmd = new MySqlCommand("set transaction isolation level " + isolationLevel + "; start transaction;", Connection);
+			var cosistentSnapshotText = Transaction.IsolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
+			using var cmd = new MySqlCommand($"set transaction isolation level {isolationLevel}; start transation{cosistentSnapshotText}", Connection);
 			cmd.ExecuteNonQuery();
 		}
 

--- a/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
+++ b/src/MySqlConnector/Core/StandardEnlistedTransaction.cs
@@ -30,8 +30,8 @@ namespace MySqlConnector.Core
 			};
 
 			var consistentSnapshotText = Transaction.IsolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
-			using (var cmd = new MySqlCommand($"set transaction isolation level {isolationLevel}; start transaction{consistentSnapshotText};", Connection))
-				cmd.ExecuteNonQuery();
+			using var cmd = new MySqlCommand($"set transaction isolation level {isolationLevel}; start transaction{consistentSnapshotText};", Connection);
+			cmd.ExecuteNonQuery();
 		}
 
 		protected override void OnPrepare(PreparingEnlistment enlistment)

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -31,8 +31,8 @@ namespace MySql.Data.MySqlClient
 			m_connectionString = connectionString ?? "";
 		}
 
-		public new MySqlTransaction BeginTransaction() => (MySqlTransaction)base.BeginTransaction();
-		public new MySqlTransaction BeginTransaction(IsolationLevel isolationLevel) => (MySqlTransaction)base.BeginTransaction(isolationLevel);
+		public new MySqlTransaction BeginTransaction() => (MySqlTransaction) base.BeginTransaction();
+		public new MySqlTransaction BeginTransaction(IsolationLevel isolationLevel) => (MySqlTransaction) base.BeginTransaction(isolationLevel);
 		protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => BeginDbTransactionAsync(isolationLevel, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 #if !NETSTANDARD2_1 && !NETCOREAPP3_0

--- a/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySql.Data.MySqlClient/MySqlConnection.cs
@@ -71,9 +71,9 @@ namespace MySql.Data.MySqlClient
 				_ => throw new NotSupportedException("IsolationLevel.{0} is not supported.".FormatInvariant(isolationLevel))
 			};
 
-			var cosistentSnapshotText = isolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
+			var consistentSnapshotText = isolationLevel == IsolationLevel.Snapshot ? " with consistent snapshot" : string.Empty;
 
-			using (var cmd = new MySqlCommand($"set transaction isolation level {isolationLevelValue}; start transation{cosistentSnapshotText}", this))
+			using (var cmd = new MySqlCommand($"set transaction isolation level {isolationLevelValue}; start transaction{consistentSnapshotText};", this))
 				await cmd.ExecuteNonQueryAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 
 			var transaction = new MySqlTransaction(this, isolationLevel);

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -77,14 +77,15 @@ namespace SideBySide
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
 
-#if !BASELINE
 		[Theory]
 		[InlineData(IsolationLevel.ReadUncommitted, "start transaction")]
 		[InlineData(IsolationLevel.ReadCommitted, "start transaction")]
 		[InlineData(IsolationLevel.RepeatableRead, "start transaction")]
 		[InlineData(IsolationLevel.Serializable, "start transaction")]
 		[InlineData(IsolationLevel.Unspecified, "start transaction")]
+#if !BASELINE
 		[InlineData(IsolationLevel.Snapshot, "start transaction with consistent snapshot")]
+#endif
 		public void DbConnectionTransactionCommand(IsolationLevel inputIsolationLevel, string expectedTransactionIsolationLevel)
 		{
 			DbConnection connection = m_connection;
@@ -98,9 +99,10 @@ namespace SideBySide
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
 			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start"));
-			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
+			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}
 
+#if !BASELINE
 		[Fact]
 		public async Task CommitAsync()
 		{

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -71,7 +71,7 @@ namespace SideBySide
 
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 4;");
-			Assert.Contains(expectedTransactionIsolationLevel, results.Last());
+			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), results.Last().ToLower());
 		}
 
 		[Theory]
@@ -93,7 +93,7 @@ namespace SideBySide
 
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 3;");
-			Assert.Equal(expectedTransactionIsolationLevel, results.Last());
+			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), results.Last().ToLower());
 		}
 
 #if !BASELINE

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -70,8 +70,9 @@ namespace SideBySide
 			}
 
 			m_connection.Execute(@"set global general_log = 0;");
-			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 4;");
-			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), results.Last().ToLower());
+			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 10;");
+			var lastIsolationLevelQuery = results.First(x => x.ToLower().Contains("set transaction isolation level"));
+			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
 
 		[Theory]
@@ -92,8 +93,9 @@ namespace SideBySide
 			}
 
 			m_connection.Execute(@"set global general_log = 0;");
-			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 3;");
-			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), results.Last().ToLower());
+			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 10;");
+			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start transaction"));
+			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}
 
 #if !BASELINE

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -70,7 +70,7 @@ namespace SideBySide
 			}
 
 			m_connection.Execute(@"set global general_log = 0;");
-			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 10;");
+			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
 			var lastIsolationLevelQuery = results.First(x => x.ToLower().Contains("set transaction isolation level"));
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
@@ -93,7 +93,7 @@ namespace SideBySide
 			}
 
 			m_connection.Execute(@"set global general_log = 0;");
-			var results = connection.Query<string>(@"select convert(argument USING utf8) from mysql.general_log order by event_time desc limit 10;");
+			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
 			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start transaction"));
 			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -57,8 +57,10 @@ namespace SideBySide
 		[InlineData(IsolationLevel.ReadCommitted, "read committed")]
 		[InlineData(IsolationLevel.RepeatableRead, "repeatable read")]
 		[InlineData(IsolationLevel.Serializable, "serializable")]
-		[InlineData(IsolationLevel.Snapshot, "repeatable read")]
 		[InlineData(IsolationLevel.Unspecified, "repeatable read")]
+#if !BASELINE
+		[InlineData(IsolationLevel.Snapshot, "repeatable read")]
+#endif
 		public void DbConnectionIsolationLevel(IsolationLevel inputIsolationLevel, string expectedTransactionIsolationLevel)
 		{
 			DbConnection connection = m_connection;
@@ -75,6 +77,7 @@ namespace SideBySide
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
 
+#if !BASELINE
 		[Theory]
 		[InlineData(IsolationLevel.ReadUncommitted, "start transaction")]
 		[InlineData(IsolationLevel.ReadCommitted, "start transaction")]
@@ -98,7 +101,6 @@ namespace SideBySide
 			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}
 
-#if !BASELINE
 		[Fact]
 		public async Task CommitAsync()
 		{

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -71,7 +71,7 @@ namespace SideBySide
 
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
-			var lastIsolationLevelQuery = results.First(x => x.ToLower().Contains("set transaction isolation level"));
+			var lastIsolationLevelQuery = results.First(x => x.ToLower().Contains("isolation"));
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
 
@@ -94,7 +94,7 @@ namespace SideBySide
 
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
-			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start transaction"));
+			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start"));
 			Assert.Equal(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}
 

--- a/tests/SideBySide/Transaction.cs
+++ b/tests/SideBySide/Transaction.cs
@@ -74,18 +74,24 @@ namespace SideBySide
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
 			var lastIsolationLevelQuery = results.First(x => x.ToLower().Contains("isolation"));
+
+			if (IsMySqlAndVersionLessThan57(m_connection.ServerVersion))
+			{
+				Assert.Contains("serializable", lastIsolationLevelQuery.ToLower());
+				return;
+			}
+
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastIsolationLevelQuery.ToLower());
 		}
 
+#if !BASELINE
 		[Theory]
 		[InlineData(IsolationLevel.ReadUncommitted, "start transaction")]
 		[InlineData(IsolationLevel.ReadCommitted, "start transaction")]
 		[InlineData(IsolationLevel.RepeatableRead, "start transaction")]
 		[InlineData(IsolationLevel.Serializable, "start transaction")]
 		[InlineData(IsolationLevel.Unspecified, "start transaction")]
-#if !BASELINE
 		[InlineData(IsolationLevel.Snapshot, "start transaction with consistent snapshot")]
-#endif
 		public void DbConnectionTransactionCommand(IsolationLevel inputIsolationLevel, string expectedTransactionIsolationLevel)
 		{
 			DbConnection connection = m_connection;
@@ -99,10 +105,16 @@ namespace SideBySide
 			m_connection.Execute(@"set global general_log = 0;");
 			var results = connection.Query<string>($"select convert(argument USING utf8) from mysql.general_log where thread_id = {m_connection.ServerThread} order by event_time desc limit 10;");
 			var lastStartTransactionQuery = results.First(x => x.ToLower().Contains("start"));
+
+			if (IsMySqlAndVersionLessThan57(m_connection.ServerVersion))
+			{
+				Assert.Contains("start transaction", lastStartTransactionQuery.ToLower());
+				return;
+			}
+
 			Assert.Contains(expectedTransactionIsolationLevel.ToLower(), lastStartTransactionQuery.ToLower());
 		}
 
-#if !BASELINE
 		[Fact]
 		public async Task CommitAsync()
 		{
@@ -369,6 +381,20 @@ namespace SideBySide
 			Assert.Equal(new int[0], results);
 		}
 #endif
+
+		private bool IsMySqlAndVersionLessThan57(string currentVersionStr)
+		{
+			var version = new Version("5.7");
+			Version currentVersion = null;
+
+			if (Version.TryParse(currentVersionStr, out currentVersion))
+			{
+				var result = version.CompareTo(currentVersion);
+				return result > 0;
+			}
+
+			return false;
+		}
 
 		readonly TransactionFixture m_database;
 		readonly MySqlConnection m_connection;


### PR DESCRIPTION
Allows the use of using the isolation level snapshot for transactions, as per https://dev.mysql.com/doc/refman/5.7/en/commit.html