### PR TITLE
Support conversion from byte[1] to byte

### DIFF
--- a/src/MySqlConnector/Core/Row.cs
+++ b/src/MySqlConnector/Core/Row.cs
@@ -62,6 +62,8 @@ namespace MySqlConnector.Core
 				return (ulong) value != 0;
 			if (value is decimal)
 				return (decimal) value != 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0] != 0;
 			return (bool) value;
 		}
 
@@ -89,6 +91,8 @@ namespace MySqlConnector.Core
 				return (sbyte) decimalValue;
 			if (value is bool boolValue)
 				return boolValue ? (sbyte) 1 : (sbyte) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return checked((sbyte) byteArrayValue[0]);
 			return (sbyte) value;
 		}
 
@@ -116,6 +120,8 @@ namespace MySqlConnector.Core
 				return (byte) decimalValue;
 			if (value is bool boolValue)
 				return boolValue ? (byte) 1 : (byte) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
 			return (byte) value;
 		}
 
@@ -199,6 +205,8 @@ namespace MySqlConnector.Core
 				return (short) (decimal) value;
 			if (value is bool)
 				return (bool) value ? (short) 1 : (short) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
 			return (short) value;
 		}
 
@@ -270,6 +278,9 @@ namespace MySqlConnector.Core
 				return (long) (decimal) value;
 			if (value is bool)
 				return (bool) value ? 1 : 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
+
 			return (long) value;
 		}
 
@@ -297,6 +308,8 @@ namespace MySqlConnector.Core
 				return (ushort) (decimal) value;
 			if (value is bool)
 				return (bool) value ? (ushort) 1 : (ushort) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
 			return (ushort) value;
 		}
 
@@ -324,6 +337,8 @@ namespace MySqlConnector.Core
 				return (uint) (decimal) value;
 			if (value is bool)
 				return (bool) value ? (uint) 1 : (uint) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
 			return (uint) value;
 		}
 
@@ -351,6 +366,8 @@ namespace MySqlConnector.Core
 				return (ulong) (decimal) value;
 			if (value is bool)
 				return (bool) value ? (ulong) 1 : (ulong) 0;
+			if (value is byte[] byteArrayValue && byteArrayValue.Length == 1)
+				return byteArrayValue[0];
 			return (ulong) value;
 		}
 

--- a/tests/Conformance.Tests/GetValueConversionTests.cs
+++ b/tests/Conformance.Tests/GetValueConversionTests.cs
@@ -119,6 +119,12 @@ namespace Conformance.Tests
 		public override void GetInt64_throws_for_maximum_Boolean() => TestGetValue(DbType.Boolean, ValueKind.Maximum, x => x.GetInt64(0), 1L);
 		public override void GetInt64_throws_for_maximum_Boolean_with_GetFieldValue() => TestGetValue(DbType.Boolean, ValueKind.Maximum, x => x.GetFieldValue<long>(0), 1L);
 
+		// GetByte allows binary (byte array) conversions with a length of one
+		public override void GetByte_throws_for_zero_Binary() => TestGetValue(DbType.Binary, ValueKind.Zero, x => x.GetByte(0), (byte) 0x00);
+		public override void GetByte_throws_for_zero_Binary_with_GetFieldValue() => TestGetValue(DbType.Binary, ValueKind.Zero, x => x.GetFieldValue<byte>(0), (byte) 0x00);
+		public override void GetByte_throws_for_one_Binary() => TestGetValue(DbType.Binary, ValueKind.One, x => x.GetByte(0), (byte) 0x11);
+		public override void GetByte_throws_for_one_Binary_with_GetFieldValue() => TestGetValue(DbType.Binary, ValueKind.One, x => x.GetFieldValue<byte>(0), (byte) 0x11);
+
 		// GetByte allows integral conversions
 		public override void GetByte_throws_for_maximum_Int16() => TestException(DbType.Int16, ValueKind.Maximum, x => x.GetByte(0), typeof(OverflowException));
 		public override void GetByte_throws_for_maximum_Int16_with_GetFieldValue() => TestException(DbType.Int16, ValueKind.Maximum, x => x.GetFieldValue<byte>(0), typeof(OverflowException));


### PR DESCRIPTION
Pomelo translates constant byte values to an explicit byte notation (e.g. `18` will be translated to `0x12`), so that the `~` operator works as expected.

A side effect is however, that constant byte values are returned as `byte[1]` instead of `byte`.