### PR TITLE
OpenTcpSocketAsync: use new cancellation token overload for >= .Net 5.0

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1083,7 +1083,11 @@ internal sealed partial class ServerSession
 						{
 							if (ioBehavior == IOBehavior.Asynchronous)
 							{
+#if NET5_0_OR_GREATER
+								await tcpClient.ConnectAsync(ipAddress, cs.Port, cancellationToken).ConfigureAwait(false);
+#else
 								await tcpClient.ConnectAsync(ipAddress, cs.Port).ConfigureAwait(false);
+#endif
 							}
 							else
 							{


### PR DESCRIPTION
There is a cancellable variant introduced in .Net 5.0:
https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.connectasync?view=net-5.0#system-net-sockets-tcpclient-connectasync(system-string-system-int32-system-threading-cancellationtoken)

(Note: The Dns.GetHostAddressesAsync(), a few lines above https://github.com/mysql-net/MySqlConnector/blob/master/src/MySqlConnector/Core/ServerSession.cs#L1036, cancellable overload was already added as part of https://github.com/mysql-net/MySqlConnector/commit/5a833319030c175904f3d09c5815168171a5e33e)