### PR TITLE
Serialize connection string options in a consistent order

### DIFF
--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -20,10 +20,9 @@ For all the other options, see the tables below. MySqlConnector supports most of
 There are also several unique options that are supported only by MySqlConnector, a replacement for `MySql.Data` that [fixes bugs](/tutorials/migrating-from-connector-net/#fixed-bugs),
 adds new features, and improves database access performance. [Install it now](/overview/installing/).
 
-Base Options
-------------
+## Connection Options
 
-These are the basic options that need to be defined to connect to a MySQL database.
+These options specify how to connect and authenticate to a MySQL database.
 
 <table class="table table-striped table-hover">
   <thead>
@@ -62,6 +61,23 @@ These are the basic options that need to be defined to connect to a MySQL databa
     <td></td>
     <td>(Optional) The case-sensitive name of the initial database to use. This may be required if the MySQL user account only has access rights to particular databases on the server.</td>
   </tr>
+  <tr id="LoadBalance">
+    <td>Load Balance, LoadBalance</td>
+    <td>RoundRobin</td>
+    <td><p>The load-balancing strategy to use when <code>Host</code> contains multiple, comma-delimited, host names.
+      The options include:</p>
+      <dl>
+        <dt>RoundRobin</dt>
+        <dd>Each new connection opened for this connection pool uses the next host name (sequentially with wraparound). Requires <code>Pooling=True</code>. This is the default if <code>Pooling=True</code>.</dd>
+        <dt>FailOver</dt>
+        <dd>Each new connection tries to connect to the first host; subsequent hosts are used only if connecting to the first one fails. This is the default if <code>Pooling=False</code>.</dd>
+        <dt>Random</dt>
+        <dd>Servers are tried in a random order.</dd>
+        <dt>LeastConnections</dt>
+        <dd>Servers are tried in ascending order of number of currently-open connections in this connection pool. Requires <code>Pooling=True</code>.</dd>
+      </dl>
+    </td>
+  </tr>
   <tr id="ConnectionProtocol">
     <td>Connection Protocol, ConnectionProtocol, Protocol</td>
     <td>Socket</td>
@@ -80,8 +96,22 @@ These are the basic options that need to be defined to connect to a MySQL databa
   </tr>
 </table>
 
-SSL/TLS Options
------------
+### Connecting to Multiple Servers
+
+The `Server` option supports multiple comma-delimited host names.
+The `LoadBalance` option controls how load is distributed across backend servers.
+Some of these options (`RoundRobin`, `LeastConnections`) only take effect if `Pooling=True`; however `Random` and `FailOver` can be used with `Pooling=False`.
+
+* `RoundRobin` (default), `Random`: A total of `MaximumPoolSize` connections will be opened, but they
+may be unevenly distributed across back ends.
+* `LeastConnections`: A total of `MaximumPoolSize` connections will be opened, and they will be evenly
+distributed across back ends. The active connections will be selected from the pool in least-recently-used
+order, which does not ensure even load across the back ends. You should set `MaximumPoolSize` to the
+number of servers multiplied by the desired maximum number of open connections per backend server.
+* `Failover`: All connections will initially be made to the first server in the list. You should set `MaximumPoolSize`
+to the maximum number of open connections you want per server.
+
+## SSL/TLS Options
 
 These are the options that need to be used in order to configure a connection to use SSL/TLS.
 
@@ -117,6 +147,16 @@ These are the options that need to be used in order to configure a connection to
     <td></td>
     <td>The password for the certificate specified using the <code>CertificateFile</code> option. Not required if the certificate file is not password protected.</td>
   </tr>
+  <tr id="CertificateStoreLocation">
+    <td>Certificate Store Location, CertificateStoreLocation</td>
+    <td>None</td>
+    <td>Specifies whether the connection should be encrypted with a certificate from the Certificate Store on the machine. The default value of <code>None</code> means the certificate store is not used; a value of <code>CurrentUser</code> or <code>LocalMachine</code> uses the specified store.</td>
+  </tr>
+  <tr id="CertificateThumbprint">
+    <td>Certificate Thumbprint, CertificateThumbprint</td>
+    <td></td>
+    <td>Specifies which certificate should be used from the certificate store specified in the setting above. This option must be used to indicate which certificate in the store should be used for authentication.</td>
+  </tr>
   <tr id="SslCert">
     <td>SSL Cert, SslCert, Ssl-Cert</td>
     <td></td>
@@ -135,30 +175,19 @@ These are the options that need to be used in order to configure a connection to
       <p>To provide a custom callback to validate the remote certificate, leave this option empty and set <code>SslMode</code> to <code>Required</code> (or <code>Preferred</code>), then set <a href="/api/mysqlconnector/mysqlconnection/remotecertificatevalidationcallback/"><code>MySqlConnection.RemoteCertificateValidationCallback</code></a> before calling <a href="/api/mysqlconnector/mysqlconnection/open/"><code>MySqlConnection.Open</code></a>. The property should be set to a delegate that will validate the remote certificate, as per <a href="https://docs.microsoft.com/en-us/dotnet/api/system.net.security.remotecertificatevalidationcallback" title="RemoteCertificateValidationCallback Delegate (MSDN)">the documentation</a>.</p>
     </td>
   </tr>
-  <tr id="CertificateStoreLocation">
-    <td>Certificate Store Location, CertificateStoreLocation</td>
-    <td>None</td>
-    <td>Specifies whether the connection should be encrypted with a certificate from the Certificate Store on the machine. The default value of <code>None</code> means the certificate store is not used; a value of <code>CurrentUser</code> or <code>LocalMachine</code> uses the specified store.</td>
-  </tr>
-  <tr id="CertificateThumbprint">
-    <td>Certificate Thumbprint, CertificateThumbprint</td>
+  <tr id="TlsVersion">
+    <td>TLS Version, TlsVersion, Tls-Version</td>
     <td></td>
-    <td>Specifies which certificate should be used from the certificate store specified in the setting above. This option must be used to indicate which certificate in the store should be used for authentication.</td>
+    <td>The TLS versions which may be used during TLS negotiation. The default value of <code>null</code> allows the OS to determine the TLS version to use (see <a href="https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls" title="Transport Layer Security (TLS) best practices with the .NET Framework">documentation</a>); this is the recommended setting. Otherwise, to restrict the versions that can be used, specify a comma-delimited list of versions taken from the following: <code>TLS 1.0</code>, <code>TLS 1.1.</code>, <code>TLS 1.2</code>, <code>TLS 1.3</code>. (This option allows each version to be specified in a few different formats: <code>Tls12</code>, <code> Tlsv1.2</code>, <code>TLS 1.2</code>, <code>Tls v1.2</code>; they are treated equivalently.)</td>
   </tr>
   <tr id="TlsCipherSuites">
     <td>TLS Cipher Suites,TlsCipherSuites</td>
     <td></td>
     <td>The TLS cipher suites which may be used during TLS negotiation. The default value (the empty string) allows the OS to determine the TLS cipher suites to use; this is the recommended setting. Otherwise, specify a comma-delimited list of <a href="https://docs.microsoft.com/en-us/dotnet/api/system.net.security.tlsciphersuite"><code>TlsCipherSuite</code> enum values</a> to allow just those cipher suites. (This option is only supported on Linux when using .NET Core 3.1 or .NET 5.0 or later.)</td>
   </tr>
-  <tr id="TlsVersion">
-    <td>TLS Version, TlsVersion, Tls-Version</td>
-    <td></td>
-    <td>The TLS versions which may be used during TLS negotiation. The default value of <code>null</code> allows the OS to determine the TLS version to use (see <a href="https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls" title="Transport Layer Security (TLS) best practices with the .NET Framework">documentation</a>); this is the recommended setting. Otherwise, to restrict the versions that can be used, specify a comma-delimited list of versions taken from the following: <code>TLS 1.0</code>, <code>TLS 1.1.</code>, <code>TLS 1.2</code>, <code>TLS 1.3</code>. (This option allows each version to be specified in a few different formats: <code>Tls12</code>, <code> Tlsv1.2</code>, <code>TLS 1.2</code>, <code>Tls v1.2</code>; they are treated equivalently.)</td>
-  </tr>
 </table>
 
-Connection Pooling Options
---------------------------
+## Connection Pooling Options
 
 Connection pooling is enabled by default. These options are used to configure it.
 
@@ -183,6 +212,11 @@ Connection pooling is enabled by default. These options are used to configure it
     <td><code>true</code></td>
     <td>If <code>true</code>, all connections retrieved from the pool will have been reset. The default value of <code>true</code> ensures that the connection is in the same state whether it’s newly created or retrieved from the pool. A value of <code>false</code> avoids making an additional server round trip to reset the connection, but the connection state is not reset, meaning that session variables and other session state changes from any previous use of the connection are carried over. Additionally (if <code>Connection Reset</code> is <code>false</code>), when <code>MySqlConnection.Open</code> returns a connection from the pool (instead of opening a new one), the connection may be invalid (and throw an exception on first use) if the server has closed the connection.</td>
   </tr>
+  <tr id="DeferConnectionReset">
+    <td>Defer Connection Reset, DeferConnectionReset</td>
+    <td></td>
+    <td>This option was obsoleted in MySqlConnector 2.0.</td>
+  </tr>
   <tr id="ConnectionIdleTimeout">
     <td>Connection Idle Timeout, ConnectionIdleTimeout</td>
     <td>180</td>
@@ -200,22 +234,7 @@ Connection pooling is enabled by default. These options are used to configure it
   </tr>
 </table>
 
-### Connection Pooling with Multiple Servers
-
-The `Server` option supports multiple comma-delimited host names. When this is used with connection
-pooling, the `LoadBalance` option controls how load is distributed across backend servers.
-
-* `RoundRobin` (default), `Random`: A total of `MaximumPoolSize` connections will be opened, but they
-may be unevenly distributed across back ends.
-* `LeastConnections`: A total of `MaximumPoolSize` connections will be opened, and they will be evenly
-distributed across back ends. The active connections will be selected from the pool in least-recently-used
-order, which does not ensure even load across the back ends. You should set `MaximumPoolSize` to the
-number of servers multiplied by the desired maximum number of open connections per backend server.
-* `Failover`: All connections will initially be made to the first server in the list. You should set `MaximumPoolSize`
-to the maximum number of open connections you want per server.
-
-Other Options
--------------
+## Other Options
 
 These are the other options that MySqlConnector supports. They are set to sensible defaults and typically do not need to be tweaked.
 
@@ -276,13 +295,6 @@ These are the other options that MySqlConnector supports. They are set to sensib
     <td>utf8mb4</td>
     <td>MySqlConnector always uses <code>utf8mb4</code> to send and receive strings from MySQL Server. This option may be specified (for backwards compatibility) but it will be ignored.</td>
   </tr>
-  <tr id="UseCompression">
-    <td>Use Compression, Compress, UseCompression</td>
-    <td>false</td>
-    <td>If true (and if the server supports compression), compresses packets sent between client and server. This option is unlikely to be useful in
-      practice unless there is a high-latency or low-bandwidth network link between the application and the database server. You should measure
-      performance with and without this option to determine if it’s beneficial in your environment.</td>
-  </tr>
   <tr id="ConnectionTimeout">
     <td>Connection Timeout, Connect Timeout, ConnectionTimeout</td>
     <td>15</td>
@@ -300,10 +312,12 @@ These are the other options that MySqlConnector supports. They are set to sensib
     a <code>MySqlException</code> will be thrown if a <code>DateTime</code> command parameter has a <code>Kind</code> of <code>Local</code> or <code>Utc</code>,
     respectively.</td>
   </tr>
-  <tr id="DeferConnectionReset">
-    <td>Defer Connection Reset, DeferConnectionReset</td>
-    <td></td>
-    <td>This option was obsoleted in MySqlConnector 2.0.</td>
+  <tr id="DefaultCommandTimeout">
+    <td>Default Command Timeout, Command Timeout, DefaultCommandTimeout</td>
+    <td>30</td>
+    <td>The length of time (in seconds) each command can execute before the query is cancelled on the server, or zero to disable timeouts.
+      See the note in the <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout">Microsoft documentation</a>
+      for more explanation of how this is determined.</td>
   </tr>
   <tr id="GuidFormat">
     <td>GUID Format, GuidFormat</td>
@@ -328,13 +342,6 @@ These are the other options that MySqlConnector supports. They are set to sensib
       </dl>
     </td>
   </tr>
-  <tr id="DefaultCommandTimeout">
-    <td>Default Command Timeout, Command Timeout, DefaultCommandTimeout</td>
-    <td>30</td>
-    <td>The length of time (in seconds) each command can execute before the query is cancelled on the server, or zero to disable timeouts.
-      See the note in the <a href="https://docs.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtimeout">Microsoft documentation</a>
-      for more explanation of how this is determined.</td>
-  </tr>
   <tr id="IgnoreCommandTransaction">
     <td>Ignore Command Transaction, IgnoreCommandTransaction</td>
     <td>false</td>
@@ -357,23 +364,6 @@ These are the other options that MySqlConnector supports. They are set to sensib
     <td>0</td>
     <td><p>TCP Keepalive idle time (in seconds). A value of 0 indicates that the OS default keepalive settings are used; a value greater than 0 is the idle connection time (in seconds) before the first keepalive packet is sent.</p>
     <p>On Windows, this option is always supported. On non-Windows platforms, this option only takes effect in .NET Core 3.0 and later. For earlier versions of .NET Core, the OS Default keepalive settings are used instead.</p></td>
-  </tr>
-  <tr id="LoadBalance">
-    <td>Load Balance, LoadBalance</td>
-    <td>RoundRobin</td>
-    <td><p>The load-balancing strategy to use when <code>Host</code> contains multiple, comma-delimited, host names.
-      The options include:</p>
-      <dl>
-        <dt>RoundRobin</dt>
-        <dd>Each new connection opened for this connection pool uses the next host name (sequentially with wraparound). Requires <code>Pooling=True</code>. This is the default if <code>Pooling=True</code>.</dd>
-        <dt>FailOver</dt>
-        <dd>Each new connection tries to connect to the first host; subsequent hosts are used only if connecting to the first one fails. This is the default if <code>Pooling=False</code>.</dd>
-        <dt>Random</dt>
-        <dd>Servers are tried in a random order.</dd>
-        <dt>LeastConnections</dt>
-        <dd>Servers are tried in ascending order of number of currently-open connections in this connection pool. Requires <code>Pooling=True</code>.</dd>
-      </dl>
-    </td>
   </tr>
   <tr id="NoBackslashEscapes">
     <td>No Backslash Escapes, NoBackslashEscapes</td>
@@ -431,6 +421,13 @@ These are the other options that MySqlConnector supports. They are set to sensib
     <td>false</td>
     <td>When <code>false</code> (default), the connection reports found rows instead of changed (affected) rows. Set to <code>true</code> to report only the number of rows actually changed by <code>UPDATE</code> or <code>INSERT … ON DUPLICATE KEY UPDATE</code> statements.</td>
   </tr>
+  <tr id="UseCompression">
+    <td>Use Compression, Compress, UseCompression</td>
+    <td>false</td>
+    <td>If true (and if the server supports compression), compresses packets sent between client and server. This option is unlikely to be useful in
+      practice unless there is a high-latency or low-bandwidth network link between the application and the database server. You should measure
+      performance with and without this option to determine if it’s beneficial in your environment.</td>
+  </tr>
   <tr id="UseXaTransactions">
     <td>Use XA Transactions, UseXaTransactions</td>
     <td>true</td>
@@ -441,9 +438,7 @@ These are the other options that MySqlConnector supports. They are set to sensib
   </tr>
 </table>
 
-
-Unsupported Options
--------------
+## Unsupported Options
 
 These options are used by Connector/NET but not supported by MySqlConnector. In general, they should be removed
 from your connection string when migrating from Connector/NET to MySqlConnector.

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -188,6 +188,33 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
+	/// Uses a certificate from the specified Certificate Store on the machine. The default value of <see cref="MySqlCertificateStoreLocation.None"/> means the certificate store is not used; a value of <see cref="MySqlCertificateStoreLocation.CurrentUser"/> or <see cref="MySqlCertificateStoreLocation.LocalMachine"/> uses the specified store.
+	/// </summary>
+	[Category("TLS")]
+	[DefaultValue(MySqlCertificateStoreLocation.None)]
+	[Description("Uses a certificate from the specified Certificate Store on the machine.")]
+	[DisplayName("Certificate Store Location")]
+	public MySqlCertificateStoreLocation CertificateStoreLocation
+	{
+		get => MySqlConnectionStringOption.CertificateStoreLocation.GetValue(this);
+		set => MySqlConnectionStringOption.CertificateStoreLocation.SetValue(this, value);
+	}
+
+	/// <summary>
+	/// Specifies which certificate should be used from the Certificate Store specified in <see cref="CertificateStoreLocation"/>. This option must be used to indicate which certificate in the store should be used for authentication.
+	/// </summary>
+	[AllowNull]
+	[Category("TLS")]
+	[DisplayName("Certificate Thumbprint")]
+	[DefaultValue("")]
+	[Description("Specifies which certificate should be used from the certificate store specified in Certificate Store Location")]
+	public string CertificateThumbprint
+	{
+		get => MySqlConnectionStringOption.CertificateThumbprint.GetValue(this);
+		set => MySqlConnectionStringOption.CertificateThumbprint.SetValue(this, value);
+	}
+
+	/// <summary>
 	/// The path to the client’s SSL certificate file in PEM format. <see cref="SslKey"/> must also be specified, and <see cref="CertificateFile"/> should not be.
 	/// </summary>
 	[AllowNull]
@@ -241,33 +268,6 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	{
 		get => MySqlConnectionStringOption.SslCa.GetValue(this);
 		set => MySqlConnectionStringOption.SslCa.SetValue(this, value);
-	}
-
-	/// <summary>
-	/// Uses a certificate from the specified Certificate Store on the machine. The default value of <see cref="MySqlCertificateStoreLocation.None"/> means the certificate store is not used; a value of <see cref="MySqlCertificateStoreLocation.CurrentUser"/> or <see cref="MySqlCertificateStoreLocation.LocalMachine"/> uses the specified store.
-	/// </summary>
-	[Category("TLS")]
-	[DefaultValue(MySqlCertificateStoreLocation.None)]
-	[Description("Uses a certificate from the specified Certificate Store on the machine.")]
-	[DisplayName("Certificate Store Location")]
-	public MySqlCertificateStoreLocation CertificateStoreLocation
-	{
-		get => MySqlConnectionStringOption.CertificateStoreLocation.GetValue(this);
-		set => MySqlConnectionStringOption.CertificateStoreLocation.SetValue(this, value);
-	}
-
-	/// <summary>
-	/// Specifies which certificate should be used from the Certificate Store specified in <see cref="CertificateStoreLocation"/>. This option must be used to indicate which certificate in the store should be used for authentication.
-	/// </summary>
-	[AllowNull]
-	[Category("TLS")]
-	[DisplayName("Certificate Thumbprint")]
-	[DefaultValue("")]
-	[Description("Specifies which certificate should be used from the certificate store specified in Certificate Store Location")]
-	public string CertificateThumbprint
-	{
-		get => MySqlConnectionStringOption.CertificateThumbprint.GetValue(this);
-		set => MySqlConnectionStringOption.CertificateThumbprint.SetValue(this, value);
 	}
 
 	/// <summary>
@@ -343,6 +343,19 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	/// This option is no longer supported.
 	/// </summary>
 	[Category("Obsolete")]
+	[DefaultValue(true)]
+	[DisplayName("Defer Connection Reset")]
+	[Obsolete("This option is no longer supported in MySqlConnector >= 1.4.0.")]
+	public bool DeferConnectionReset
+	{
+		get => MySqlConnectionStringOption.DeferConnectionReset.GetValue(this);
+		set => MySqlConnectionStringOption.DeferConnectionReset.SetValue(this, value);
+	}
+
+	/// <summary>
+	/// This option is no longer supported.
+	/// </summary>
+	[Category("Obsolete")]
 	[DefaultValue(0u)]
 	[DisplayName("Connection Idle Ping Time")]
 	[Obsolete("This option is no longer supported in MySqlConnector >= 1.4.0.")]
@@ -363,19 +376,6 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	{
 		get => MySqlConnectionStringOption.ConnectionIdleTimeout.GetValue(this);
 		set => MySqlConnectionStringOption.ConnectionIdleTimeout.SetValue(this, value);
-	}
-
-	/// <summary>
-	/// This option is no longer supported.
-	/// </summary>
-	[Category("Obsolete")]
-	[DefaultValue(true)]
-	[DisplayName("Defer Connection Reset")]
-	[Obsolete("This option is no longer supported in MySqlConnector >= 1.4.0.")]
-	public bool DeferConnectionReset
-	{
-		get => MySqlConnectionStringOption.DeferConnectionReset.GetValue(this);
-		set => MySqlConnectionStringOption.DeferConnectionReset.SetValue(this, value);
 	}
 
 	/// <summary>
@@ -486,6 +486,19 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
+	/// The length of time (in seconds) to wait for a query to be canceled when <see cref="MySqlCommand.CommandTimeout"/> expires, or zero for no timeout.
+	/// </summary>
+	[Category("Other")]
+	[DefaultValue(2)]
+	[Description("The length of time (in seconds) to wait for a query to be canceled when MySqlCommand.CommandTimeout expires, or zero for no timeout.")]
+	[DisplayName("Cancellation Timeout")]
+	public int CancellationTimeout
+	{
+		get => MySqlConnectionStringOption.CancellationTimeout.GetValue(this);
+		set => MySqlConnectionStringOption.CancellationTimeout.SetValue(this, value);
+	}
+
+	/// <summary>
 	/// Supported for backwards compatibility; MySqlConnector always uses <c>utf8mb4</c>.
 	/// </summary>
 	[AllowNull]
@@ -549,19 +562,6 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	{
 		get => MySqlConnectionStringOption.DefaultCommandTimeout.GetValue(this);
 		set => MySqlConnectionStringOption.DefaultCommandTimeout.SetValue(this, value);
-	}
-
-	/// <summary>
-	/// The length of time (in seconds) to wait for a query to be canceled when <see cref="MySqlCommand.CommandTimeout"/> expires, or zero for no timeout.
-	/// </summary>
-	[Category("Other")]
-	[DefaultValue(2)]
-	[Description("The length of time (in seconds) to wait for a query to be canceled when MySqlCommand.CommandTimeout expires, or zero for no timeout.")]
-	[DisplayName("Cancellation Timeout")]
-	public int CancellationTimeout
-	{
-		get => MySqlConnectionStringOption.CancellationTimeout.GetValue(this);
-		set => MySqlConnectionStringOption.CancellationTimeout.SetValue(this, value);
 	}
 
 	/// <summary>

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 using MySqlConnector.Utilities;
 
@@ -788,6 +789,11 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	// Other Methods
 
 	/// <summary>
+	/// Returns an <see cref="ICollection"/> that contains the keys in the <see cref="MySqlConnectionStringBuilder"/>.
+	/// </summary>
+	public override ICollection Keys => base.Keys.Cast<string>().OrderBy(x => MySqlConnectionStringOption.OptionNames.IndexOf(x)).ToList();
+
+	/// <summary>
 	/// Whether this <see cref="MySqlConnectionStringBuilder"/> contains a set option with the specified name.
 	/// </summary>
 	/// <param name="keyword">The option name.</param>
@@ -876,6 +882,8 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 
 internal abstract class MySqlConnectionStringOption
 {
+	public static List<string> OptionNames { get; } = new();
+
 	// Connection Options
 	public static readonly MySqlConnectionStringReferenceOption<string> Server;
 	public static readonly MySqlConnectionStringValueOption<uint> Port;
@@ -892,9 +900,9 @@ internal abstract class MySqlConnectionStringOption
 	public static readonly MySqlConnectionStringReferenceOption<string> CertificatePassword;
 	public static readonly MySqlConnectionStringValueOption<MySqlCertificateStoreLocation> CertificateStoreLocation;
 	public static readonly MySqlConnectionStringReferenceOption<string> CertificateThumbprint;
-	public static readonly MySqlConnectionStringReferenceOption<string> SslCa;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslCert;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslKey;
+	public static readonly MySqlConnectionStringReferenceOption<string> SslCa;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsVersion;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsCipherSuites;
 
@@ -960,6 +968,7 @@ internal abstract class MySqlConnectionStringOption
 	{
 		foreach (string key in option.m_keys)
 			s_options.Add(key, option);
+		OptionNames.Add(option.m_keys[0]);
 	}
 
 #pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
@@ -1014,8 +1023,12 @@ internal abstract class MySqlConnectionStringOption
 			keys: new[] { "Certificate Password", "CertificatePassword" },
 			defaultValue: ""));
 
-		AddOption(SslCa = new(
-			keys: new[] { "SSL CA", "CACertificateFile", "CA Certificate File", "SslCa", "Ssl-Ca" },
+		AddOption(CertificateStoreLocation = new(
+			keys: new[] { "Certificate Store Location", "CertificateStoreLocation" },
+			defaultValue: MySqlCertificateStoreLocation.None));
+
+		AddOption(CertificateThumbprint = new(
+			keys: new[] { "Certificate Thumbprint", "CertificateThumbprint", "Certificate Thumb Print" },
 			defaultValue: ""));
 
 		AddOption(SslCert = new(
@@ -1026,12 +1039,8 @@ internal abstract class MySqlConnectionStringOption
 			keys: new[] { "SSL Key", "SslKey", "Ssl-Key" },
 			defaultValue: ""));
 
-		AddOption(CertificateStoreLocation = new(
-			keys: new[] { "Certificate Store Location", "CertificateStoreLocation" },
-			defaultValue: MySqlCertificateStoreLocation.None));
-
-		AddOption(CertificateThumbprint = new(
-			keys: new[] { "Certificate Thumbprint", "CertificateThumbprint", "Certificate Thumb Print" },
+		AddOption(SslCa = new(
+			keys: new[] { "SSL CA", "CACertificateFile", "CA Certificate File", "SslCa", "Ssl-Ca" },
 			defaultValue: ""));
 
 		AddOption(TlsVersion = new(

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -232,6 +232,22 @@ public class MySqlConnectionStringBuilderTests
 		Assert.True(csb.UseAffectedRows);
 		Assert.True(csb.UseCompression);
 		Assert.Equal("username", csb.UserID);
+
+#if !BASELINE
+		Assert.Equal("Server=db-server;Port=1234;User ID=username;Password=Pass1234;Database=schema_name;Load Balance=Random;" +
+			"Connection Protocol=NamedPipe;Pipe Name=MyPipe;SSL Mode=VerifyCA;Certificate File=file.pfx;Certificate Password=Pass2345;" +
+			"Certificate Store Location=CurrentUser;Certificate Thumbprint=thumbprint123;SSL Cert=client-cert.pem;SSL Key=client-key.pem;" +
+			"SSL CA=ca.pem;TLS Version=\"TLS 1.2, TLS 1.3\";TLS Cipher Suites=TLS_AES_128_CCM_8_SHA256,TLS_RSA_WITH_RC4_128_MD5;" +
+			"Pooling=False;Connection Lifetime=15;Connection Reset=False;Defer Connection Reset=True;Connection Idle Timeout=30;" +
+			"Minimum Pool Size=5;Maximum Pool Size=15;Allow Load Local Infile=True;Allow Public Key Retrieval=True;Allow User Variables=True;" +
+			"Allow Zero DateTime=True;Application Name=\"My Test Application\";Auto Enlist=False;Cancellation Timeout=-1;Character Set=latin1;" +
+			"Connection Timeout=30;Convert Zero DateTime=True;DateTime Kind=Utc;Default Command Timeout=123;Force Synchronous=True;" +
+			"GUID Format=TimeSwapBinary16;Ignore Command Transaction=True;Ignore Prepare=True;Interactive Session=True;Keep Alive=90;" +
+			"No Backslash Escapes=True;Old Guids=True;Persist Security Info=True;Pipelining=False;Server Redirection Mode=Required;" +
+			"Server RSA Public Key File=rsa.pem;Server SPN=mariadb/host.example.com@EXAMPLE.COM;Treat Tiny As Boolean=False;" +
+			"Use Affected Rows=True;Use Compression=True;Use XA Transactions=False",
+			csb.ConnectionString);
+#endif
 	}
 
 	[Fact]

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -114,7 +114,7 @@ public class MySqlConnectionStringBuilderTests
 				"allow zero datetime=true;" +
 				"auto enlist=False;" +
 				"certificate file=file.pfx;" +
-				"certificate password=Pass1234;" +
+				"certificate password=Pass2345;" +
 				"certificate store location=CurrentUser;" +
 				"certificate thumb print=thumbprint123;" +
 				"Character Set=latin1;" +
@@ -175,7 +175,7 @@ public class MySqlConnectionStringBuilderTests
 		// Connector/NET treats "CertificateFile" (client certificate) and "SslCa" (server CA) as aliases
 		Assert.Equal("file.pfx", csb.CertificateFile);
 #endif
-		Assert.Equal("Pass1234", csb.CertificatePassword);
+		Assert.Equal("Pass2345", csb.CertificatePassword);
 		Assert.Equal(MySqlCertificateStoreLocation.CurrentUser, csb.CertificateStoreLocation);
 		Assert.Equal("thumbprint123", csb.CertificateThumbprint);
 		Assert.Equal("latin1", csb.CharacterSet);

--- a/tests/SideBySide/ConnectionTests.cs
+++ b/tests/SideBySide/ConnectionTests.cs
@@ -208,7 +208,7 @@ public class ConnectionTests : IClassFixture<DatabaseFixture>
 		if (openConnection)
 			connection.Open();
 		using var connection2 = connection.CloneWith("user=root;password=pass;server=example.com;database=test");
-		Assert.Equal("User ID=root;Password=pass;Server=example.com;Database=test", connection2.ConnectionString);
+		Assert.Equal("Server=example.com;User ID=root;Password=pass;Database=test", connection2.ConnectionString);
 	}
 
 	[Fact]


### PR DESCRIPTION
Fixes #1217 

Connection string options are now serialized (e.g., for the `MySqlConnectionStringBuilder.ConnectionString` property) in a consistent order.

The order is not alphabetical, but "logical", with options ordered hopefully close to the way they're most commonly authored by hand (e.g., `Server` first; `Minimum Pool Size` before `Maximum Pool Size` etc.).

The documentation and source code have been updated to be consistent with the canonical order in the connection string.

This also fixes a minor bug where "equivalent" connection strings with options in different orders would create distinct connection pools.