### PR TITLE
Bump YamlDotNet from 11.2.1 to 12.0.0 in tools/SchemaCollectionGenerator

### DIFF
--- a/src/MySqlConnector/MySqlConnector.csproj
+++ b/src/MySqlConnector/MySqlConnector.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net471' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
   </ItemGroup>
 

--- a/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.csproj
+++ b/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated YamlDotNet package from 11.2.1 to 12.0.0 in tools/SchemaCollectionGenerator/

## YamlDotNet 12.0.0
- [Release Notes](https://github.com/aaubry/YamlDotNet/releases/tag/v12.0.0)
- [Download and Install](https://www.nuget.org/packages/YamlDotNet/12.0.0)


## YamlDotNet 11.2.1
- [Release Notes](https://github.com/aaubry/YamlDotNet/releases/tag/v11.2.1)
- [Download and Install](https://www.nuget.org/packages/YamlDotNet/11.2.1)