### PR TITLE
Allows for the retrievel of more than 2^31-1 rows in a single query.

### DIFF
--- a/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
+++ b/src/MySqlConnector/Protocol/Serialization/StandardPayloadHandler.cs
@@ -47,6 +47,6 @@ namespace MySqlConnector.Protocol.Serialization
 		readonly Func<int> m_getNextSequenceNumber;
 		IByteHandler? m_byteHandler;
 		BufferedByteReader? m_bufferedByteReader;
-		int m_sequenceNumber;
+		byte m_sequenceNumber;
 	}
 }


### PR DESCRIPTION
Prior to this fix the internal counter for the sequence number was stored as a signed 32-bit integer which was causing overflow issues when we hit Int32.MaxValue.

Signed-off-by: Your Name <adam@tonic.ai>