### PR TITLE
Add Method to MySqlParameterCollection datastructure which allow memory allocation in advance for m_parameters if the size is known

### DIFF
--- a/src/MySqlConnector/MySqlParameterCollection.cs
+++ b/src/MySqlConnector/MySqlParameterCollection.cs
@@ -11,6 +11,13 @@ public sealed class MySqlParameterCollection : DbParameterCollection, IEnumerabl
 		m_nameToIndex = new(StringComparer.OrdinalIgnoreCase);
 	}
 
+	public void SetParameterCapacity(int capacity)
+	{
+		if(capacity < 0)
+			throw new ArgumentOutOfRangeException(nameof(capacity));
+		m_parameters.Capacity = capacity;
+	}
+
 	public MySqlParameter Add(string parameterName, DbType dbType)
 	{
 		var parameter = new MySqlParameter


### PR DESCRIPTION
Add Constructor/Method to MySqlParameterCollection which allow memory allocation in advance for m_parameters if the size is known.

Related to issue : https://github.com/mysql-net/MySqlConnector/issues/1119