### PR TITLE
Added the NCC FreeSql to the list of supported ORMs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ from Oracle.
 This library is compatible with popular .NET ORMs including:
 
 * [Dapper](https://stackexchange.github.io/Dapper/) ([GitHub](https://github.com/StackExchange/dapper-dot-net), [NuGet](https://www.nuget.org/packages/Dapper))
+* [FreeSql](http://freesql.net/) ([GitHub](https://github.com/dotnetcore/FreeSql), [NuGet](https://www.nuget.org/packages/FreeSql.Provider.MySqlConnector/))
 * [LINQ to DB](https://linq2db.github.io/) ([GitHub](https://github.com/linq2db/linq2db), [NuGet](https://www.nuget.org/packages/linq2db.MySqlConnector))
 * [NHibernate](https://www.nhibernate.info) ([GitHub](https://github.com/nhibernate/NHibernate.MySqlConnector), [NuGet](https://www.nuget.org/packages/NHibernate.Driver.MySqlConnector))
 * [NReco.Data](https://www.nrecosite.com/dalc_net.aspx) ([GitHub](https://github.com/nreco/data), [NuGet](https://www.nuget.org/packages/NReco.Data))


### PR DESCRIPTION
FreeSql is currently used by many Chinese developers, including in the projects of many commercial companies. Users who have used FreeSql said that he is even better than EFCore:

> EFCore is excellent, and FreeSql stands on the shoulders of giants.

We will work hard to internationalize FreeSql's documentation so that more developers can understand and use it.