### PR TITLE
Permit multi-authentication

### DIFF
--- a/.ci/server/init_ed25519.sql
+++ b/.ci/server/init_ed25519.sql
@@ -1,3 +1,6 @@
 INSTALL SONAME 'auth_ed25519';
 CREATE USER 'ed25519user'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('Ed255!9');
 GRANT ALL PRIVILEGES ON *.* TO 'ed25519user'@'%';
+
+CREATE USER 'multiAuthUser'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('Ed255!9') OR mysql_native_password as password("secret");
+GRANT ALL PRIVILEGES ON *.* TO 'multiAuthUser'@'%';

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -561,7 +561,7 @@ internal sealed partial class ServerSession
 			payload = await ReceiveReplyAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 
 			// if server doesn't support the authentication fast path, it will send a new challenge
-			if (payload.HeaderByte == AuthenticationMethodSwitchRequestPayload.Signature)
+			while (payload.HeaderByte == AuthenticationMethodSwitchRequestPayload.Signature)
 			{
 				payload = await SwitchAuthenticationAsync(cs, password, payload, ioBehavior, cancellationToken).ConfigureAwait(false);
 			}

--- a/tests/IntegrationTests/ConnectAsync.cs
+++ b/tests/IntegrationTests/ConnectAsync.cs
@@ -439,6 +439,18 @@ public class ConnectAsync : IClassFixture<DatabaseFixture>
 		using var connection = new MySqlConnection(csb.ConnectionString);
 		await connection.OpenAsync();
 	}
+
+	[SkippableFact(ServerFeatures.Ed25519)]
+	public async Task MultiAuthentication()
+	{
+		Ed25519AuthenticationPlugin.Install();
+		var csb = AppConfig.CreateConnectionStringBuilder();
+		csb.UserID = "multiAuthUser";
+		csb.Password = "secret";
+		csb.Database = null;
+		using var connection = new MySqlConnection(csb.ConnectionString);
+		await connection.OpenAsync();
+	}
 #endif
 
 	// To create a MariaDB GSSAPI user for a current user


### PR DESCRIPTION
Authentication switch request can result in 3 type of responses:
* OK_Packet
* ERR_Packet
* another authentication switch request.

Actual implementation does not permit another authentication switch request.

This can be the case when using multiple authentication, like :
```
create user mysqltest1 identified via mysql_native_password as password("good") OR unix_socket;
``` 
Existing in:
* MariaDB 10.4.3+ (https://mariadb.com/kb/en/create-user/#identified-viawith-authentication_plugin) 
* MySQL 8.0.27+ multifactor authentication (MFA) (https://dev.mysql.com/doc/refman/8.0/en/create-user.html)
