### PR TITLE
Reduce overhead of `CommandTimeout`

### DIFF
--- a/src/MySqlConnector/Core/ICancellableCommand.cs
+++ b/src/MySqlConnector/Core/ICancellableCommand.cs
@@ -11,7 +11,7 @@ internal interface ICancellableCommand
 	int CommandTimeout { get; }
 	int CancelAttemptCount { get; set; }
 	MySqlConnection? Connection { get; }
-	IDisposable? RegisterCancel(CancellationToken cancellationToken);
+	CancellationTokenRegistration RegisterCancel(CancellationToken cancellationToken);
 	void SetTimeout(int milliseconds);
 	bool IsTimedOut { get; }
 }

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -231,7 +231,6 @@ internal sealed class ResultSet
 		if (BufferState is ResultSetState.HasMoreData or ResultSetState.NoMoreData or ResultSetState.None)
 			return new ValueTask<Row?>(default(Row?));
 
-		using var registration = Command.CancellableCommand.RegisterCancel(cancellationToken);
 		var payloadValueTask = Session.ReceiveReplyAsync(ioBehavior, CancellationToken.None);
 		return payloadValueTask.IsCompletedSuccessfully
 			? new ValueTask<Row?>(ScanRowAsyncRemainder(this, payloadValueTask.Result, row))

--- a/src/MySqlConnector/MySqlBatch.cs
+++ b/src/MySqlConnector/MySqlBatch.cs
@@ -249,10 +249,10 @@ public sealed class MySqlBatch :
 	int ICancellableCommand.CommandTimeout => Timeout;
 	int ICancellableCommand.CancelAttemptCount { get; set; }
 
-	IDisposable? ICancellableCommand.RegisterCancel(CancellationToken cancellationToken)
+	CancellationTokenRegistration ICancellableCommand.RegisterCancel(CancellationToken cancellationToken)
 	{
 		if (!cancellationToken.CanBeCanceled)
-			return null;
+			return default;
 
 		m_cancelAction ??= Cancel;
 		return cancellationToken.Register(m_cancelAction);

--- a/src/MySqlConnector/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlCommand.cs
@@ -385,10 +385,10 @@ public sealed class MySqlCommand : DbCommand, IMySqlCommand, ICancellableCommand
 	/// <returns>An object that must be disposed to revoke the cancellation registration.</returns>
 	/// <remarks>This method is more efficient than calling <code>token.Register(Command.Cancel)</code> because it avoids
 	/// unnecessary allocations.</remarks>
-	IDisposable? ICancellableCommand.RegisterCancel(CancellationToken cancellationToken)
+	CancellationTokenRegistration ICancellableCommand.RegisterCancel(CancellationToken cancellationToken)
 	{
 		if (!cancellationToken.CanBeCanceled)
-			return null;
+			return default;
 
 		m_cancelAction ??= Cancel;
 		return cancellationToken.Register(m_cancelAction);

--- a/src/MySqlConnector/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlCommand.cs
@@ -70,6 +70,7 @@ public sealed class MySqlCommand : DbCommand, IMySqlCommand, ICancellableCommand
 	{
 		GC.SuppressFinalize(this);
 		m_commandTimeout = other.m_commandTimeout;
+		((ICancellableCommand) this).EffectiveCommandTimeout = null;
 		m_commandType = other.m_commandType;
 		DesignTimeVisible = other.DesignTimeVisible;
 		UpdatedRowSource = other.UpdatedRowSource;
@@ -226,7 +227,11 @@ public sealed class MySqlCommand : DbCommand, IMySqlCommand, ICancellableCommand
 	public override int CommandTimeout
 	{
 		get => Math.Min(m_commandTimeout ?? Connection?.DefaultCommandTimeout ?? 0, int.MaxValue / 1000);
-		set => m_commandTimeout = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "CommandTimeout must be greater than or equal to zero.");
+		set
+		{
+			m_commandTimeout = value >= 0 ? value : throw new ArgumentOutOfRangeException(nameof(value), "CommandTimeout must be greater than or equal to zero.");
+			((ICancellableCommand) this).EffectiveCommandTimeout = null;
+		}
 	}
 
 	/// <inheritdoc/>
@@ -409,6 +414,8 @@ public sealed class MySqlCommand : DbCommand, IMySqlCommand, ICancellableCommand
 	bool ICancellableCommand.IsTimedOut => Volatile.Read(ref m_commandTimedOut);
 
 	int ICancellableCommand.CommandId => m_commandId;
+
+	int? ICancellableCommand.EffectiveCommandTimeout { get; set; }
 
 	int ICancellableCommand.CancelAttemptCount { get; set; }
 


### PR DESCRIPTION
* Use concrete type to eliminate the overhead of boxing.
* Remove unnecessary call to `RegisterCancel` (suggested by #1337).
* Eliminate subsequent calls to `session.SetTimeout(Constants.InfiniteTimeout)` in the case where `CommandTimeout == 0` (which is intended to eliminate overhead).

Benchmarks (which I would take with a grain of salt, because some results seem unexpectedly slow):

|             Method |  Version | Timeout |       Mean |     Error |    StdDev |   StdErr |     Median |        Min |         Q1 |         Q3 |        Max |    Op/s |    Gen0 | Allocated |
|------------------- |--------- |-------- |-----------:|----------:|----------:|---------:|-----------:|-----------:|-----------:|-----------:|-----------:|--------:|--------:|----------:|
| ExecuteScalarAsync |      Old |       0 | 1,023.9 us |  29.29 us |  84.97 us |  8.63 us | 1,007.5 us |   910.5 us |   950.1 us | 1,091.2 us | 1,295.3 us |   976.6 |       - |    2929 B |
| ExecuteScalarAsync |      New |       0 |   997.9 us |  22.33 us |  62.98 us |  6.57 us |   979.7 us |   908.7 us |   949.5 us | 1,031.7 us | 1,187.9 us | 1,002.1 |       - |    2946 B |
|  ExecuteScalarSync |      Old |       0 |   902.3 us |  16.27 us |  28.50 us |  4.56 us |   903.3 us |   840.6 us |   879.2 us |   923.4 us |   957.5 us | 1,108.3 |       - |     866 B |
|  ExecuteScalarSync |      New |       0 |   887.2 us |  17.21 us |  39.54 us |  4.98 us |   875.6 us |   818.1 us |   856.7 us |   917.1 us |   990.4 us | 1,127.2 |       - |     873 B |
|      ManyRowsAsync |      Old |       0 | 3,114.3 us |  73.80 us | 206.95 us | 21.69 us | 3,066.5 us | 2,814.3 us | 2,960.4 us | 3,255.5 us | 3,792.6 us |   321.1 |       - |    3048 B |
|      ManyRowsAsync |      New |       0 | 2,979.6 us |  55.72 us |  99.05 us | 15.66 us | 2,970.5 us | 2,817.5 us | 2,909.3 us | 3,025.2 us | 3,228.7 us |   335.6 |       - |    3073 B |
|       ManyRowsSync |      Old |       0 | 2,956.6 us |  72.04 us | 206.69 us | 21.21 us | 2,926.8 us | 2,664.4 us | 2,799.6 us | 3,097.1 us | 3,518.9 us |   338.2 |       - |     844 B |
|       ManyRowsSync |      New |       0 | 2,691.1 us |  52.95 us |  94.12 us | 14.88 us | 2,693.5 us | 2,552.7 us | 2,613.9 us | 2,741.1 us | 2,909.8 us |   371.6 |       - |     852 B |
| ExecuteScalarAsync |      Old |      10 |   971.7 us |  19.16 us |  39.15 us |  5.48 us |   959.9 us |   898.3 us |   945.2 us |   998.0 us | 1,065.7 us | 1,029.1 |       - |    2993 B |
| ExecuteScalarAsync |      New |      10 |   978.4 us |  19.53 us |  17.31 us |  4.63 us |   973.4 us |   956.7 us |   967.0 us |   988.0 us | 1,019.0 us | 1,022.1 |       - |    3010 B |
|  ExecuteScalarSync |      Old |      10 | 1,259.6 us | 141.08 us | 393.29 us | 41.46 us | 1,121.2 us |   829.1 us |   928.7 us | 1,503.2 us | 2,586.2 us |   793.9 |       - |     929 B |
|  ExecuteScalarSync |      New |      10 |   908.2 us |  18.11 us |  20.13 us |  4.62 us |   905.7 us |   883.0 us |   892.4 us |   915.2 us |   945.5 us | 1,101.1 |       - |     938 B |
|      ManyRowsAsync |      Old |      10 | 3,559.3 us |  71.01 us | 182.02 us | 20.74 us | 3,535.9 us | 3,292.2 us | 3,423.0 us | 3,670.1 us | 4,021.7 us |   281.0 |       - |    3100 B |
|      ManyRowsAsync |      New |      10 | 3,370.6 us |  65.97 us |  98.74 us | 18.03 us | 3,382.4 us | 3,215.0 us | 3,282.4 us | 3,415.8 us | 3,580.5 us |   296.7 |       - |    3116 B |
|       ManyRowsSync |      Old |      10 | 3,235.0 us |  69.29 us | 196.57 us | 20.38 us | 3,180.8 us | 2,948.5 us | 3,087.0 us | 3,342.0 us | 3,765.9 us |   309.1 |       - |     908 B |
|       ManyRowsSync |      New |      10 | 3,144.8 us |  62.70 us | 175.82 us | 18.43 us | 3,080.0 us | 2,935.2 us | 3,017.9 us | 3,247.5 us | 3,610.3 us |   318.0 |       - |     916 B |


