### PR TITLE
Avoid normalize parameter every operation in prepared query

### DIFF
--- a/src/MySqlConnector/Core/ParsedStatement.cs
+++ b/src/MySqlConnector/Core/ParsedStatement.cs
@@ -18,6 +18,12 @@ internal sealed class ParsedStatement
 	public List<string?> ParameterNames { get; } = new();
 
 	/// <summary>
+	/// The normalized names of the parameters (if known) of the parameters in the prepared statement. There
+	/// is one entry in this list for each parameter, which will be <c>null</c> if the name is unknown.
+	/// </summary>
+	public List<string?> NormalizedParameterNames { get; } = new();
+
+	/// <summary>
 	/// The indexes of the parameters in the prepared statement. There is one entry in this list for
 	/// each parameter; it will be <c>-1</c> if the parameter is named.
 	/// </summary>

--- a/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
+++ b/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
@@ -116,10 +116,10 @@ internal sealed class SingleCommandPayloadCreator : ICommandPayloadCreator
 			var parameters = new MySqlParameter[commandParameterCount + attributeCount];
 			for (var i = 0; i < commandParameterCount; i++)
 			{
-				var parameterName = preparedStatement.Statement.ParameterNames![i];
-				var parameterIndex = parameterName is not null ? (parameterCollection?.NormalizedIndexOf(parameterName) ?? -1) : preparedStatement.Statement.ParameterIndexes[i];
+				var parameterName = preparedStatement.Statement.NormalizedParameterNames![i];
+				var parameterIndex = parameterName is not null ? (parameterCollection?.UnsafeIndexOf(parameterName) ?? -1) : preparedStatement.Statement.ParameterIndexes[i];
 				if (parameterIndex == -1 && parameterName is not null)
-					throw new MySqlException("Parameter '{0}' must be defined.".FormatInvariant(parameterName));
+					throw new MySqlException("Parameter '{0}' must be defined.".FormatInvariant(preparedStatement.Statement.ParameterNames![i]));
 				else if (parameterIndex < 0 || parameterIndex >= (parameterCollection?.Count ?? 0))
 					throw new MySqlException("Parameter index {0} is invalid when only {1} parameter{2} defined.".FormatInvariant(parameterIndex, parameterCollection?.Count ?? 0, parameterCollection?.Count == 1 ? " is" : "s are"));
 				parameters[i] = parameterCollection![parameterIndex];

--- a/src/MySqlConnector/Core/StatementPreparer.cs
+++ b/src/MySqlConnector/Core/StatementPreparer.cs
@@ -147,6 +147,7 @@ internal sealed class StatementPreparer
 
 			// store the parameter index
 			m_statements[m_statements.Count - 1].ParameterNames.Add(parameterName);
+			m_statements[m_statements.Count - 1].NormalizedParameterNames.Add(parameterName == null ? null : MySqlParameter.NormalizeParameterName(parameterName));
 			m_statements[m_statements.Count - 1].ParameterIndexes.Add(parameterIndex);
 		}
 

--- a/src/MySqlConnector/MySqlParameterCollection.cs
+++ b/src/MySqlConnector/MySqlParameterCollection.cs
@@ -96,6 +96,11 @@ public sealed class MySqlParameterCollection : DbParameterCollection, IEnumerabl
 		return m_nameToIndex.TryGetValue(normalizedName, out var index) ? index : -1;
 	}
 
+	internal int UnsafeIndexOf(string? normalizedParameterName)
+	{
+		return m_nameToIndex.TryGetValue(normalizedParameterName ?? "", out var index) ? index : -1;
+	}
+
 	public override void Insert(int index, object value) => AddParameter((MySqlParameter) (value ?? throw new ArgumentNullException(nameof(value))), index);
 
 	public override bool IsFixedSize => false;


### PR DESCRIPTION
If using prepared query,
`SingleCommandPayloadCreator.WritePreparedStatement` calls `parameterCollection?.NormalizedIndexOf` and it allocates string(Trim `@`).
However, since the Parameter of a Prepared Statement is always the same, if it is Normalized in advance, it will not be Allocated each time.

This PR adds `List<string?> NormalizedParameterNames` to `ParsedStatement` (`ParsedStatement` is only used prepared query).
Also added MySqlParameterCollection.UnsafeIndexOf, which is an IndexOf that expects the argument to be already normalized.

This improves the performance of Prepared Queries that are executed multiple times.