### PR TITLE
SetSuccess extension method should not allow null.

### DIFF
--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -423,7 +423,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 			if (m_connectionSettings.AutoEnlist && System.Transactions.Transaction.Current is not null)
 				EnlistTransaction(System.Transactions.Transaction.Current);
 
-			activity.SetSuccess();
+			activity?.SetSuccess();
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{

--- a/src/MySqlConnector/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlDataReader.cs
@@ -602,7 +602,7 @@ public sealed class MySqlDataReader : DbDataReader
 			Command.CancellableCommand.SetTimeout(Constants.InfiniteTimeout);
 			connection.FinishQuerying(m_hasWarnings);
 
-			Activity.SetSuccess();
+			Activity?.SetSuccess();
 			Activity?.Stop();
 
 			if ((m_behavior & CommandBehavior.CloseConnection) != 0)

--- a/src/MySqlConnector/MySqlTransaction.cs
+++ b/src/MySqlConnector/MySqlTransaction.cs
@@ -36,7 +36,7 @@ public sealed class MySqlTransaction : DbTransaction
 				await cmd.ExecuteNonQueryAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 			Connection!.CurrentTransaction = null;
 			Connection = null;
-			activity.SetSuccess();
+			activity?.SetSuccess();
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{
@@ -260,9 +260,9 @@ public sealed class MySqlTransaction : DbTransaction
 		{
 			using var cmd = new MySqlCommand("rollback", Connection, this) { NoActivity = true };
 			await cmd.ExecuteNonQueryAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
-			activity.SetSuccess();
+			activity?.SetSuccess();
 		}
-		catch (Exception ex) when(activity is { IsAllDataRequested: true })
+		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{
 			activity.SetException(ex);
 			throw;

--- a/src/MySqlConnector/Utilities/ActivitySourceHelper.cs
+++ b/src/MySqlConnector/Utilities/ActivitySourceHelper.cs
@@ -36,7 +36,7 @@ internal static class ActivitySourceHelper
 		return activity;
 	}
 
-	public static void SetSuccess(this Activity? activity) => activity?.SetTag(StatusCodeTagName, "OK");
+	public static void SetSuccess(this Activity activity) => activity.SetTag(StatusCodeTagName, "OK");
 
 	public static void SetException(this Activity activity, Exception exception)
 	{


### PR DESCRIPTION
This matches the behavior of SetException and is less confusing at the call sites.