### PR TITLE
Trim SQL statements

### DIFF
--- a/tests/MySqlConnector.Tests/StatementPreparerTests.cs
+++ b/tests/MySqlConnector.Tests/StatementPreparerTests.cs
@@ -209,6 +209,12 @@ SELECT @'var' as R")]
 		[InlineData("SELECT * FROM `SELECT`", "SELECT * FROM `SELECT`;", true)]
 		[InlineData("SELECT * FROM test WHERE id = ?;", "SELECT * FROM test WHERE id = 0;", true)]
 		[InlineData("SELECT * FROM test WHERE id = ?", "SELECT * FROM test WHERE id = 0;", true)]
+		[InlineData(";SELECT 1", "SELECT 1;", true)]
+		[InlineData("; SELECT 1;", "SELECT 1;", true)]
+		[InlineData(" ; SELECT 1 ; ", "SELECT 1 ;", true)]
+		[InlineData(";;;SELECT 1;;;", "SELECT 1;", true)]
+		[InlineData("-- test\n; SELECT 1;", "SELECT 1;", true)]
+		[InlineData("SELECT 1; -- test\n", "SELECT 1;", true)]
 		public void CompleteStatements(string sql, string expectedSql, bool expectedComplete)
 		{
 			var parameters = new MySqlParameterCollection { new() { Value = 0 } };

--- a/tests/MySqlConnector.Tests/StatementPreparerTests.cs
+++ b/tests/MySqlConnector.Tests/StatementPreparerTests.cs
@@ -224,6 +224,7 @@ SELECT @'var' as R")]
 
 		[Theory]
 		[InlineData("SELECT 1", new[] { "SELECT 1" }, "")]
+		[InlineData("SELECT 1 ", new[] { "SELECT 1 " }, "")]
 		[InlineData("SELECT 1;", new[] { "SELECT 1" }, "")]
 		[InlineData("\r\n-- leading comment\r\nSELECT 1;\r\n\r\n-- trailing comment", new[] { "SELECT 1" }, "")]
 		[InlineData("SELECT 1; SELECT 2;", new[] { "SELECT 1", "SELECT 2" }, ";")]
@@ -234,6 +235,11 @@ SELECT @'var' as R")]
 		[InlineData("SELECT @one, @two; SELECT @zero, @three", new[] { "SELECT ?, ?", "SELECT ?, ?" }, "@one,@two;@zero,@three")]
 		[InlineData("SELECT ?, ?; SELECT ?, ?", new[] { "SELECT ?, ?", "SELECT ?, ?" }, "0,1;2,3")]
 		[InlineData("SELECT '@one' FROM `@three` WHERE `@zero` = @two;", new[] { "SELECT '@one' FROM `@three` WHERE `@zero` = ?" }, "@two")]
+		[InlineData(";SELECT 1", new[] { "SELECT 1" }, "")]
+		[InlineData(" ; SELECT 1 ; ", new[] { "SELECT 1 " }, "")]
+		[InlineData(";;;SELECT 1;;;", new[] { "SELECT 1" }, "")]
+		[InlineData("-- test\n; SELECT 1;", new[] { "SELECT 1" }, "")]
+		[InlineData("SELECT 1; -- test\n", new[] { "SELECT 1" }, "")]
 		public void SplitStatement(string sql, string[] expectedStatements, string expectedStatementParametersString)
 		{
 			// verify InlineData is in the expected format

--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -613,6 +613,23 @@ insert into query_null_parameter (id, value) VALUES (1, 'one'), (2, 'two'), (3, 
 
 		[Theory]
 		[InlineData(false)]
+#if !BASELINE
+		[InlineData(true)]
+#endif
+		public void EmptyStatements(bool prepareCommand)
+		{
+			using var connection = new MySqlConnection(AppConfig.ConnectionString);
+			connection.Open();
+
+			using var cmd = connection.CreateCommand();
+			cmd.CommandText = " ; select 1 ; ; ";
+			if (prepareCommand)
+				cmd.Prepare();
+			Assert.Equal(1L, cmd.ExecuteScalar());
+		}
+
+		[Theory]
+		[InlineData(false)]
 		[InlineData(true)]
 		public void SumInts(bool prepareCommand)
 		{


### PR DESCRIPTION
Related to https://github.com/mysql-net/MySqlConnector/issues/961.

This trims the SQL (from `MySqlCommand.CommandText`) for _non-prepared_ commands before sending it to the server for execution.

This matches the behaviour of `MySqlCommand.Prepare()` better, as well as matching Connector/NET's behaviour in some trivial cases.

It does add some increased risk that unusual SQL will be transformed/truncated by this new code and thus introduce new bugs.