### PR TITLE
Implement "IgnoreHasActiveReader" to fix #867

### DIFF
--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -111,6 +111,7 @@ namespace MySqlConnector.Core
 			DefaultCommandTimeout = (int) csb.DefaultCommandTimeout;
 			ForceSynchronous = csb.ForceSynchronous;
 			IgnoreCommandTransaction = csb.IgnoreCommandTransaction;
+			IgnoreHasActiveReader = csb.IgnoreHasActiveReader;
 			IgnorePrepare = csb.IgnorePrepare;
 			InteractiveSession = csb.InteractiveSession;
 			GuidFormat = GetEffectiveGuidFormat(csb.GuidFormat, csb.OldGuids);
@@ -197,6 +198,7 @@ namespace MySqlConnector.Core
 		public bool ForceSynchronous { get; }
 		public MySqlGuidFormat GuidFormat { get; }
 		public bool IgnoreCommandTransaction { get; }
+		public bool IgnoreHasActiveReader { get; }
 		public bool IgnorePrepare { get; }
 		public bool InteractiveSession { get; }
 		public uint Keepalive { get; }

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -755,6 +755,8 @@ namespace MySqlConnector
 #else
 		internal bool IgnoreCommandTransaction => GetInitializedConnectionSettings().IgnoreCommandTransaction || m_enlistedTransaction is StandardEnlistedTransaction;
 #endif
+		internal bool IgnoreHasActiveReader => GetInitializedConnectionSettings().IgnoreHasActiveReader;
+
 		internal bool IgnorePrepare => GetInitializedConnectionSettings().IgnorePrepare;
 		internal bool NoBackslashEscapes => GetInitializedConnectionSettings().NoBackslashEscapes;
 		internal bool TreatTinyAsBoolean => GetInitializedConnectionSettings().TreatTinyAsBoolean;
@@ -765,7 +767,7 @@ namespace MySqlConnector
 
 		internal MySqlSslMode SslMode => GetInitializedConnectionSettings().SslMode;
 
-		internal bool HasActiveReader => m_activeReader is not null;
+		internal bool HasActiveReader => !IgnoreHasActiveReader && m_activeReader is not null;
 
 		internal void SetActiveReader(MySqlDataReader dataReader)
 		{

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -755,7 +755,7 @@ namespace MySqlConnector
 #else
 		internal bool IgnoreCommandTransaction => GetInitializedConnectionSettings().IgnoreCommandTransaction || m_enlistedTransaction is StandardEnlistedTransaction;
 #endif
-		internal bool IgnoreHasActiveReader => GetInitializedConnectionSettings().IgnoreHasActiveReader;
+		internal bool IgnoreHasActiveReader => m_connectionSettings?.IgnoreHasActiveReader ?? false;
 
 		internal bool IgnorePrepare => GetInitializedConnectionSettings().IgnorePrepare;
 		internal bool NoBackslashEscapes => GetInitializedConnectionSettings().NoBackslashEscapes;

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -277,6 +277,12 @@ namespace MySqlConnector
 			set => MySqlConnectionStringOption.IgnoreCommandTransaction.SetValue(this, value);
 		}
 
+		public bool IgnoreHasActiveReader
+		{
+			get => MySqlConnectionStringOption.IgnoreHasActiveReader.GetValue(this);
+			set => MySqlConnectionStringOption.IgnoreHasActiveReader.SetValue(this, value);
+		}
+
 		public bool IgnorePrepare
 		{
 			get => MySqlConnectionStringOption.IgnorePrepare.GetValue(this);
@@ -450,6 +456,7 @@ namespace MySqlConnector
 		public static readonly MySqlConnectionStringValueOption<bool> ForceSynchronous;
 		public static readonly MySqlConnectionStringValueOption<MySqlGuidFormat> GuidFormat;
 		public static readonly MySqlConnectionStringValueOption<bool> IgnoreCommandTransaction;
+		public static readonly MySqlConnectionStringValueOption<bool> IgnoreHasActiveReader;
 		public static readonly MySqlConnectionStringValueOption<bool> IgnorePrepare;
 		public static readonly MySqlConnectionStringValueOption<bool> InteractiveSession;
 		public static readonly MySqlConnectionStringValueOption<uint> Keepalive;
@@ -678,6 +685,10 @@ namespace MySqlConnector
 
 			AddOption(IgnoreCommandTransaction = new(
 				keys: new[] { "IgnoreCommandTransaction", "Ignore Command Transaction" },
+				defaultValue: false));
+
+			AddOption(IgnoreHasActiveReader = new(
+				keys: new[] { "IgnoreHasActiveReader", "Ignore HasActiveReader" },
 				defaultValue: false));
 
 			AddOption(IgnorePrepare = new(

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -50,6 +50,7 @@ namespace MySqlConnector.Tests
 			Assert.False(csb.ForceSynchronous);
 			Assert.Equal(MySqlGuidFormat.Default, csb.GuidFormat);
 			Assert.False(csb.IgnoreCommandTransaction);
+			Assert.False(csb.IgnoreHasActiveReader);
 			Assert.Equal(MySqlLoadBalance.RoundRobin, csb.LoadBalance);
 #endif
 			Assert.True(csb.IgnorePrepare);
@@ -122,6 +123,7 @@ namespace MySqlConnector.Tests
 					"connectionidletimeout=30;" +
 					"forcesynchronous=true;" +
 					"ignore command transaction=true;" +
+					"ignore hasactivereader=true;" +
 					"server rsa public key file=rsa.pem;" +
 					"load balance=random;" +
 					"guidformat=timeswapbinary16;" +
@@ -178,6 +180,7 @@ namespace MySqlConnector.Tests
 			Assert.Equal(30u, csb.ConnectionIdleTimeout);
 			Assert.True(csb.ForceSynchronous);
 			Assert.True(csb.IgnoreCommandTransaction);
+			Assert.True(csb.IgnoreHasActiveReader);
 			Assert.Equal("rsa.pem", csb.ServerRsaPublicKeyFile);
 			Assert.Equal(MySqlLoadBalance.Random, csb.LoadBalance);
 			Assert.Equal(MySqlGuidFormat.TimeSwapBinary16, csb.GuidFormat);


### PR DESCRIPTION
I need to disable the "HasActiveReader" check because it is validating even if ther is no open reader.

fix #867