### PR TITLE
Permit real prepared stored procedure

### DIFF
--- a/src/MySqlConnector/Core/IMySqlCommand.cs
+++ b/src/MySqlConnector/Core/IMySqlCommand.cs
@@ -13,6 +13,8 @@ internal interface IMySqlCommand
 	CommandBehavior CommandBehavior { get; }
 	MySqlParameterCollection? RawParameters { get; }
 	MySqlAttributeCollection? RawAttributes { get; }
+	CachedProcedure? CachedProc { get; set; }
+	PreparedStatements? PreparedStmts { get; set; }
 	PreparedStatements? TryGetPreparedStatements();
 	MySqlConnection? Connection { get; }
 	long LastInsertedId { get; }

--- a/src/MySqlConnector/MySqlBatchCommand.cs
+++ b/src/MySqlConnector/MySqlBatchCommand.cs
@@ -60,6 +60,21 @@ public sealed class MySqlBatchCommand :
 
 	MySqlAttributeCollection? IMySqlCommand.RawAttributes => null;
 
+	CachedProcedure? IMySqlCommand.CachedProc
+	{
+		get => null;
+		set
+		{
+		}
+	}
+	PreparedStatements? IMySqlCommand.PreparedStmts
+	{
+		get => null;
+		set
+		{
+		}
+	}
+
 	MySqlConnection? IMySqlCommand.Connection => Batch?.Connection;
 
 	long IMySqlCommand.LastInsertedId => m_lastInsertedId;

--- a/src/MySqlConnector/MySqlParameter.cs
+++ b/src/MySqlConnector/MySqlParameter.cs
@@ -12,6 +12,8 @@ namespace MySqlConnector;
 
 public sealed class MySqlParameter : DbParameter, IDbDataParameter, ICloneable
 {
+	public static readonly MySqlParameter NullParameter = new MySqlParameter("", null);
+
 	public MySqlParameter()
 		: this(default(string?), default(object?))
 	{

--- a/src/MySqlConnector/Utilities/StoredProcedureUtil.cs
+++ b/src/MySqlConnector/Utilities/StoredProcedureUtil.cs
@@ -1,0 +1,50 @@
+using System.Text;
+
+namespace MySqlConnector.Utilities;
+
+internal static class StoredProcedureUtils
+{
+	public static string Format(string commandText, int parameterCount)
+	{
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+			return string.Create(commandText.Length + 7 + parameterCount * 2 + (parameterCount == 0 ? 1 : 0), (commandText, parameterCount), static (buffer, state) =>
+			{
+				buffer[0] = 'C';
+				buffer[1] = 'A';
+				buffer[2] = 'L';
+				buffer[3] = 'L';
+				buffer[4] = ' ';
+				buffer = buffer[5..];
+				state.commandText.AsSpan().CopyTo(buffer);
+				buffer = buffer[state.commandText.Length..];
+				buffer[0] = '(';
+				buffer = buffer[1..];
+				if (state.parameterCount > 0)
+				{
+					buffer[0] = '?';
+					buffer = buffer[1..];
+					for (var i = 1; i < state.parameterCount; i++)
+					{
+						buffer[0] = ',';
+						buffer[1] = '?';
+						buffer = buffer[2..];
+					}
+				}
+				buffer[0] = ')';
+				buffer[1] = ';';
+			});
+#else
+		var callStatement = new StringBuilder("CALL ", commandText.Length + 8 + parameterCount * 2);
+		callStatement.Append(commandText);
+		callStatement.Append('(');
+		for (int i = 0; i < parameterCount; i++)
+			callStatement.Append("?,");
+		if (parameterCount == 0)
+			callStatement.Append(')');
+		else
+			callStatement[callStatement.Length - 1] = ')';
+		callStatement.Append(';');
+		return callStatement.ToString();
+#endif
+	}
+}


### PR DESCRIPTION
When using BINARY protocol, output parameters are sent using an additional result-set that is marked with intermediate EOF and ending EOF/OK Packet with flag [SERVER_PS_OUT_PARAMS](https://mariadb.com/kb/en/ok_packet/#server-status-flag) set (Capability PS_MULTI_RESULTS has been added to permit that).

This is an old functionality, working for any type of server > 5.0.

I think that using binary implementation must even be the basis : stored procedure can always be prepared, and only BINARY protocol permit to get output parameter.

This permits better performance than using multi-resultset with "SET @inParam1=xx;...; SELECT @outParam1,@outParam2".

Since implementation use streaming result-set, DEPRECATE_EOF capability is disabled, in order to identify "output parameter resultset" in intermediate EOF. It could be improved checking if next packet is a row packet and then fetching next packet to check if this is an EOF/OK_Packet with SERVER_PS_OUT_PARAMS flag set, but i didn't know how to make that properly.

 bench base on StoredProcedureCircle test, like
 ```
 using (var cmd = Connection.CreateCommand())
 		{
 			cmd.CommandText = "circle";
 			cmd.CommandType = CommandType.StoredProcedure;
 			cmd.Parameters.Add(new MySqlParameter()
 			{
 				ParameterName = "@radius",
 				DbType = DbType.Double,
 				Direction = ParameterDirection.Input,
 				Value = 1.0,
 			});
 			...
 			cmd.Parameters.Add(new MySqlParameter()
 			{
 				ParameterName = "@shape",
 				DbType = DbType.String,
 				Direction = ParameterDirection.Output,
 			});
 			using (var reader = await cmd.ExecuteReaderAsync())
 			{
 				if (await reader.ReadAsync())
 					reader.GetValue(0);
 			}

 		}
 ```
 show improved result:
 with 2.3.0-beta.2:
 ```
  |                 Method |        Library |     Mean |   Error |
 |----------------------- |--------------- |---------:|--------:|
 |     storeProcedureText | MySqlConnector | 120.9 us | 2.41 us |
 ```

 with PR:
 ```
 |                 Method |        Library |      Mean |    Error |
 |----------------------- |--------------- |----------:|---------:|
 |     storeProcedureText | MySqlConnector | 118.79 us | 2.311 us |
 | storeProcedurePrepared | MySqlConnector |  93.31 us | 1.021 us |
```