### PR TITLE
Permit skipping metadata for MariaDB

### DIFF
--- a/src/MySqlConnector/Core/CommandListPosition.cs
+++ b/src/MySqlConnector/Core/CommandListPosition.cs
@@ -8,6 +8,7 @@ internal struct CommandListPosition
 	public CommandListPosition(IReadOnlyList<IMySqlCommand> commands)
 	{
 		Commands = commands;
+		PreparedStatements = null;
 		CommandIndex = 0;
 		PreparedStatementIndex = 0;
 	}
@@ -18,6 +19,11 @@ internal struct CommandListPosition
 	public IReadOnlyList<IMySqlCommand> Commands { get; }
 
 	/// <summary>
+	/// Associated prepared statements of commands
+	/// </summary>
+	public PreparedStatements? PreparedStatements;
+
+	/// <summary>
 	/// The index of the current command.
 	/// </summary>
 	public int CommandIndex;
@@ -26,4 +32,9 @@ internal struct CommandListPosition
 	/// If the current command is a prepared statement, the index of the current prepared statement for that command.
 	/// </summary>
 	public int PreparedStatementIndex;
+
+	/// <summary>
+	/// Retrieve the last used prepared statement
+	/// </summary>
+	public PreparedStatement? LastUsedPreparedStatement;
 }

--- a/src/MySqlConnector/Core/PreparedStatement.cs
+++ b/src/MySqlConnector/Core/PreparedStatement.cs
@@ -17,6 +17,6 @@ internal sealed class PreparedStatement
 
 	public int StatementId { get; }
 	public ParsedStatement Statement { get; }
-	public ColumnDefinitionPayload[]? Columns { get; }
+	public ColumnDefinitionPayload[]? Columns { get; internal set; }
 	public ColumnDefinitionPayload[]? Parameters { get; }
 }

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -62,6 +62,7 @@ internal sealed partial class ServerSession
 	public WeakReference<MySqlConnection>? OwningConnection { get; set; }
 	public bool SupportsComMulti => m_supportsComMulti;
 	public bool SupportsDeprecateEof => m_supportsDeprecateEof;
+	public bool SupportsMetaSkip => m_supportsMetaSkip;
 	public bool SupportsQueryAttributes { get; private set; }
 	public bool SupportsSessionTrack => m_supportsSessionTrack;
 	public bool ProcAccessDenied { get; set; }
@@ -483,6 +484,7 @@ internal sealed partial class ServerSession
 				m_supportsComMulti = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.MariaDbComMulti) != 0;
 				m_supportsConnectionAttributes = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.ConnectionAttributes) != 0;
 				m_supportsDeprecateEof = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.DeprecateEof) != 0;
+				m_supportsMetaSkip = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.MariaDbCacheMetadata) != 0;
 				SupportsQueryAttributes = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.QueryAttributes) != 0;
 				m_supportsSessionTrack = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.SessionTrack) != 0;
 				var serverSupportsSsl = (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.Ssl) != 0;
@@ -517,7 +519,7 @@ internal sealed partial class ServerSession
 					}
 				}
 
-				Log.SessionMadeConnection(m_logger, Id, ServerVersion.OriginalString, ConnectionId, m_useCompression, m_supportsConnectionAttributes, m_supportsDeprecateEof, serverSupportsSsl, m_supportsSessionTrack, m_supportsPipelining, SupportsQueryAttributes);
+				Log.SessionMadeConnection(m_logger, Id, ServerVersion.OriginalString, ConnectionId, m_useCompression, m_supportsConnectionAttributes, m_supportsDeprecateEof, m_supportsMetaSkip, serverSupportsSsl, m_supportsSessionTrack, m_supportsPipelining, SupportsQueryAttributes);
 
 				if (cs.SslMode != MySqlSslMode.None && (cs.SslMode != MySqlSslMode.Preferred || serverSupportsSsl))
 				{
@@ -1967,6 +1969,7 @@ internal sealed partial class ServerSession
 	private bool m_supportsComMulti;
 	private bool m_supportsConnectionAttributes;
 	private bool m_supportsDeprecateEof;
+	private bool m_supportsMetaSkip;
 	private bool m_supportsSessionTrack;
 	private bool m_supportsPipelining;
 	private CharacterSet m_characterSet;

--- a/src/MySqlConnector/Logging/Log.cs
+++ b/src/MySqlConnector/Logging/Log.cs
@@ -40,8 +40,8 @@ internal static partial class Log
 	[LoggerMessage(EventIds.AutoDetectedAurora57, LogLevel.Debug, "Session {SessionId} auto-detected Aurora 5.7 at '{HostName}'; disabling pipelining")]
 	public static partial void AutoDetectedAurora57(ILogger logger, string sessionId, string hostName);
 
-	[LoggerMessage(EventIds.SessionMadeConnection, LogLevel.Debug, "Session {SessionId} made connection; server version {ServerVersion}; connection ID {ConnectionId}; supports: compression {SupportsCompression}, attributes {SupportsAttributes}, deprecate EOF {SupportsDeprecateEof}, SSL {SupportsSsl}, session track {SupportsSessionTrack}, pipelining {SupportsPipelining}, query attributes {SupportsQueryAttributes}")]
-	public static partial void SessionMadeConnection(ILogger logger, string sessionId, string serverVersion, int connectionId, bool supportsCompression, bool supportsAttributes, bool supportsDeprecateEof, bool supportsSsl, bool supportsSessionTrack, bool supportsPipelining, bool supportsQueryAttributes);
+	[LoggerMessage(EventIds.SessionMadeConnection, LogLevel.Debug, "Session {SessionId} made connection; server version {ServerVersion}; connection ID {ConnectionId}; supports: compression {SupportsCompression}, attributes {SupportsAttributes}, deprecate EOF {SupportsDeprecateEof}, metadata skip {supportsMetaSkip}, SSL {SupportsSsl}, session track {SupportsSessionTrack}, pipelining {SupportsPipelining}, query attributes {SupportsQueryAttributes}")]
+	public static partial void SessionMadeConnection(ILogger logger, string sessionId, string serverVersion, int connectionId, bool supportsCompression, bool supportsAttributes, bool supportsDeprecateEof, bool supportsMetaSkip, bool supportsSsl, bool supportsSessionTrack, bool supportsPipelining, bool supportsQueryAttributes);
 
 	[LoggerMessage(EventIds.ServerDoesNotSupportSsl, LogLevel.Error, "Session {SessionId} requires SSL but server doesn't support it")]
 	public static partial void ServerDoesNotSupportSsl(ILogger logger, string sessionId);

--- a/src/MySqlConnector/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlDataReader.cs
@@ -691,6 +691,8 @@ public sealed class MySqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 			throw new InvalidOperationException("Can't call this method when MySqlDataReader is closed.");
 	}
 
+	internal PreparedStatement? CurrentPrepareStmt() => m_commandListPosition.LastUsedPreparedStatement;
+
 	private ResultSet GetResultSet()
 	{
 		VerifyNotDisposed();

--- a/src/MySqlConnector/Protocol/Payloads/ColumnCountPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/ColumnCountPayload.cs
@@ -1,0 +1,28 @@
+using MySqlConnector.Protocol.Serialization;
+
+namespace MySqlConnector.Protocol.Payloads;
+
+/// <summary>
+///     Helper class to parse Column count packet.
+///     https://mariadb.com/kb/en/result-set-packets/#column-count-packet
+///     Packet contains a columnCount, and - if capability MARIADB_CLIENT_CACHE_METADATA is set - a flag to indicate if metadata follows
+/// </summary>
+internal sealed class ColumnCountPayload
+{
+	private ColumnCountPayload(int columnCount, bool metadataFollows)
+	{
+		ColumnCount = columnCount;
+		MetadataFollows = metadataFollows;
+	}
+
+	public int ColumnCount { get; }
+	public bool MetadataFollows { get; }
+
+	public static ColumnCountPayload Create(ReadOnlySpan<byte> span, bool supportsMetaSkip)
+	{
+		var reader = new ByteArrayReader(span);
+		var columnCount = (int) reader.ReadLengthEncodedInteger();
+		var metadataFollows = supportsMetaSkip ? reader.ReadByte() == 1 : true;
+		return new ColumnCountPayload(columnCount, metadataFollows);
+	}
+}

--- a/src/MySqlConnector/Protocol/ProtocolCapabilities.cs
+++ b/src/MySqlConnector/Protocol/ProtocolCapabilities.cs
@@ -147,4 +147,14 @@ internal enum ProtocolCapabilities : ulong
 	/// Support of array binding.
 	/// </summary>
 	MariaDbStatementBulkOperations = 0x4_0000_0000,
+
+	/// <summary>
+	/// metadata extended information
+	/// </summary>
+	MariaDbExtendedTypeInfo = 0x8_0000_0000,
+
+	/// <summary>
+	/// permit metadata caching
+	/// </summary>
+	MariaDbCacheMetadata = 0x16_0000_0000,
 }

--- a/tests/IntegrationTests/CommandTests.cs
+++ b/tests/IntegrationTests/CommandTests.cs
@@ -45,6 +45,111 @@ public class CommandTests : IClassFixture<DatabaseFixture>
 	}
 
 	[Fact]
+	public void SingleQueryWithPrepareReuse()
+	{
+		using var connection = new MySqlConnection(m_database.Connection.ConnectionString);
+		connection.Open();
+		using (var cmd = connection.CreateCommand())
+		{
+			cmd.CommandText = "select ?";
+			cmd.Prepare();
+			cmd.Parameters.Add(new() { Value = 1 });
+			using (var reader = cmd.ExecuteReader())
+			{
+				while (reader.Read())
+				{
+					Assert.Equal(1, reader.GetInt32(0));
+				}
+			}
+
+			cmd.Parameters.Clear();
+			cmd.Parameters.Add(new() { Value = 100 });
+			using (var reader = cmd.ExecuteReader())
+			{
+				while (reader.Read())
+				{
+					Assert.Equal(100, reader.GetInt32(0));
+				}
+			}
+		}
+
+		using (var cmd = connection.CreateCommand())
+		{
+			cmd.CommandText = "select ?";
+			cmd.Prepare();
+			cmd.Parameters.Add(new() { Value = 2 });
+			using var reader = cmd.ExecuteReader();
+			while (reader.Read())
+			{
+				Assert.Equal(2, reader.GetInt32(0));
+			}
+		}
+	}
+
+	[Fact]
+	public void MultiQueryWithPrepareReuse()
+	{
+		using var connection = new MySqlConnection(m_database.Connection.ConnectionString);
+		connection.Open();
+		using (var cmd = connection.CreateCommand())
+		{
+			cmd.CommandText = "select ?; select ? + 2";
+			cmd.Prepare();
+			cmd.Parameters.Add(new() { Value = 1 });
+			cmd.Parameters.Add(new() { Value = 4 });
+			using (var reader = cmd.ExecuteReader())
+			{
+				while (reader.Read())
+				{
+					Assert.Equal(1, reader.GetInt32(0));
+				}
+
+				Assert.True(reader.NextResult());
+				while (reader.Read())
+				{
+					Assert.Equal(6, reader.GetInt32(0));
+				}
+			}
+
+			cmd.Parameters.Clear();
+			cmd.Parameters.Add(new() { Value = 100 });
+			cmd.Parameters.Add(new() { Value = 400 });
+			using (var reader = cmd.ExecuteReader())
+			{
+				while (reader.Read())
+				{
+					Assert.Equal(100, reader.GetInt32(0));
+				}
+
+				Assert.True(reader.NextResult());
+				while (reader.Read())
+				{
+					Assert.Equal(402, reader.GetInt32(0));
+				}
+			}
+		}
+
+		using (var cmd = connection.CreateCommand())
+		{
+			cmd.CommandText = "select ?; select ? + 2";
+			cmd.Prepare();
+			cmd.Parameters.Add(new() { Value = 2 });
+			cmd.Parameters.Add(new() { Value = 5 });
+			using var reader = cmd.ExecuteReader();
+			while (reader.Read())
+			{
+				Assert.Equal(2, reader.GetInt32(0));
+			}
+
+			Assert.True(reader.NextResult());
+			while (reader.Read())
+			{
+				Assert.Equal(7, reader.GetInt32(0));
+			}
+		}
+	}
+
+	[Fact]
 	public void CreateCommandDoesNotSetTransaction()
 	{
 		using var connection = new MySqlConnection(AppConfig.ConnectionString);

--- a/tests/IntegrationTests/InsertTests.cs
+++ b/tests/IntegrationTests/InsertTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Numerics;
 #if MYSQL_DATA
 using MySql.Data.Types;
@@ -471,7 +472,7 @@ create table insert_big_integer(rowid integer not null primary key auto_incremen
 
 		using var reader = connection.ExecuteReader(@"select value from insert_mysql_decimal order by rowid;");
 		Assert.True(reader.Read());
-		var val = reader.GetValue(0).ToString();
+		var val = ((decimal) reader.GetValue(0)).ToString(CultureInfo.InvariantCulture);
 		Assert.Equal(value, val);
 	}
 #endif

--- a/tests/MySqlConnector.Tests/MySqlDecimalTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlDecimalTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace MySqlConnector.Tests;
@@ -90,7 +91,7 @@ public class MySqlDecimalTests
 		var value = "-0.2342323";
 		var decimalVal = new MySqlDecimal(value);
 		Assert.Equal(value, decimalVal.ToString());
-		Assert.Equal(decimal.Parse(value), decimalVal.Value);
+		Assert.Equal(decimal.Parse(value, CultureInfo.InvariantCulture), decimalVal.Value);
 	}
 
 	[Fact]


### PR DESCRIPTION
Since MariaDB 10.6 (with https://jira.mariadb.org/browse/MDEV-19237) binary result-set can skip sending metadata when they haven't changed.
This avoid network data and parsing client side.

Benchmarks results using DDL:
```
CREATE TABLE test100 (i1 int,i2 int,...,i100 int);
INSERT INTO test100 value (1,2,...,100);
```

test methods:
```
    [Benchmark]
    public async Task<int> readOneRow100FieldsAsync()
    {
        var total = 0;
        using (var cmd = Connection.CreateCommand())
        {
            cmd.CommandText = "select * FROM test100";
            using (var reader = await cmd.ExecuteReaderAsync())
            {
                while (await reader.ReadAsync())
                    for (var i = 0; i < 100; i++)
                        total += reader.GetInt32(i);
            }
        }
        return total;
    }

    [Benchmark]
    public async Task<int> readOneRow100FieldsPrepareAsync()
    {
        var total = 0;
        using (var cmd = Connection.CreateCommand())
        {
            cmd.CommandText = "select * FROM test100";
            cmd.Prepare();
            using (var reader = await cmd.ExecuteReaderAsync())
            {
                while (await reader.ReadAsync())
                    for (var i = 0; i < 100; i++)
                        total += reader.GetInt32(i);
            }
        }
        return total;
    }
```

before PR:
```
|                          Method |        Library |      Mean |    Error |
|-------------------------------- |--------------- |----------:|---------:|
|        readOneRow100FieldsAsync | MySqlConnector | 104.47 us | 1.468 us |
| readOneRow100FieldsPrepareAsync | MySqlConnector |  92.49 us | 1.154 us |
```
After PR:
```
|                          Method |        Library |      Mean |    Error |
|-------------------------------- |--------------- |----------:|---------:|
|        readOneRow100FieldsAsync | MySqlConnector | 103.99 us | 0.914 us |
| readOneRow100FieldsPrepareAsync | MySqlConnector |  71.50 us | 1.402 us |
```