### PR TITLE
Bump YamlDotNet from 11.2.1 to 12.0.0 in tools/SchemaCollectionGenerator

### DIFF
--- a/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.csproj
+++ b/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated YamlDotNet package from 11.2.1 to 12.0.0 in tools/SchemaCollectionGenerator/

## YamlDotNet 12.0.0
- [Release Notes](https://github.com/aaubry/YamlDotNet/releases/tag/v12.0.0)
- [Download and Install](https://www.nuget.org/packages/YamlDotNet/12.0.0)


## YamlDotNet 11.2.1
- [Release Notes](https://github.com/aaubry/YamlDotNet/releases/tag/v11.2.1)
- [Download and Install](https://www.nuget.org/packages/YamlDotNet/11.2.1)