### PR TITLE
Small test improvement

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,15 +196,15 @@ jobs:
       'MariaDB 10.6':
         image: 'mariadb:10.6'
         connectionStringExtra: ''
-        unsupportedFeatures: 'CachingSha2Password,CancelSleepSuccessfully,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
+        unsupportedFeatures: 'CachingSha2Password,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
       'MariaDB 10.10':
         image: 'mariadb:10.10'
         connectionStringExtra: ''
-        unsupportedFeatures: 'CachingSha2Password,CancelSleepSuccessfully,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
+        unsupportedFeatures: 'CachingSha2Password,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
       'MariaDB 10.11':
         image: 'mariadb:10.11'
         connectionStringExtra: ''
-        unsupportedFeatures: 'CachingSha2Password,CancelSleepSuccessfully,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
+        unsupportedFeatures: 'CachingSha2Password,Json,RoundDateTime,QueryAttributes,Sha256Password,Tls11,UuidToBin'
   steps:
   - template: '.ci/integration-tests-steps.yml'
     parameters:

--- a/tests/IntegrationTests/CancelTests.cs
+++ b/tests/IntegrationTests/CancelTests.cs
@@ -32,7 +32,15 @@ public class CancelTests : IClassFixture<CancelFixture>, IDisposable
 		});
 
 		var stopwatch = Stopwatch.StartNew();
-		TestUtilities.AssertIsOne(cmd.ExecuteScalar());
+		if (m_database.Connection.Session.ServerVersion.IsMariaDb)
+		{
+			MySqlException ex = Assert.Throws<MySqlException>(() => cmd.ExecuteScalar());
+			Assert.Contains("Query execution was interrupted", ex.Message, StringComparison.OrdinalIgnoreCase);
+		}
+		else
+		{
+			TestUtilities.AssertIsOne(cmd.ExecuteScalar());
+		}
 		Assert.InRange(stopwatch.ElapsedMilliseconds, 250, 2500);
 
 		task.Wait(); // shouldn't throw
@@ -58,7 +66,15 @@ public class CancelTests : IClassFixture<CancelFixture>, IDisposable
 		});
 
 		var stopwatch = Stopwatch.StartNew();
-		TestUtilities.AssertIsOne(await command.ExecuteScalarAsync());
+		if (connection.Session.ServerVersion.IsMariaDb)
+		{
+			MySqlException ex = await Assert.ThrowsAsync<MySqlException>(() => command.ExecuteScalarAsync());
+			Assert.Contains("Query execution was interrupted", ex.Message, StringComparison.OrdinalIgnoreCase);
+		}
+		else
+		{
+			TestUtilities.AssertIsOne(await command.ExecuteScalarAsync());
+		}
 		Assert.InRange(stopwatch.ElapsedMilliseconds, 250, 2500);
 
 		task.Wait(); // shouldn't throw
@@ -78,7 +94,15 @@ public class CancelTests : IClassFixture<CancelFixture>, IDisposable
 		using var command = new MySqlCommand("SELECT SLEEP(5)", connection);
 		using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
 		var stopwatch = Stopwatch.StartNew();
-		TestUtilities.AssertIsOne(await command.ExecuteScalarAsync(cts.Token));
+		if (connection.Session.ServerVersion.IsMariaDb)
+		{
+			OperationCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(() => command.ExecuteScalarAsync(cts.Token));
+			Assert.Contains("Query execution was interrupted", ex.Message, StringComparison.OrdinalIgnoreCase);
+		}
+		else
+		{
+			TestUtilities.AssertIsOne(await command.ExecuteScalarAsync(cts.Token));
+		}
 		Assert.InRange(stopwatch.ElapsedMilliseconds, 250, 2500);
 	}
 #endif
@@ -442,7 +466,15 @@ create table cancel_completed_command(id integer not null primary key, value tex
 		});
 
 		var stopwatch = Stopwatch.StartNew();
-		TestUtilities.AssertIsOne(batch.ExecuteScalar());
+		if (m_database.Connection.Session.ServerVersion.IsMariaDb)
+		{
+			MySqlException ex = Assert.Throws<MySqlException>(() => batch.ExecuteScalar());
+			Assert.Contains("Query execution was interrupted", ex.Message, StringComparison.OrdinalIgnoreCase);
+		}
+		else
+		{
+			TestUtilities.AssertIsOne(batch.ExecuteScalar());
+		}
 		Assert.InRange(stopwatch.ElapsedMilliseconds, 250, 2500);
 
 		task.Wait(); // shouldn't throw

--- a/tests/IntegrationTests/CommandTimeoutTests.cs
+++ b/tests/IntegrationTests/CommandTimeoutTests.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace IntegrationTests;
 
 public class CommandTimeoutTests : IClassFixture<DatabaseFixture>, IDisposable
@@ -61,8 +63,17 @@ public class CommandTimeoutTests : IClassFixture<DatabaseFixture>, IDisposable
 #else
 			using (var reader = cmd.ExecuteReader())
 			{
-				Assert.True(reader.Read());
-				Assert.Equal(1, reader.GetInt32(0));
+				if (m_connection.Session.ServerVersion.IsMariaDb)
+				{
+					MySqlException ex = Assert.Throws<MySqlException>(() => reader.Read());
+					Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+					Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+				}
+				else
+				{
+					Assert.True(reader.Read());
+					Assert.Equal(1, reader.GetInt32(0));
+				}
 			}
 #endif
 			sw.Stop();
@@ -87,8 +98,17 @@ public class CommandTimeoutTests : IClassFixture<DatabaseFixture>, IDisposable
 #else
 			using (var reader = await cmd.ExecuteReaderAsync())
 			{
-				Assert.True(await reader.ReadAsync());
-				Assert.Equal(1, reader.GetInt32(0));
+				if (m_connection.Session.ServerVersion.IsMariaDb)
+				{
+					MySqlException ex = await Assert.ThrowsAsync<MySqlException>(() => reader.ReadAsync());
+					Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+					Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+				}
+				else
+				{
+					Assert.True(await reader.ReadAsync());
+					Assert.Equal(1, reader.GetInt32(0));
+				}
 			}
 #endif
 			sw.Stop();
@@ -128,8 +148,17 @@ end;", m_connection))
 #else
 		using (var reader = cmd.ExecuteReader())
 		{
-			Assert.True(reader.Read());
-			Assert.Equal(1, reader.GetInt32(0));
+			if (m_connection.Session.ServerVersion.IsMariaDb)
+			{
+				MySqlException ex = Assert.Throws<MySqlException>(() => reader.Read());
+				Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+				Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+			}
+			else
+			{
+				Assert.True(reader.Read());
+				Assert.Equal(1, reader.GetInt32(0));
+			}
 		}
 #endif
 		sw.Stop();
@@ -159,8 +188,17 @@ end;", m_connection))
 			connectionState = ConnectionState.Closed;
 #else
 			Assert.True(reader.NextResult());
-			Assert.True(reader.Read());
-			Assert.Equal(1, reader.GetInt32(0));
+			if (m_connection.Session.ServerVersion.IsMariaDb)
+			{
+				MySqlException ex = Assert.Throws<MySqlException>(() => reader.Read());
+				Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+				Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+			}
+			else
+			{
+				Assert.True(reader.Read());
+				Assert.Equal(1, reader.GetInt32(0));
+			}
 #endif
 
 			sw.Stop();
@@ -192,8 +230,17 @@ end;", m_connection))
 			connectionState = ConnectionState.Closed;
 #else
 			Assert.True(await reader.NextResultAsync());
-			Assert.True(reader.Read());
-			Assert.Equal(1, reader.GetInt32(0));
+			if (m_connection.Session.ServerVersion.IsMariaDb)
+			{
+				MySqlException ex = Assert.Throws<MySqlException>(() => reader.Read());
+				Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+				Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+			}
+			else
+			{
+				Assert.True(reader.Read());
+				Assert.Equal(1, reader.GetInt32(0));
+			}
 #endif
 
 			sw.Stop();
@@ -262,8 +309,17 @@ end;", m_connection))
 #else
 			using (var reader = cmd.ExecuteReader())
 			{
-				Assert.True(reader.Read());
-				Assert.Equal(1, reader.GetInt32(0));
+				if (m_connection.Session.ServerVersion.IsMariaDb)
+				{
+					MySqlException ex = Assert.Throws<MySqlException>(() => reader.Read());
+					Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+					Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+				}
+				else
+				{
+					Assert.True(reader.Read());
+					Assert.Equal(1, reader.GetInt32(0));
+				}
 			}
 #endif
 			sw.Stop();
@@ -289,8 +345,17 @@ end;", m_connection))
 #else
 			using (var reader = await cmd.ExecuteReaderAsync())
 			{
-				Assert.True(await reader.ReadAsync());
-				Assert.Equal(1, reader.GetInt32(0));
+				if (m_connection.Session.ServerVersion.IsMariaDb)
+				{
+					MySqlException ex = await Assert.ThrowsAsync<MySqlException>(() => reader.ReadAsync());
+					Assert.Contains("The Command Timeout expired before the operation completed", ex.Message, StringComparison.OrdinalIgnoreCase);
+					Assert.Contains("Query execution was interrupted", ex.InnerException.Message, StringComparison.OrdinalIgnoreCase);
+				}
+				else
+				{
+					Assert.True(await reader.ReadAsync());
+					Assert.Equal(1, reader.GetInt32(0));
+				}
 			}
 #endif
 			sw.Stop();

--- a/tests/IntegrationTests/ConnectAsync.cs
+++ b/tests/IntegrationTests/ConnectAsync.cs
@@ -194,7 +194,8 @@ public class ConnectAsync : IClassFixture<DatabaseFixture>
 		connection.ProvidePasswordCallback = _ => { wasCalled = true; return password; };
 
 		await connection.OpenAsync();
-		Assert.False(wasCalled);
+		if (password.Length != 0)
+			Assert.False(wasCalled);
 	}
 
 	[Fact]

--- a/tests/IntegrationTests/ConnectSync.cs
+++ b/tests/IntegrationTests/ConnectSync.cs
@@ -268,7 +268,8 @@ public class ConnectSync : IClassFixture<DatabaseFixture>
 		connection.ProvidePasswordCallback = _ => { wasCalled = true; return password; };
 
 		connection.Open();
-		Assert.False(wasCalled);
+		if (password.Length != 0)
+			Assert.False(wasCalled);
 	}
 
 	[Fact]


### PR DESCRIPTION
* MariaDB and MySQL server differ when executing KILL QUERY on SELECT SLEEP(x) command. MariaDB server send an ERR_Packet "Query execution was interrupted" while mysql send an OK_Packet. This PR permit to enable all tests using SLEEP(x).
* Correct ProvidePasswordCallback test when no password are used in testing environment