### PR TITLE
Fix deadlock when command is being cancelled from two threads

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1750,8 +1750,9 @@ internal sealed class ServerSession
 	{
 		if (m_state != state1 && m_state != state2 && m_state != state3 && m_state != state4 && m_state != state5 && m_state != state6)
 		{
-			Log.Error("Session{0} should have SessionStateExpected {1} or SessionStateExpected2 {2} or SessionStateExpected3 {3} but was SessionState {4}", m_logArguments[0], state1, state2, state3, m_state);
-			throw new InvalidOperationException("Expected state to be ({0}|{1}|{2}) but was {3}.".FormatInvariant(state1, state2, state3, m_state));
+			Log.Error("Session{0} should have SessionStateExpected {1} or SessionStateExpected2 {2} or SessionStateExpected3 {3} or SessionStateExpected4 {4} or SessionStateExpected5 {5} or SessionStateExpected6 {6} but was SessionState {7}",
+				m_logArguments[0], state1, state2, state3, state4, state5, state6, m_state);
+			throw new InvalidOperationException("Expected state to be ({0}|{1}|{2}|{3}|{4}|{5}) but was {6}.".FormatInvariant(state1, state2, state3, state4, state5, state6, m_state));
 		}
 	}
 

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -96,7 +96,7 @@ internal sealed class ServerSession
 		{
 			if (ActiveCommandId != command.CommandId)
 				return false;
-			VerifyState(State.Querying, State.CancelingQuery, State.ClearingPendingCancellation, State.Failed);
+			VerifyState(State.Querying, State.CancelingQuery, State.ClearingPendingCancellation, State.Closing, State.Closed, State.Failed);
 			if (m_state != State.Querying)
 				return false;
 			if (command.CancelAttemptCount++ >= 10)
@@ -1746,9 +1746,9 @@ internal sealed class ServerSession
 		}
 	}
 
-	private void VerifyState(State state1, State state2, State state3, State state4)
+	private void VerifyState(State state1, State state2, State state3, State state4, State state5, State state6)
 	{
-		if (m_state != state1 && m_state != state2 && m_state != state3 && m_state != state4)
+		if (m_state != state1 && m_state != state2 && m_state != state3 && m_state != state4 && m_state != state5 && m_state != state6)
 		{
 			Log.Error("Session{0} should have SessionStateExpected {1} or SessionStateExpected2 {2} or SessionStateExpected3 {3} but was SessionState {4}", m_logArguments[0], state1, state2, state3, m_state);
 			throw new InvalidOperationException("Expected state to be ({0}|{1}|{2}) but was {3}.".FormatInvariant(state1, state2, state3, m_state));

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -96,7 +96,7 @@ internal sealed class ServerSession
 		{
 			if (ActiveCommandId != command.CommandId)
 				return false;
-			VerifyState(State.Querying, State.CancelingQuery, State.Failed);
+			VerifyState(State.Querying, State.CancelingQuery, State.ClearingPendingCancellation, State.Failed);
 			if (m_state != State.Querying)
 				return false;
 			if (command.CancelAttemptCount++ >= 10)
@@ -1746,9 +1746,9 @@ internal sealed class ServerSession
 		}
 	}
 
-	private void VerifyState(State state1, State state2, State state3)
+	private void VerifyState(State state1, State state2, State state3, State state4)
 	{
-		if (m_state != state1 && m_state != state2 && m_state != state3)
+		if (m_state != state1 && m_state != state2 && m_state != state3 && m_state != state4)
 		{
 			Log.Error("Session{0} should have SessionStateExpected {1} or SessionStateExpected2 {2} or SessionStateExpected3 {3} but was SessionState {4}", m_logArguments[0], state1, state2, state3, m_state);
 			throw new InvalidOperationException("Expected state to be ({0}|{1}|{2}) but was {3}.".FormatInvariant(state1, state2, state3, m_state));

--- a/src/MySqlConnector/Utilities/TimerQueue.cs
+++ b/src/MySqlConnector/Utilities/TimerQueue.cs
@@ -67,12 +67,14 @@ internal sealed class TimerQueue
 
 	private void Callback(object? obj)
 	{
+		var actionsToBeCalled = new List<Action>();
+
 		lock (m_lock)
 		{
 			// process all timers that have expired or will expire in the granularity of a clock tick
 			while (m_timeoutActions.Count > 0 && unchecked(m_timeoutActions[0].Time - Environment.TickCount) < 15)
 			{
-				m_timeoutActions[0].Action();
+				actionsToBeCalled.Add(m_timeoutActions[0].Action);
 				m_timeoutActions.RemoveAt(0);
 			}
 
@@ -85,6 +87,11 @@ internal sealed class TimerQueue
 				var delay = Math.Max(250, unchecked(m_timeoutActions[0].Time - Environment.TickCount));
 				UnsafeSetTimer(delay);
 			}
+		}
+
+		foreach (var action in actionsToBeCalled)
+		{
+			action();
 		}
 	}
 


### PR DESCRIPTION
Hi there, 
A couple of days ago we encountered a deadlock inside mysql connector which lead our system to downtime.

**What happened?**
Our monitoring detected that there are no new writes are happened to database in about 10 minutes. We dumped process memory and started looking for a problem. It turned out that deadlock happened in TimerQueue and connection Session.

**The problem**
The problem is that timer callback is being called under TimerQueue lock. Since callback can be almost any user code no one restricts it from acquiring other locks inside which exactly happened in our case. 
`ServerSession.TryStartCancel`  and `ServerSession.DoCancel` already uses a lock inside to protect internal session state and when it's called from TimerQueue it also implicitly acquires the lock on TimerQueue.
I attached screenshots which clearly illustrates the problem.
![1](https://user-images.githubusercontent.com/1203788/152629061-aec7ec97-d71f-4b64-acac-2ccd5a8b8e35.png)
![2](https://user-images.githubusercontent.com/1203788/152629065-499fde05-53fa-40ac-a163-25526f2aedfd.png)
![4](https://user-images.githubusercontent.com/1203788/152629067-4d956ed5-37df-4321-926b-0869f17de24d.png)

**Reproduction**
I was able to create a pretty stable repro. All you need is to make cancellation happenned simultaneously both from external cancellation source (CancellationTokenSource with timeout/HttpContext.RequestAborted etc.) and command timeout watchdog.
You can examine the code here https://github.com/ahydrax/StableMysqlConnectorDeadlockRepro

**The solution**
From my perspective solution should be pretty simple: timer queue calls pending callbacks outside of TimerQueue internal lock.

**Closing notes**
After fixing deadlock I've encountered a small bug inside `Session.TryStartCancel` which didn't respect all command states inside during state verifying. 