### PR TITLE
Support configuration with MySqlConnectorLoggingConfiguration without using MySqlDataSource

### DIFF
--- a/src/MySqlConnector/Logging/MySqlConnectorLoggingConfiguration.cs
+++ b/src/MySqlConnector/Logging/MySqlConnectorLoggingConfiguration.cs
@@ -3,14 +3,28 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace MySqlConnector.Logging;
 
-internal sealed class MySqlConnectorLoggingConfiguration(ILoggerFactory loggerFactory)
+public sealed class MySqlConnectorLoggingConfiguration(ILoggerFactory loggerFactory)
 {
-	public ILogger DataSourceLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlDataSource");
-	public ILogger ConnectionLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlConnection");
-	public ILogger CommandLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlCommand");
-	public ILogger PoolLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.ConnectionPool");
-	public ILogger BulkCopyLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlBulkCopy");
+	internal ILogger DataSourceLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlDataSource");
+	internal ILogger ConnectionLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlConnection");
+	internal ILogger CommandLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlCommand");
+	internal ILogger PoolLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.ConnectionPool");
+	internal ILogger BulkCopyLogger { get; } = loggerFactory.CreateLogger("MySqlConnector.MySqlBulkCopy");
 
-	public static MySqlConnectorLoggingConfiguration NullConfiguration { get; } = new MySqlConnectorLoggingConfiguration(NullLoggerFactory.Instance);
-	public static MySqlConnectorLoggingConfiguration GlobalConfiguration { get; set; } = NullConfiguration;
+	internal static ILoggerFactory GlobalLoggerFactory { get; set; } = NullLoggerFactory.Instance;
+	internal static MySqlConnectorLoggingConfiguration NullConfiguration { get; } = new MySqlConnectorLoggingConfiguration(GlobalLoggerFactory);
+	internal static MySqlConnectorLoggingConfiguration GlobalConfiguration { get; set; } = NullConfiguration;
+
+	/// <summary>
+	/// <para>
+	/// Globally initializes MySqlConnector logging to use the provided <paramref name="loggerFactory" />.
+	/// Must be called before any MySqlConnector APIs are used.
+	/// </para>
+	/// </summary>
+	/// <param name="loggerFactory">The logging factory to use when logging from MySqlConnector.</param>
+	public static void InitializeLogging(ILoggerFactory loggerFactory)
+	{
+		GlobalLoggerFactory = loggerFactory;
+		GlobalConfiguration = new MySqlConnectorLoggingConfiguration(loggerFactory);
+	}
 }


### PR DESCRIPTION
The visibility of `MySqlConnectorLoggingConfiguration` has been changed from `internal` to `public`, and an `InitializeLogging` static method has been added to allow users to globally initialize `LoggerFactory`. Other internal properties of the object have been changed from `public` to `internal`, making them invisible to users.

A `GlobalLoggerFactory` object property has been created, which allows in special scenarios the retrieval of the configured `GlobalLoggerFactory` via reflection, thereby enabling the addition of more logging providers.

Issue: #1410

