### PR TITLE
Query timeout using per query variables

### DIFF
--- a/src/MySqlConnector/Core/ICancellableCommand.cs
+++ b/src/MySqlConnector/Core/ICancellableCommand.cs
@@ -60,7 +60,7 @@ internal static class ICancellableCommandExtensions
 			{
 				session.SetTimeout(Constants.InfiniteTimeout);
 			}
-			else
+			else if (!command.Connection!.SupportPerQueryVariables)
 			{
 				var commandTimeUntilCanceled = command.GetCommandTimeUntilCanceled() * 1000;
 				if (session.CancellationTimeout > 0)

--- a/src/MySqlConnector/Core/IMySqlCommand.cs
+++ b/src/MySqlConnector/Core/IMySqlCommand.cs
@@ -9,6 +9,7 @@ internal interface IMySqlCommand
 {
 	string? CommandText { get; }
 	CommandType CommandType { get; }
+	int CommandTimeout { get; }
 	bool AllowUserVariables { get; }
 	CommandBehavior CommandBehavior { get; }
 	MySqlParameterCollection? RawParameters { get; }

--- a/src/MySqlConnector/Core/ServerVersions.cs
+++ b/src/MySqlConnector/Core/ServerVersions.cs
@@ -16,4 +16,7 @@ internal static class ServerVersions
 
 	// https://ocelot.ca/blog/blog/2017/08/22/no-more-mysql-proc-in-mysql-8-0/
 	public static readonly Version RemovesMySqlProcTable = new(8, 0, 0);
+
+	// https://mariadb.com/kb/en/set-statement/
+	public static readonly Version MariaDbSupportPerQueryVariables = new(10, 1, 2);
 }

--- a/src/MySqlConnector/MySqlBatchCommand.cs
+++ b/src/MySqlConnector/MySqlBatchCommand.cs
@@ -41,6 +41,8 @@ public sealed class MySqlBatchCommand :
 #endif
 		0;
 
+	public int CommandTimeout => 0;
+
 #if NET6_0_OR_GREATER
 	public new MySqlParameterCollection Parameters =>
 #else

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -855,6 +855,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 
 	internal int? ActiveCommandId => m_session?.ActiveCommandId;
 
+	internal bool SupportPerQueryVariables => m_session is not null && m_session.SupportPerQueryVariables;
 	internal bool HasActiveReader => m_activeReader is not null;
 
 	internal void SetActiveReader(MySqlDataReader dataReader)


### PR DESCRIPTION
MariaDB and percona server permits per query variables
(see https://mariadb.com/kb/en/set-statement/ and https://www.percona.com/blog/using-per-query-variable-statements-in-percona-server/)

This corresponds to commands like
```
SET STATEMENT <variable=value> FOR <statement>
```
These 2 servers have a `max_statement_time` variable that allows the abort of requests taking longer than this time.

This PR set session `max_statement_time` to avoid using a TimerQueue for each execution, and if reaching timeout, using `KILL QUERY` commands on another connection. This just leave the server handling the timeout.

The server will then return an error "The execution of the request was interrupted (max_statement_time exceeded)".

This functionality is available in MySQL since version 5.7.4, renamed max_execution_time but is limited to read-only SELECT queries and not in stored procedures, which makes it unusable for connectors.

this also allows CommandBehavior.SchemaOnly and CommandBehavior.SingleRow to not use multiple statements, which helps improve performance.

Benchmark results using default command timeout and a MariaDB server:

```

    [Benchmark]
    public async Task<bool> ReadSingleRow()
    {
	    using (var cmd = Connection.CreateCommand())
	    {
		    cmd.CommandText = "SELECT * FROM seq_10_to_20";
		    using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow))
		    {
			    await reader.ReadAsync();
			    reader.GetInt32(0);
			    return await reader.ReadAsync();
		    }
	    }
    }

    [Benchmark]
    public async Task<System.Data.DataColumnCollection> ReadSchemaOnly()
    {
	    using (var cmd = Connection.CreateCommand())
	    {
		    cmd.CommandText = "SELECT * FROM seq_10_to_20";
		    using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly))
		    {
			    await reader.ReadAsync();
			    return reader.GetSchemaTable().Columns;
		    }
	    }
    }

    [Benchmark]
    public async Task CommandTimeout()
    {
	    using (var cmd = Connection.CreateCommand())
	    {
		    cmd.CommandText = "SELECT 1";
		    // cmd.CommandTimeout = 1; //using default timeout
		    using (var reader = await cmd.ExecuteReaderAsync())
		    {
				reader.Read();
		    }
	    }
    }
```

results :
```
|         Method |        Library |     Mean |    Error |
|--------------- |--------------- |---------:|---------:|
|  ReadSingleRow | MySqlConnector | 60.69 us | 0.367 us |
| ReadSchemaOnly | MySqlConnector | 64.02 us | 1.238 us |
| CommandTimeout | MySqlConnector | 34.53 us | 0.606 us |
```
after PR:
```
|         Method |        Library |     Mean |    Error |
|--------------- |--------------- |---------:|---------:|
|  ReadSingleRow | MySqlConnector | 49.73 us | 0.222 us |
| ReadSchemaOnly | MySqlConnector | 57.26 us | 1.032 us |
| CommandTimeout | MySqlConnector | 34.25 us | 0.279 us |
```

Command using default timeout result are similar, the difference being minimal, but running the benchmark 15x, performance is always around 1% better.

In order to run test, i've slightly change Cancel and Timeout test, because of MySQL and MariaDB difference, killing a `SLEEP(x)` command resulting in a OK_Packet in MySQL, throwing an "Query execution was interrupted" exception for MariaDB
