### PR TITLE
Avoid culture aware comparisons and a string allocation

### DIFF
--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -27,7 +27,7 @@ internal sealed class ConnectionSettings
 			if (csb.LoadBalance != MySqlLoadBalance.RoundRobin)
 				throw new NotSupportedException("LoadBalance not supported when ConnectionProtocol=NamedPipe");
 			ConnectionProtocol = MySqlConnectionProtocol.NamedPipe;
-			HostNames = (csb.Server == "." || string.Equals(csb.Server, "localhost", StringComparison.OrdinalIgnoreCase)) ? s_localhostPipeServer : new[] { csb.Server };
+			HostNames = (csb.Server is "." || string.Equals(csb.Server, "localhost", StringComparison.OrdinalIgnoreCase)) ? s_localhostPipeServer : new[] { csb.Server };
 			PipeName = csb.PipeName;
 		}
 		else if (csb.ConnectionProtocol == MySqlConnectionProtocol.SharedMemory)

--- a/src/MySqlConnector/Core/SchemaProvider.cs
+++ b/src/MySqlConnector/Core/SchemaProvider.cs
@@ -391,7 +391,7 @@ internal sealed partial class SchemaProvider
 		}
 
 		// remove columns that the server doesn't support
-		if (dataTable.TableName == "Columns")
+		if (dataTable.TableName is "Columns")
 		{
 			using (var command = new MySqlCommand("SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = 'information_schema' AND table_name = 'COLUMNS' AND column_name = 'GENERATION_EXPRESSION';", m_connection))
 			{

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -520,7 +520,7 @@ internal sealed class ServerSession
 						await InitSslAsync(initialHandshake.ProtocolCapabilities, cs, connection, sslProtocols, ioBehavior, cancellationToken).ConfigureAwait(false);
 						shouldRetrySsl = false;
 					}
-					catch (ArgumentException ex) when (ex.ParamName == "sslProtocolType" && sslProtocols == SslProtocols.None)
+					catch (ArgumentException ex) when (ex.ParamName is "sslProtocolType" && sslProtocols == SslProtocols.None)
 					{
 						Log.Debug(ex, "Session{0} doesn't support SslProtocols.None; falling back to explicitly specifying SslProtocols", m_logArguments);
 						sslProtocols = SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12;
@@ -848,7 +848,7 @@ internal sealed class ServerSession
 		if (cs.AllowPublicKeyRetrieval)
 		{
 			// request the RSA public key
-			var payloadContent = switchRequestName == "caching_sha2_password" ? (byte) 0x02 : (byte) 0x01;
+			var payloadContent = switchRequestName is "caching_sha2_password" ? (byte) 0x02 : (byte) 0x01;
 			await SendReplyAsync(new PayloadData(new[] { payloadContent }), ioBehavior, cancellationToken).ConfigureAwait(false);
 			var payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 			var publicKeyPayload = AuthenticationMoreDataPayload.Create(payload.Span);
@@ -1912,7 +1912,7 @@ internal sealed class ServerSession
 
 		protected override void OnStatementBegin(int index)
 		{
-			if (index + 10 < m_sql.Length && string.Equals("delimiter ", m_sql.Substring(index, 10), StringComparison.OrdinalIgnoreCase))
+			if (index + 10 < m_sql.Length && m_sql.AsSpan(index, 10).Equals("delimiter ".AsSpan(), StringComparison.OrdinalIgnoreCase))
 				HasDelimiter = true;
 		}
 

--- a/src/MySqlConnector/MySqlBulkCopy.cs
+++ b/src/MySqlConnector/MySqlBulkCopy.cs
@@ -272,11 +272,11 @@ public sealed class MySqlBulkCopy
 			for (var i = 0; i < Math.Min(m_valuesEnumerator!.FieldCount, schema.Count); i++)
 			{
 				var destinationColumn = reader.GetName(i);
-				if (schema[i].DataTypeName == "BIT")
+				if (schema[i].DataTypeName is "BIT")
 				{
 					AddColumnMapping(columnMappings, addDefaultMappings, i, destinationColumn, $"@`\uE002\bcol{i}`", $"%COL% = CAST(%VAR% AS UNSIGNED)");
 				}
-				else if (schema[i].DataTypeName == "YEAR")
+				else if (schema[i].DataTypeName is "YEAR")
 				{
 					// the current code can't distinguish between 0 = 0000 and 0 = 2000
 					throw new NotSupportedException("'YEAR' columns are not supported by MySqlBulkLoader.");

--- a/src/MySqlConnector/MySqlDecimal.cs
+++ b/src/MySqlConnector/MySqlDecimal.cs
@@ -36,7 +36,7 @@ public readonly struct MySqlDecimal
 			var fractionLength = match.Groups[3].Value.TrimEnd('0').Length;
 
 			var isWithinLengthLimits = wholeLength + fractionLength <= 65 && fractionLength <= 30;
-			var isNegativeZero = value[0] == '-' && match.Groups[1].Value == "0" && fractionLength == 0;
+			var isNegativeZero = value[0] is '-' && match.Groups[1].Value is "0" && fractionLength == 0;
 			if (isWithinLengthLimits && !isNegativeZero)
 			{
 				m_value = value;

--- a/src/MySqlConnector/Protocol/Payloads/ErrorPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/ErrorPayload.cs
@@ -21,7 +21,7 @@ internal sealed class ErrorPayload
 		var errorCode = reader.ReadUInt16();
 		var stateMarker = Encoding.ASCII.GetString(reader.ReadByteString(1));
 		string state, message;
-		if (stateMarker == "#")
+		if (stateMarker is "#")
 		{
 			state = Encoding.ASCII.GetString(reader.ReadByteString(5));
 			message = Encoding.UTF8.GetString(reader.ReadByteString(span.Length - 9));


### PR DESCRIPTION
The standard string == operator is a culture aware comparison. Updating these to "is" makes these culture invariant.

This PR removes the few instances of these.

It also removes a single string allocation when checking for HasDelimiter. There are also a few other opportunities to avoid string allocations if we raise our minimum target to NET461 (ideally NET462).