### PR TITLE
Add ConflictOption property to MySqlBulkCopy

### DIFF
--- a/src/MySqlConnector/MySqlBulkCopy.cs
+++ b/src/MySqlConnector/MySqlBulkCopy.cs
@@ -57,6 +57,11 @@ public sealed class MySqlBulkCopy
 	}
 
 	/// <summary>
+	/// A <see cref="MySqlBulkLoaderConflictOption"/> value that specifies how conflicts are resolved (default <see cref="MySqlBulkLoaderConflictOption.None"/>).
+	/// </summary>
+	public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
+
+	/// <summary>
 	/// The number of seconds for the operation to complete before it times out, or <c>0</c> for no timeout.
 	/// </summary>
 	public int BulkCopyTimeout { get; set; }
@@ -247,6 +252,7 @@ public sealed class MySqlBulkCopy
 			Source = this,
 			TableName = tableName,
 			Timeout = BulkCopyTimeout,
+			ConflictOption = ConflictOption,
 		};
 
 		var closeConnection = false;


### PR DESCRIPTION
The PR adds a new property `ConflictOption` to `MySqlBulkCopy` type:

```csharp
public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
```

The property specifies how conflicts during bulk copying are resolved. This change is a simple 'pass through' of `ConflictOption` to `MySqlBulkLoader` which is used inside of `MySqlBulkCopy`.