### PR TITLE
MariaDB version parsing evolution

### DIFF
--- a/src/MySqlConnector/Core/CachedProcedure.cs
+++ b/src/MySqlConnector/Core/CachedProcedure.cs
@@ -12,7 +12,9 @@ internal sealed class CachedProcedure
 	public static async Task<CachedProcedure?> FillAsync(IOBehavior ioBehavior, MySqlConnection connection, string schema, string component, ILogger logger, CancellationToken cancellationToken)
 	{
 		// try to use mysql.proc first, as it is much faster
-		if (connection.Session.ServerVersion.Version < ServerVersions.RemovesMySqlProcTable && !connection.Session.ProcAccessDenied)
+		if (!connection.Session.ServerVersion.MariaDb
+		    && connection.Session.ServerVersion.Version < ServerVersions.RemovesMySqlProcTable
+		    && !connection.Session.ProcAccessDenied)
 		{
 			try
 			{
@@ -127,7 +129,7 @@ internal sealed class CachedProcedure
 			if (!alignParam.HasSetDbType)
 				alignParam.MySqlDbType = cachedParam.MySqlDbType;
 
-			// cached parameters are oredered by ordinal position
+			// cached parameters are ordered by ordinal position
 			alignedParams.Add(alignParam);
 		}
 

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -610,7 +610,9 @@ internal sealed partial class ServerSession
 			ClearPreparedStatements();
 
 			PayloadData payload;
-			if (DatabaseOverride is null && (ServerVersion.Version.CompareTo(ServerVersions.SupportsResetConnection) >= 0 || ServerVersion.MariaDbVersion?.CompareTo(ServerVersions.MariaDbSupportsResetConnection) >= 0))
+			if (DatabaseOverride is null
+			    && ((!ServerVersion.MariaDb && ServerVersion.Version.CompareTo(ServerVersions.SupportsResetConnection) >= 0)
+			    || (ServerVersion.MariaDb && ServerVersion.Version.CompareTo(ServerVersions.MariaDbSupportsResetConnection) >= 0)))
 			{
 				if (m_supportsPipelining)
 				{

--- a/tests/MySqlConnector.Tests/ServerVersionTests.cs
+++ b/tests/MySqlConnector.Tests/ServerVersionTests.cs
@@ -8,41 +8,32 @@ namespace MySqlConnector.Tests;
 public class ServerVersionTests
 {
 	[Theory]
-	[InlineData("5.5.5-10.1.38-MariaDB-1~bionic", "5.5.5", "10.1.38")]
-	[InlineData("5.5.5-10-MariaDB", "5.5.5", null)]
-	[InlineData("5.5.5-10.2-MariaDB", "5.5.5", null)]
-	[InlineData("5.5.5-10.2.13-MariaDB", "5.5.5", "10.2.13")]
-	[InlineData("5.5.5-10.2.19-MariaDB-1:10.2.19+maria~bionic", "5.5.5", "10.2.19")]
-	[InlineData("5.5.5-10.3.13-MariaDB-1:10.3.13+maria~bionic", "5.5.5", "10.3.13")]
-	[InlineData("5.7.21-log", "5.7.21", null)]
-	[InlineData("8.0.13", "8.0.13", null)]
-	[InlineData("5.7.25-28", "5.7.25", null)]
-	[InlineData("5.7.25-", "5.7.25", null)]
-	[InlineData("5.7.25-10.2.3", "5.7.25", null)]
-	[InlineData("5.7.25-MariaDB-10.2.3", "5.7.25", null)]
-	[InlineData("5.7.25-10.2.3-10.3.19-MariaDB-1", "5.7.25", null)]
-	[InlineData("a.b.c", "0.0.0", null)]
-	[InlineData("1", "1.0.0", null)]
-	[InlineData("1.", "1.0.0", null)]
-	[InlineData("1.2", "1.2.0", null)]
-	[InlineData("1.2.", "1.2.0", null)]
-	[InlineData("1.2.3", "1.2.3", null)]
-	[InlineData("1.2.3.", "1.2.3", null)]
-	[InlineData("1.2.3-", "1.2.3", null)]
-	public void ParseServerVersion(string input, string expectedString, string expectedMariaDbString)
+	[InlineData("5.5.5-10.1.38-MariaDB-1~bionic", "10.1.38", true)]
+	[InlineData("5.5.5-10.2.13-MariaDB", "10.2.13", true)]
+	[InlineData("5.5.5-10.2.19-MariaDB-1:10.2.19+maria~bionic", "10.2.19", true)]
+	[InlineData("5.5.5-10.3.13-MariaDB-1:10.3.13+maria~bionic", "10.3.13", true)]
+	[InlineData("11.0.1-MariaDB-1:11.0.1+maria~bionic", "11.0.1", true)]
+	[InlineData("10.3.13-MariaDB-1:10.3.13+maria~bionic", "10.3.13", true)]
+	[InlineData("5.7.21-log", "5.7.21", false)]
+	[InlineData("8.0.13", "8.0.13", false)]
+	[InlineData("5.7.25-28", "5.7.25", false)]
+	[InlineData("5.7.25-", "5.7.25", false)]
+	[InlineData("5.7.25-10.2.3", "5.7.25", false)]
+	[InlineData("5.7.25-MariaDB-10.2.3", "5.7.25", true)]
+	[InlineData("5.7.25-10.2.3-10.3.19-MariaDB-1", "5.7.25", true)]
+	[InlineData("a.b.c", "0.0.0", false)]
+	[InlineData("1", "1.0.0", false)]
+	[InlineData("1.", "1.0.0", false)]
+	[InlineData("1.2", "1.2.0", false)]
+	[InlineData("1.2.", "1.2.0", false)]
+	[InlineData("1.2.3", "1.2.3", false)]
+	[InlineData("1.2.3.", "1.2.3", false)]
+	[InlineData("1.2.3-", "1.2.3", false)]
+	public void ParseServerVersion(string input, string expectedString, bool expectedMariaDb)
 	{
 		var serverVersion = new ServerVersion(Encoding.UTF8.GetBytes(input));
 		var expected = Version.Parse(expectedString);
 		Assert.Equal(expected, serverVersion.Version);
-
-		if (expectedMariaDbString is null)
-		{
-			Assert.Equal(default(Version), serverVersion.MariaDbVersion);
-		}
-		else
-		{
-			var expectedMariaDb = Version.Parse(expectedMariaDbString);
-			Assert.Equal(expectedMariaDb, serverVersion.MariaDbVersion);
-		}
+		Assert.Equal(expectedMariaDb, serverVersion.MariaDb);
 	}
 }


### PR DESCRIPTION
fix #1259

Since MariaDB server 11.0.1 (MDEV-28910) doesn't have "5.5.5-" prefix anymore. This PR propose to evolve server identification  based on 2 principles:
* version is stripped of "5.5.5-" prefix and identified as MariaDB (The only server that use 'x.y.z-' prefix is percona, but first percona 5.5 server was 5.5.7). MySQL use "x.y.z", alibaba and aurora use x.y.z.a notation)
* server version string contains "MariaDB"

(All mariadb connectors use that exact same behavior for mariadb identification)