### PR TITLE
Add Foreign Keys, Indexes, IndexColumns schema collections

### DIFF
--- a/docs/content/overview/schema-collections.md
+++ b/docs/content/overview/schema-collections.md
@@ -1,6 +1,6 @@
 ---
 date: 2021-04-24
-lastmod: 2023-12-14
+lastmod: 2023-12-15
 menu:
   main:
     parent: getting started
@@ -44,6 +44,6 @@ weight: 80
 * `Triggers`
 * `UserPrivileges`
 * `Views`
-* `Foreign Keys`
-* `Indexes`
-* `IndexColumns`
+* `Foreign Keys`—[information about foreign keys in the server's SQL syntax](../schema/foreign keys/)
+* `Indexes`—[information about indexes in the server's SQL syntax](../schema/indexes/)
+* `IndexColumns`—[information about indexes in the server's SQL syntax](../schema/indexcolumns/)

--- a/docs/content/overview/schema/columns.md
+++ b/docs/content/overview/schema/columns.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: Columns Schema
 ---
 

--- a/docs/content/overview/schema/datatypes.md
+++ b/docs/content/overview/schema/datatypes.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: DataTypes Schema
 ---
 

--- a/docs/content/overview/schema/foreign keys.md
+++ b/docs/content/overview/schema/foreign keys.md
@@ -1,0 +1,34 @@
+---
+date: 2022-07-10
+lastmod: 2023-12-15
+title: Foreign Keys Schema
+---
+
+# Foreign Keys Schema
+
+The `Foreign Keys` schema provides information about foreign keys in the server's SQL syntax.
+
+Column Name | Data Type | Description
+--- | --- | ---
+CONSTRAINT_CATALOG | string | 
+CONSTRAINT_SCHEMA | string | 
+CONSTRAINT_NAME | string | 
+TABLE_CATALOG | string | 
+TABLE_SCHEMA | string | 
+TABLE_NAME | string | 
+MATCH_OPTION | string | 
+UPDATE_RULE | string | 
+DELETE_RULE | string | 
+REFERENCED_TABLE_CATALOG | string | 
+REFERENCED_TABLE_SCHEMA | string | 
+REFERENCED_TABLE_NAME | string | 
+
+The following restrictions are supported:
+
+Restriction Name | Restriction Default | Restriction Number
+--- | --- | --:
+Catalog | TABLE_CATALOG | 1
+Schema | TABLE_SCHEMA | 2
+Table | TABLE_NAME | 3
+Column | COLUMN_NAME | 4
+

--- a/docs/content/overview/schema/indexcolumns.md
+++ b/docs/content/overview/schema/indexcolumns.md
@@ -1,0 +1,30 @@
+---
+date: 2022-07-10
+lastmod: 2023-12-15
+title: IndexColumns Schema
+---
+
+# IndexColumns Schema
+
+The `IndexColumns` schema provides information about indexes in the server's SQL syntax.
+
+Column Name | Data Type | Description
+--- | --- | ---
+INDEX_CATALOG | string | 
+INDEX_SCHEMA | string | 
+INDEX_NAME | string | 
+TABLE_NAME | string | 
+COLUMN_NAME | string | 
+ORDINAL_POSITION | int | 
+SORT_ORDER | string | 
+
+The following restrictions are supported:
+
+Restriction Name | Restriction Default | Restriction Number
+--- | --- | --:
+Catalog | TABLE_CATALOG | 1
+Schema | TABLE_SCHEMA | 2
+Table | TABLE_NAME | 3
+Constraint | CONSTRAINT_NAME | 4
+Column | COLUMN_NAME | 5
+

--- a/docs/content/overview/schema/indexes.md
+++ b/docs/content/overview/schema/indexes.md
@@ -1,0 +1,31 @@
+---
+date: 2022-07-10
+lastmod: 2023-12-15
+title: Indexes Schema
+---
+
+# Indexes Schema
+
+The `Indexes` schema provides information about indexes in the server's SQL syntax.
+
+Column Name | Data Type | Description
+--- | --- | ---
+SEQ_IN_INDEX | long | 
+INDEX_CATALOG | string | 
+INDEX_SCHEMA | string | 
+INDEX_NAME | string | 
+TABLE_NAME | string | 
+UNIQUE | bool | 
+PRIMARY | bool | 
+TYPE | string | 
+COMMENT | string | 
+
+The following restrictions are supported:
+
+Restriction Name | Restriction Default | Restriction Number
+--- | --- | --:
+Catalog | TABLE_CATALOG | 1
+Schema | TABLE_SCHEMA | 2
+Table | TABLE_NAME | 3
+Column | COLUMN_NAME | 4
+

--- a/docs/content/overview/schema/metadatacollections.md
+++ b/docs/content/overview/schema/metadatacollections.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: MetaDataCollections Schema
 ---
 

--- a/docs/content/overview/schema/procedures.md
+++ b/docs/content/overview/schema/procedures.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: Procedures Schema
 ---
 

--- a/docs/content/overview/schema/reservedwords.md
+++ b/docs/content/overview/schema/reservedwords.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: ReservedWords Schema
 ---
 

--- a/docs/content/overview/schema/restrictions.md
+++ b/docs/content/overview/schema/restrictions.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-07-11
+lastmod: 2023-12-15
 title: Restrictions Schema
 ---
 

--- a/docs/content/overview/schema/tables.md
+++ b/docs/content/overview/schema/tables.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-07-10
-lastmod: 2022-08-12
+lastmod: 2023-12-15
 title: Tables Schema
 ---
 

--- a/src/MySqlConnector/Core/SchemaProvider.g.cs
+++ b/src/MySqlConnector/Core/SchemaProvider.g.cs
@@ -854,7 +854,7 @@ internal sealed partial class SchemaProvider
 		await FillDataTableAsync(ioBehavior, dataTable, "VIEWS", null, cancellationToken).ConfigureAwait(false);
 	}
 
-	private async Task FillForeignKeysAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
+	private Task FillForeignKeysAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
 	{
 		if (restrictionValues is { Length: > 4 })
 			throw new ArgumentException("More than 4 restrictionValues are not supported for schema 'Foreign Keys'.", nameof(restrictionValues));
@@ -868,29 +868,20 @@ internal sealed partial class SchemaProvider
 			new("TABLE_CATALOG", typeof(string)),
 			new("TABLE_SCHEMA", typeof(string)),
 			new("TABLE_NAME", typeof(string)),
-			new("COLUMN_NAME", typeof(string)),
+			new("MATCH_OPTION", typeof(string)),
+			new("UPDATE_RULE", typeof(string)),
+			new("DELETE_RULE", typeof(string)),
+			new("REFERENCED_TABLE_CATALOG", typeof(string)),
 			new("REFERENCED_TABLE_SCHEMA", typeof(string)),
 			new("REFERENCED_TABLE_NAME", typeof(string)),
-			new("REFERENCED_COLUMN_NAME", typeof(string)),
 		]);
 
-		var columns = new List<KeyValuePair<string, string>>();
-		if (restrictionValues is not null)
-		{
-			if (restrictionValues.Length > 0 && !string.IsNullOrEmpty(restrictionValues[0]))
-				columns.Add(new("TABLE_CATALOG", restrictionValues[0]!));
-			if (restrictionValues.Length > 1 && !string.IsNullOrEmpty(restrictionValues[1]))
-				columns.Add(new("TABLE_SCHEMA", restrictionValues[1]!));
-			if (restrictionValues.Length > 2 && !string.IsNullOrEmpty(restrictionValues[2]))
-				columns.Add(new("TABLE_NAME", restrictionValues[2]!));
-			if (restrictionValues.Length > 3 && !string.IsNullOrEmpty(restrictionValues[3]))
-				columns.Add(new("COLUMN_NAME", restrictionValues[3]!));
-		}
+		DoFillForeignKeys(dataTable, restrictionValues);
 
-		await FillDataTableAsync(ioBehavior, dataTable, "KEY_COLUMN_USAGE", columns, cancellationToken).ConfigureAwait(false);
+		return Task.CompletedTask;
 	}
 
-	private async Task FillIndexesAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
+	private Task FillIndexesAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
 	{
 		if (restrictionValues is { Length: > 4 })
 			throw new ArgumentException("More than 4 restrictionValues are not supported for schema 'Indexes'.", nameof(restrictionValues));
@@ -898,30 +889,23 @@ internal sealed partial class SchemaProvider
 		dataTable.TableName = tableName;
 		dataTable.Columns.AddRange(
 		[
-			new("TABLE_CATALOG", typeof(string)),
-			new("TABLE_SCHEMA", typeof(string)),
-			new("TABLE_NAME", typeof(string)),
-			new("COLUMN_NAME", typeof(string)),
+			new("SEQ_IN_INDEX", typeof(long)),
+			new("INDEX_CATALOG", typeof(string)),
+			new("INDEX_SCHEMA", typeof(string)),
 			new("INDEX_NAME", typeof(string)),
+			new("TABLE_NAME", typeof(string)),
+			new("UNIQUE", typeof(bool)),
+			new("PRIMARY", typeof(bool)),
+			new("TYPE", typeof(string)),
+			new("COMMENT", typeof(string)),
 		]);
 
-		var columns = new List<KeyValuePair<string, string>>();
-		if (restrictionValues is not null)
-		{
-			if (restrictionValues.Length > 0 && !string.IsNullOrEmpty(restrictionValues[0]))
-				columns.Add(new("TABLE_CATALOG", restrictionValues[0]!));
-			if (restrictionValues.Length > 1 && !string.IsNullOrEmpty(restrictionValues[1]))
-				columns.Add(new("TABLE_SCHEMA", restrictionValues[1]!));
-			if (restrictionValues.Length > 2 && !string.IsNullOrEmpty(restrictionValues[2]))
-				columns.Add(new("TABLE_NAME", restrictionValues[2]!));
-			if (restrictionValues.Length > 3 && !string.IsNullOrEmpty(restrictionValues[3]))
-				columns.Add(new("COLUMN_NAME", restrictionValues[3]!));
-		}
+		DoFillIndexes(dataTable, restrictionValues);
 
-		await FillDataTableAsync(ioBehavior, dataTable, "STATISTICS", columns, cancellationToken).ConfigureAwait(false);
+		return Task.CompletedTask;
 	}
 
-	private async Task FillIndexColumnsAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
+	private Task FillIndexColumnsAsync(IOBehavior ioBehavior, DataTable dataTable, string tableName, string?[]? restrictionValues, CancellationToken cancellationToken)
 	{
 		if (restrictionValues is { Length: > 5 })
 			throw new ArgumentException("More than 5 restrictionValues are not supported for schema 'IndexColumns'.", nameof(restrictionValues));
@@ -929,29 +913,18 @@ internal sealed partial class SchemaProvider
 		dataTable.TableName = tableName;
 		dataTable.Columns.AddRange(
 		[
-			new("TABLE_CATALOG", typeof(string)),
-			new("TABLE_SCHEMA", typeof(string)),
+			new("INDEX_CATALOG", typeof(string)),
+			new("INDEX_SCHEMA", typeof(string)),
+			new("INDEX_NAME", typeof(string)),
 			new("TABLE_NAME", typeof(string)),
-			new("CONSTRAINT_NAME", typeof(string)),
 			new("COLUMN_NAME", typeof(string)),
+			new("ORDINAL_POSITION", typeof(int)),
+			new("SORT_ORDER", typeof(string)),
 		]);
 
-		var columns = new List<KeyValuePair<string, string>>();
-		if (restrictionValues is not null)
-		{
-			if (restrictionValues.Length > 0 && !string.IsNullOrEmpty(restrictionValues[0]))
-				columns.Add(new("TABLE_CATALOG", restrictionValues[0]!));
-			if (restrictionValues.Length > 1 && !string.IsNullOrEmpty(restrictionValues[1]))
-				columns.Add(new("TABLE_SCHEMA", restrictionValues[1]!));
-			if (restrictionValues.Length > 2 && !string.IsNullOrEmpty(restrictionValues[2]))
-				columns.Add(new("TABLE_NAME", restrictionValues[2]!));
-			if (restrictionValues.Length > 3 && !string.IsNullOrEmpty(restrictionValues[3]))
-				columns.Add(new("CONSTRAINT_NAME", restrictionValues[3]!));
-			if (restrictionValues.Length > 4 && !string.IsNullOrEmpty(restrictionValues[4]))
-				columns.Add(new("COLUMN_NAME", restrictionValues[4]!));
-		}
+		DoFillIndexColumns(dataTable, restrictionValues);
 
-		await FillDataTableAsync(ioBehavior, dataTable, "KEY_COLUMN_USAGE", columns, cancellationToken).ConfigureAwait(false);
+		return Task.CompletedTask;
 	}
 
 }

--- a/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.cs
+++ b/tools/SchemaCollectionGenerator/SchemaCollectionGenerator.cs
@@ -148,8 +148,10 @@ foreach (var schema in schemaCollections)
 	}
 	else
 	{
+		// custom cunction will be called here
+		string restrictions = (schema.Restrictions?.Count > 0) ? ", restrictionValues" : "";
 		codeWriter.WriteLine($"""
-					{schema.Custom}(dataTable);
+					{schema.Custom}(dataTable{restrictions});
 			""");
 	}
 

--- a/tools/SchemaCollectionGenerator/SchemaCollections.yaml
+++ b/tools/SchemaCollectionGenerator/SchemaCollections.yaml
@@ -761,7 +761,8 @@
     type: string
 
 - name: Foreign Keys
-  table: KEY_COLUMN_USAGE
+  description: information about foreign keys in the server's SQL syntax
+  custom: DoFillForeignKeys
   restrictions:
   - name: Catalog
     default: TABLE_CATALOG
@@ -784,17 +785,22 @@
     type: string
   - name: TABLE_NAME
     type: string
-  - name: COLUMN_NAME
+  - name: MATCH_OPTION
+    type: string
+  - name: UPDATE_RULE
+    type: string
+  - name: DELETE_RULE
+    type: string
+  - name: REFERENCED_TABLE_CATALOG
     type: string
   - name: REFERENCED_TABLE_SCHEMA
     type: string
   - name: REFERENCED_TABLE_NAME
     type: string
-  - name: REFERENCED_COLUMN_NAME
-    type: string
 
 - name: Indexes
-  table: STATISTICS
+  description: information about indexes in the server's SQL syntax
+  custom: DoFillIndexes
   restrictions:
   - name: Catalog
     default: TABLE_CATALOG
@@ -805,20 +811,29 @@
   - name: Column # it is only a guess - might need to be changed, but NHibernate passes 4 values, with last one is null
     default: COLUMN_NAME
   columns:
-  - name: TABLE_CATALOG
+  - name: SEQ_IN_INDEX
+    type: long
+  - name: INDEX_CATALOG # placeholder  - will be filled by SQL query
     type: string
-  - name: TABLE_SCHEMA
+  - name: INDEX_SCHEMA # same as TABLE_SCHEMA, see https://mariadb.com/kb/en/information-schema-statistics-table/
+    type: string
+  - name: INDEX_NAME
     type: string
   - name: TABLE_NAME
     type: string
-  - name: COLUMN_NAME
+  - name: UNIQUE
+    type: bool
+  - name: PRIMARY
+    type: bool
+  - name: TYPE
     type: string
-  - name: INDEX_NAME
+  - name: COMMENT
     type: string
 
 
 - name: IndexColumns
-  table: KEY_COLUMN_USAGE
+  description: information about indexes in the server's SQL syntax
+  custom: DoFillIndexColumns
   restrictions:
   - name: Catalog
     default: TABLE_CATALOG
@@ -828,16 +843,20 @@
     default: TABLE_NAME
   - name: Constraint
     default: CONSTRAINT_NAME
-  - name: Column # it is only a guess - might need to be changed, but NHibernate passes 5 values, with last one is null
+  - name: Column # it comes fro
     default: COLUMN_NAME
   columns:
-  - name: TABLE_CATALOG
+  - name: INDEX_CATALOG # placeholder  - will be filled by SQL query
     type: string
-  - name: TABLE_SCHEMA
+  - name: INDEX_SCHEMA # same as TABLE_SCHEMA, see https://mariadb.com/kb/en/information-schema-statistics-table/
+    type: string
+  - name: INDEX_NAME
     type: string
   - name: TABLE_NAME
     type: string
-  - name: CONSTRAINT_NAME
-    type: string
   - name: COLUMN_NAME
+    type: string
+  - name: ORDINAL_POSITION
+    type: int
+  - name: SORT_ORDER
     type: string


### PR DESCRIPTION
Hello @bgrainger 

sorry for extra work for you, however I took into account your wish for better alignment with MySql.Data and hence I reworked how Foreign Keys, Indexes, IndexColumns schema collections are generated, so it is now from data similar to MySql.Data.

I missed unfortunately one of your commits, and hence I unnecessary adjusted lastmod once again (just saw it).

PS: I am new to the github workflow so please excuse the extra work for you.

