### PR TITLE
Activities - update handling status

### DIFF
--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -447,8 +447,6 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 
 			if (m_connectionSettings.AutoEnlist && System.Transactions.Transaction.Current is not null)
 				EnlistTransaction(System.Transactions.Transaction.Current);
-
-			activity?.SetSuccess();
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{

--- a/src/MySqlConnector/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlDataReader.cs
@@ -468,7 +468,6 @@ public sealed class MySqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 			throw new InvalidOperationException("Expected ColumnDefinitions to be null");
 		m_closed = false;
 		m_hasWarnings = false;
-		m_initializationFailed = false;
 		RealRecordsAffected = null;
 
 		// initialize for new command
@@ -503,7 +502,6 @@ public sealed class MySqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 				activity.SetException(ex);
 				activity.Stop();
 			}
-			m_initializationFailed = true;
 			Dispose();
 			throw;
 		}
@@ -638,8 +636,6 @@ public sealed class MySqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 			Command.CancellableCommand.SetTimeout(Constants.InfiniteTimeout);
 			connection.FinishQuerying(m_hasWarnings);
 
-			if (!m_initializationFailed)
-				Activity?.SetSuccess();
 			Activity?.Stop();
 			Activity = null;
 
@@ -709,6 +705,5 @@ public sealed class MySqlDataReader : DbDataReader, IDbColumnSchemaGenerator
 	private bool m_closed;
 	private bool m_hasWarnings;
 	private bool m_hasMoreResults;
-	private bool m_initializationFailed;
 	private DataTable? m_schemaTable;
 }

--- a/src/MySqlConnector/MySqlTransaction.cs
+++ b/src/MySqlConnector/MySqlTransaction.cs
@@ -36,7 +36,6 @@ public sealed class MySqlTransaction : DbTransaction
 				await cmd.ExecuteNonQueryAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 			Connection!.CurrentTransaction = null;
 			Connection = null;
-			activity?.SetSuccess();
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{
@@ -260,7 +259,6 @@ public sealed class MySqlTransaction : DbTransaction
 		{
 			using var cmd = new MySqlCommand("rollback", Connection, this) { NoActivity = true };
 			await cmd.ExecuteNonQueryAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
-			activity?.SetSuccess();
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{

--- a/src/MySqlConnector/Utilities/ActivitySourceHelper.cs
+++ b/src/MySqlConnector/Utilities/ActivitySourceHelper.cs
@@ -16,7 +16,6 @@ internal static class ActivitySourceHelper
 	public const string NetPeerNameTagName = "net.peer.name";
 	public const string NetPeerPortTagName = "net.peer.port";
 	public const string NetTransportTagName = "net.transport";
-	public const string StatusCodeTagName = "otel.status_code";
 	public const string ThreadIdTagName = "thread.id";
 
 	public const string DatabaseSystemValue = "mysql";
@@ -35,18 +34,10 @@ internal static class ActivitySourceHelper
 		return activity;
 	}
 
-	public static void SetSuccess(this Activity activity)
-	{
-		activity.SetStatus(ActivityStatusCode.Ok);
-		activity.SetTag(StatusCodeTagName, "OK");
-	}
-
 	public static void SetException(this Activity activity, Exception exception)
 	{
 		var description = exception is MySqlException mySqlException ? mySqlException.ErrorCode.ToString() : exception.Message;
 		activity.SetStatus(ActivityStatusCode.Error, description);
-		activity.SetTag(StatusCodeTagName, "ERROR");
-		activity.SetTag("otel.status_description", description);
 		activity.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
 		{
 			{ "exception.type", exception.GetType().FullName },

--- a/tests/IntegrationTests/ActivityTests.cs
+++ b/tests/IntegrationTests/ActivityTests.cs
@@ -38,12 +38,9 @@ public class ActivityTests : IClassFixture<DatabaseFixture>
 		Assert.NotNull(activity);
 		Assert.Equal(ActivityKind.Client, activity.Kind);
 		Assert.Equal("Open", activity.OperationName);
-#if NET6_0_OR_GREATER
-		Assert.Equal(ActivityStatusCode.Ok, activity.Status);
-#endif
+		Assert.Equal(ActivityStatusCode.Unset, activity.Status);
 
 		AssertTags(activity.Tags, csb);
-		AssertTag(activity.Tags, "otel.status_code", "OK");
 	}
 
 	[Fact]
@@ -74,7 +71,6 @@ public class ActivityTests : IClassFixture<DatabaseFixture>
 				connection.Open();
 
 			Assert.NotNull(activities[i]);
-			AssertTag(activities[i].Tags, "otel.status_code", "OK");
 		}
 
 		// activities should have the same connection ID
@@ -104,12 +100,9 @@ public class ActivityTests : IClassFixture<DatabaseFixture>
 		Assert.NotNull(activity);
 		Assert.Equal(ActivityKind.Client, activity.Kind);
 		Assert.Equal("Open", activity.OperationName);
-#if NET6_0_OR_GREATER
 		Assert.Equal(ActivityStatusCode.Error, activity.Status);
-#endif
 
 		AssertTags(activity.Tags, csb);
-		AssertTag(activity.Tags, "otel.status_code", "ERROR");
 	}
 
 	[Fact]
@@ -140,14 +133,11 @@ public class ActivityTests : IClassFixture<DatabaseFixture>
 		Assert.NotNull(activity);
 		Assert.Equal(ActivityKind.Client, activity.Kind);
 		Assert.Equal("Execute", activity.OperationName);
-#if NET6_0_OR_GREATER
-		Assert.Equal(ActivityStatusCode.Ok, activity.Status);
-#endif
+		Assert.Equal(ActivityStatusCode.Unset, activity.Status);
 
 		AssertTags(activity.Tags, csb);
 		AssertTag(activity.Tags, "db.connection_id", connection.ServerThread.ToString(CultureInfo.InvariantCulture));
 		AssertTag(activity.Tags, "db.statement", "SELECT 1;");
-		AssertTag(activity.Tags, "otel.status_code", "OK");
 	}
 
 	private void AssertTags(IEnumerable<KeyValuePair<string, string>> tags, MySqlConnectionStringBuilder csb)


### PR DESCRIPTION
This PR changes the way how to handle ActivityStatus

1. Manually setting `otel.status_code` and `otel.status_description` is no longer needed. System.Diagnostics.DiagnosticSource v6+ handles it natively. Ref: https://github.com/open-telemetry/opentelemetry-dotnet/issues/2569
2. Avoid setting spanstasus.ok. The unset value is preferred one https://opentelemetry.io/docs/concepts/signals/traces/#span-status
3. Removed unused fields/constants.
4. Conditional compilation simplified - it should work on any .NET version. As long as it is referencing System.Diagnostics.DiagnosticSource v6+