### PR TITLE
Fix EF Core issue when using MySqlGeometry.Value

### DIFF
--- a/src/MySqlConnector/MySql.Data.Types/MySqlGeometry.cs
+++ b/src/MySqlConnector/MySql.Data.Types/MySqlGeometry.cs
@@ -38,12 +38,12 @@ namespace MySql.Data.Types
 		/// <summary>
 		/// The Well-known Binary serialization of this geometry.
 		/// </summary>
-		public ReadOnlySpan<byte> WKB => Value.Slice(4);
+		public ReadOnlySpan<byte> WKB => new ReadOnlySpan<byte>(Value).Slice(4);
 
 		/// <summary>
 		/// The internal MySQL form of this geometry.
 		/// </summary>
-		public ReadOnlySpan<byte> Value => m_bytes;
+		public byte[] Value => m_bytes;
 
 		internal MySqlGeometry(byte[] bytes) => m_bytes = bytes;
 


### PR DESCRIPTION
EF Core throws an exception, when using `MySqlGeometry`, because there is some very general code in `Microsoft.EntityFrameworkCore.Storage.Internal.DbParameterCollectionExtensions.FormatParameterValue(StringBuilder builder, object parameterValue)`, that is unable to handle the `ReadOnlySpan<byte>` type of `MySqlGeometry.Value`.

This PR changes the type to `byte[]` instead. Technically, this is a breaking change for anyone who used the `Value` property before. But because of the implicit cast between `byte[]` and `ReadOnlySpan<byte>`, this should be less of an issue.

In any case, if there is an issue in someones code, this change will lead to a compiler error, that can be easily fixed by replacing `Value` with either `Value.AsSpan()` or `new ReadOnlySpan<byte>(Value)`.