### PR TITLE
pass Port and UserId to cancel connection

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -59,6 +59,8 @@ internal sealed partial class ServerSession
 	public string? DatabaseOverride { get; set; }
 	public string HostName { get; private set; }
 	public IPAddress? IPAddress => (m_tcpClient?.Client.RemoteEndPoint as IPEndPoint)?.Address;
+	public int? Port => (m_tcpClient?.Client.RemoteEndPoint as IPEndPoint)?.Port;
+	public string UserID { get; private set; } = string.Empty;
 	public WeakReference<MySqlConnection>? OwningConnection { get; set; }
 	public bool SupportsComMulti => m_supportsComMulti;
 	public bool SupportsDeprecateEof => m_supportsDeprecateEof;
@@ -471,6 +473,7 @@ internal sealed partial class ServerSession
 				AuthPluginData = initialHandshake.AuthPluginData;
 				m_useCompression = cs.UseCompression && (initialHandshake.ProtocolCapabilities & ProtocolCapabilities.Compress) != 0;
 				CancellationTimeout = cs.CancellationTimeout;
+				UserID = cs.UserID;
 
 				// set activity tags
 				{

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -759,6 +759,10 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 			};
 			if (m_session?.IPAddress is { } ipAddress)
 				csb.Server = ipAddress.ToString();
+			if (m_session?.Port is { } port)
+				csb.Port = (uint) port;
+			if (m_session?.UserID is { Length: > 0 } userId)
+				csb.UserID = userId;
 			var cancellationTimeout = GetConnectionSettings().CancellationTimeout;
 			csb.ConnectionTimeout = cancellationTimeout < 1 ? 3u : (uint) cancellationTimeout;
 


### PR DESCRIPTION
Fixes #1302.

When canceling a connection, current `Port` and `UserID` are passed to new connection, because host, port and user might be different when the server supports redirection (and using `ServerRedirectionMode`).