### PR TITLE
 Fix Bug from Issue #1132

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -416,7 +416,7 @@ internal sealed class ServerSession
 			InitialHandshakePayload initialHandshake;
 			do
 			{
-				shouldRetrySsl = (sslProtocols == SslProtocols.None || (sslProtocols & SslProtocols.Tls12) == SslProtocols.Tls12) && Utility.IsWindows();
+				shouldRetrySsl = sslProtocols == SslProtocols.None && Utility.IsWindows();
 
 				var connected = false;
 				if (cs.ConnectionProtocol == MySqlConnectionProtocol.Sockets)


### PR DESCRIPTION
Change the logic used to determine when a connection attempt is failing
due to a lack of support for TLS 1.2+ in yaSSL-based MySQL Server so
that a downgrade no longer occurs if the user has explicitly configured
supported TLS Version(s) in the connection string.

Signed-off-by: Andrew Nagel <andrew.nagel@gmail.com>