### PR TITLE
support per query variables for CommandBehavior

### DIFF
--- a/src/MySqlConnector/Core/ConcatenatedCommandPayloadCreator.cs
+++ b/src/MySqlConnector/Core/ConcatenatedCommandPayloadCreator.cs
@@ -32,10 +32,12 @@ internal sealed class ConcatenatedCommandPayloadCreator : ICommandPayloadCreator
 			var command = commandListPosition.Commands[commandListPosition.CommandIndex];
 			Log.PreparingCommandPayload(command.Logger, command.Connection!.Session.Id, command.CommandText!);
 
-			isComplete = SingleCommandPayloadCreator.WriteQueryPayload(command, cachedProcedures, writer, commandListPosition.CommandIndex < commandListPosition.Commands.Count - 1 || appendSemicolon);
+			isComplete = SingleCommandPayloadCreator.WriteQueryPayload(command, cachedProcedures, writer,
+				commandListPosition.CommandIndex < commandListPosition.Commands.Count - 1 || appendSemicolon,
+				commandListPosition.CommandIndex == 0,
+				commandListPosition.CommandIndex == commandListPosition.Commands.Count - 1);
 			commandListPosition.CommandIndex++;
-		}
-		while (commandListPosition.CommandIndex < commandListPosition.Commands.Count && isComplete);
+		} while (commandListPosition.CommandIndex < commandListPosition.Commands.Count && isComplete);
 
 		return true;
 	}

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -48,6 +48,7 @@ internal sealed partial class ServerSession
 
 	public string Id { get; }
 	public ServerVersion ServerVersion { get; set; }
+	public bool SupportsPerQueryVariables => ServerVersion.IsMariaDb && ServerVersion.Version >= ServerVersions.MariaDbSupportsPerQueryVariables;
 	public int ActiveCommandId { get; private set; }
 	public int CancellationTimeout { get; private set; }
 	public int ConnectionId { get; set; }

--- a/src/MySqlConnector/Core/ServerVersions.cs
+++ b/src/MySqlConnector/Core/ServerVersions.cs
@@ -16,4 +16,7 @@ internal static class ServerVersions
 
 	// https://ocelot.ca/blog/blog/2017/08/22/no-more-mysql-proc-in-mysql-8-0/
 	public static readonly Version RemovesMySqlProcTable = new(8, 0, 0);
+
+	// https://mariadb.com/kb/en/set-statement/
+	public static readonly Version MariaDbSupportsPerQueryVariables = new(10, 1, 2);
 }

--- a/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
+++ b/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
@@ -246,23 +246,52 @@ internal sealed class SingleCommandPayloadCreator : ICommandPayloadCreator
 	{
 		var isSchemaOnly = (command.CommandBehavior & CommandBehavior.SchemaOnly) != 0;
 		var isSingleRow = (command.CommandBehavior & CommandBehavior.SingleRow) != 0;
-		if (isSchemaOnly)
+		if (isSchemaOnly || isSingleRow)
 		{
-			ReadOnlySpan<byte> setSqlSelectLimit0 = "SET sql_select_limit=0;\n"u8;
-			writer.Write(setSqlSelectLimit0);
+			if (!command.Connection!.SupportsPerQueryVariables)
+			{
+				// server doesn't support per query variables, so using multi-statements
+				if (isSchemaOnly)
+				{
+					ReadOnlySpan<byte> setSqlSelectLimit0 = "SET sql_select_limit=0;\n"u8;
+					writer.Write(setSqlSelectLimit0);
+				}
+				else if (isSingleRow)
+				{
+					ReadOnlySpan<byte> setSqlSelectLimit1 = "SET sql_select_limit=1;\n"u8;
+					writer.Write(setSqlSelectLimit1);
+				}
+				var preparer = new StatementPreparer(command.CommandText!, command.RawParameters, command.CreateStatementPreparerOptions() | ((appendSemicolon || isSchemaOnly || isSingleRow) ? StatementPreparerOptions.AppendSemicolon : StatementPreparerOptions.None));
+				var isComplete = preparer.ParseAndBindParameters(writer);
+				if (isComplete && (isSchemaOnly || isSingleRow))
+				{
+					ReadOnlySpan<byte> clearSqlSelectLimit = "\nSET sql_select_limit=default;"u8;
+					writer.Write(clearSqlSelectLimit);
+				}
+				return isComplete;
+			}
+			else
+			{
+				// server support per query variables, so using SET STATEMENT ... FOR command
+				writer.Write("SET STATEMENT "u8);
+				if (isSchemaOnly)
+				{
+					ReadOnlySpan<byte> setSqlSelectLimit0 = "sql_select_limit=0"u8;
+					writer.Write(setSqlSelectLimit0);
+				} else if (isSingleRow)
+				{
+					writer.Write("sql_select_limit=1"u8);
+				}
+
+				writer.Write(" FOR "u8);
+				var preparer = new StatementPreparer(command.CommandText!, command.RawParameters, command.CreateStatementPreparerOptions() | ((appendSemicolon || isSchemaOnly || isSingleRow) ? StatementPreparerOptions.AppendSemicolon : StatementPreparerOptions.None));
+				var isComplete = preparer.ParseAndBindParameters(writer);
+				return isComplete;
+			}
 		}
-		else if (isSingleRow)
-		{
-			ReadOnlySpan<byte> setSqlSelectLimit1 = "SET sql_select_limit=1;\n"u8;
-			writer.Write(setSqlSelectLimit1);
-		}
-		var preparer = new StatementPreparer(command.CommandText!, command.RawParameters, command.CreateStatementPreparerOptions() | ((appendSemicolon || isSchemaOnly || isSingleRow) ? StatementPreparerOptions.AppendSemicolon : StatementPreparerOptions.None));
-		var isComplete = preparer.ParseAndBindParameters(writer);
-		if (isComplete && (isSchemaOnly || isSingleRow))
-		{
-			ReadOnlySpan<byte> clearSqlSelectLimit = "\nSET sql_select_limit=default;"u8;
-			writer.Write(clearSqlSelectLimit);
-		}
-		return isComplete;
+
+		var preparer1 = new StatementPreparer(command.CommandText!, command.RawParameters, command.CreateStatementPreparerOptions() | ((appendSemicolon || isSchemaOnly || isSingleRow) ? StatementPreparerOptions.AppendSemicolon : StatementPreparerOptions.None));
+		var isComplete1 = preparer1.ParseAndBindParameters(writer);
+		return isComplete1;
 	}
 }

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -862,6 +862,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 
 	internal int? ActiveCommandId => m_session?.ActiveCommandId;
 
+	internal bool SupportsPerQueryVariables => m_session is not null && m_session.SupportsPerQueryVariables;
 	internal bool HasActiveReader => m_activeReader is not null;
 
 	internal void SetActiveReader(MySqlDataReader dataReader)

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -862,7 +862,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 
 	internal int? ActiveCommandId => m_session?.ActiveCommandId;
 
-	internal bool SupportsPerQueryVariables => m_session is not null && m_session.SupportsPerQueryVariables;
+	internal bool SupportsPerQueryVariables => m_session?.SupportsPerQueryVariables ?? false;
 	internal bool HasActiveReader => m_activeReader is not null;
 
 	internal void SetActiveReader(MySqlDataReader dataReader)


### PR DESCRIPTION
(Reuse part of https://github.com/mysql-net/MySqlConnector/pull/1304)

MariaDB and percona server permits per query variables (see https://mariadb.com/kb/en/set-statement/ and https://www.percona.com/blog/using-per-query-variable-statements-in-percona-server/)

This corresponds to commands like

```
SET STATEMENT <variable=value> FOR <statement>
```

PR is to propose using per query variable when using CommandBehavior.SchemaOnly/ CommandBehavior.SingleRow in place of multiple statements, which helps improve performance.

Benchmark results a MariaDB server:

```

    [Benchmark]
    public async Task<bool> ReadSingleRow()
    {
	    using (var cmd = Connection.CreateCommand())
	    {
		    cmd.CommandText = "SELECT * FROM seq_10_to_20";
		    using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow))
		    {
			    await reader.ReadAsync();
			    reader.GetInt32(0);
			    return await reader.ReadAsync();
		    }
	    }
    }

    [Benchmark]
    public async Task<System.Data.DataColumnCollection> ReadSchemaOnly()
    {
	    using (var cmd = Connection.CreateCommand())
	    {
		    cmd.CommandText = "SELECT * FROM seq_10_to_20";
		    using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly))
		    {
			    await reader.ReadAsync();
			    return reader.GetSchemaTable().Columns;
		    }
	    }
    }
```

results :
```
|         Method |        Library |     Mean |    Error |
|--------------- |--------------- |---------:|---------:|
|  ReadSingleRow | MySqlConnector | 81.15 us | 0.486 us |
| ReadSchemaOnly | MySqlConnector | 83.48 us | 0.698 us |
```
After PR:
```
|         Method |        Library |     Mean |    Error |
|--------------- |--------------- |---------:|---------:|
|  ReadSingleRow | MySqlConnector | 67.92 us | 0.569 us |
| ReadSchemaOnly | MySqlConnector | 74.44 us | 1.019 us |
```