### PR TITLE
Fixed issues found by PVS-Studio

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1770,7 +1770,7 @@ internal sealed partial class ServerSession
 	{
 		if (m_state != state1 && m_state != state2 && m_state != state3 && m_state != state4 && m_state != state5 && m_state != state6)
 		{
-			ExpectedSessionState6(m_logger, Id, state1, state2, state3, state4, state5, state5, m_state);
+			ExpectedSessionState6(m_logger, Id, state1, state2, state3, state4, state5, state6, m_state);
 			throw new InvalidOperationException($"Expected state to be ({state1}|{state2}|{state3}|{state4}|{state5}|{state6}) but was {m_state}.");
 		}
 	}

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1291,7 +1291,7 @@ internal sealed partial class ServerSession
 			try
 			{
 				var storeLocation = (cs.CertificateStoreLocation == MySqlCertificateStoreLocation.CurrentUser) ? StoreLocation.CurrentUser : StoreLocation.LocalMachine;
-				var store = new X509Store(StoreName.My, storeLocation);
+				using var store = new X509Store(StoreName.My, storeLocation);
 				store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
 
 				if (cs.CertificateThumbprint.Length == 0)


### PR DESCRIPTION
I have performed a quick check with [PVS-Studio](https://pvs-studio.com/pvs-studio/?utm_source=website&utm_medium=github&utm_campaign=open_source) - static analyzer for C, C++, C#, and Java code.

Found two issues, listed below. Other issues were either not critical, false positive or already known (e.g. disabled with #pragma).

>[V3038](https://pvs-studio.com/en/docs/warnings/v3038/) The argument was passed to method several times. It is possible that other argument should be passed instead.

This seems like a typo: `state5` was passed instead of `state6`:
```c#
ExpectedSessionState6(m_logger, Id, state1, state2, state3, state4, state5, state5, m_state);
```

>[V3114](https://pvs-studio.com/en/docs/warnings/v3114/) IDisposable object 'store' is not disposed before method returns.

The `store` was not neither disposed nor closed (it implements `IDisposable` [since  .NET Framework 4.6](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509store?view=net-7.0#remarks))

