### PR TITLE
Fixed packet corruption issue when enum was not 4 bytes

### DIFF
--- a/src/MySqlConnector/MySqlParameter.cs
+++ b/src/MySqlConnector/MySqlParameter.cs
@@ -835,7 +835,45 @@ public sealed class MySqlParameter : DbParameter, IDbDataParameter, ICloneable
 		}
 		else if (Value is Enum)
 		{
-			writer.Write(Convert.ToInt32(Value, CultureInfo.InvariantCulture));
+			var enumType = Value.GetType();
+			var enumUnderlyingType = enumType.GetEnumUnderlyingType();
+
+			if (enumUnderlyingType == typeof(byte))
+			{
+				writer.Write((byte) Value);
+			}
+			else if (enumUnderlyingType == typeof(sbyte))
+			{
+				writer.Write(unchecked((byte) (sbyte) Value));
+			}
+			else if (enumUnderlyingType == typeof(short))
+			{
+				writer.Write(unchecked((ushort) (short) Value));
+			}
+			else if (enumUnderlyingType == typeof(ushort))
+			{
+				writer.Write((ushort) Value);
+			}
+			else if (enumUnderlyingType == typeof(int))
+			{
+				writer.Write((int) Value);
+			}
+			else if (enumUnderlyingType == typeof(uint))
+			{
+				writer.Write((uint) Value);
+			}
+			else if (enumUnderlyingType == typeof(long))
+			{
+				writer.Write(unchecked((ulong) (long) Value));
+			}
+			else if (enumUnderlyingType == typeof(ulong))
+			{
+				writer.Write((ulong) Value);
+			}
+			else
+			{
+				throw new NotSupportedException($"Parameter type {Value.GetType().Name} is not supported; see https://fl.vu/mysql-param-type. Value: {Value}");
+			}
 		}
 		else if (MySqlDbType == MySqlDbType.Int16)
 		{

--- a/tests/MySqlConnector.Tests/DummyEnum.cs
+++ b/tests/MySqlConnector.Tests/DummyEnum.cs
@@ -4,4 +4,52 @@ internal enum DummyEnum
 {
 	FirstValue,
 	SecondValue
-} 
+}
+
+internal enum DummyByteEnum : byte
+{
+	FirstValue,
+	SecondValue = 0x11,
+}
+
+internal enum DummySByteEnum : sbyte
+{
+	FirstValue,
+	SecondValue = 0x11,
+}
+
+internal enum DummyShortEnum : short
+{
+	FirstValue,
+	SecondValue = 0x1122,
+}
+
+internal enum DummyUShortEnum : ushort
+{
+	FirstValue,
+	SecondValue = 0x1122,
+}
+
+internal enum DummyIntEnum : int
+{
+	FirstValue,
+	SecondValue = 0x11223344,
+}
+
+internal enum DummyUIntEnum : uint
+{
+	FirstValue,
+	SecondValue = 0x11223344,
+}
+
+internal enum DummyLongEnum : long
+{
+	FirstValue,
+	SecondValue = 0x11223344_55667788,
+}
+
+internal enum DummyULongEnum : ulong
+{
+	FirstValue,
+	SecondValue = 0x11223344_55667788,
+}

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'MySqlData' ">
     <PackageReference Include="MySql.Data" />
-    <Compile Remove="ByteBufferWriterTests.cs;CachedProcedureTests.cs;CancellationTests.cs;ColumnCountPayloadTests.cs;ColumnReaderTests.cs;ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;LoadBalancerTests.cs;MySqlDecimalTests.cs;MySqlExceptionTests.cs;MySqlParameterCollectionNameToIndexTests.cs;NormalizeTests.cs;ServerVersionTests.cs;StatementPreparerTests.cs;TypeMapperTests.cs;UtilityTests.cs" />
+    <Compile Remove="ByteBufferWriterTests.cs;CachedProcedureTests.cs;CancellationTests.cs;ColumnCountPayloadTests.cs;ColumnReaderTests.cs;ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;LoadBalancerTests.cs;MySqlDecimalTests.cs;MySqlExceptionTests.cs;MySqlParameterAppendBinaryTests.cs;MySqlParameterCollectionNameToIndexTests.cs;NormalizeTests.cs;ServerVersionTests.cs;StatementPreparerTests.cs;TypeMapperTests.cs;UtilityTests.cs" />
     <Compile Remove="Metrics\*.cs" />
     <Using Include="MySql.Data.MySqlClient" />
     <Using Include="MySql.Data.Types" />

--- a/tests/MySqlConnector.Tests/MySqlParameterAppendBinaryTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlParameterAppendBinaryTests.cs
@@ -1,0 +1,27 @@
+using MySqlConnector.Protocol.Serialization;
+
+namespace MySqlConnector.Tests;
+
+public class MySqlParameterAppendBinaryTests
+{
+	[Theory]
+	[InlineData(DummySByteEnum.SecondValue, MySqlDbType.Byte, new byte[] { 0x11 })]
+	[InlineData(DummyByteEnum.SecondValue, MySqlDbType.UByte, new byte[] { 0x11 })]
+	[InlineData(DummyShortEnum.SecondValue, MySqlDbType.Int16, new byte[] { 0x22, 0x11 })]
+	[InlineData(DummyUShortEnum.SecondValue, MySqlDbType.UInt16, new byte[] { 0x22, 0x11 })]
+	[InlineData(DummyIntEnum.SecondValue, MySqlDbType.Int32, new byte[] { 0x44, 0x33, 0x22, 0x11 })]
+	[InlineData(DummyUIntEnum.SecondValue, MySqlDbType.UInt32, new byte[] { 0x44, 0x33, 0x22, 0x11 })]
+	[InlineData(DummyEnum.SecondValue, MySqlDbType.Int32, new byte[] { 0x01, 0x00, 0x00, 0x00 })]
+	[InlineData(DummyLongEnum.SecondValue, MySqlDbType.Int64, new byte[] { 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 })]
+	[InlineData(DummyULongEnum.SecondValue, MySqlDbType.UInt64, new byte[] { 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11 })]
+	public void WriteBinaryEnumType(object value, MySqlDbType expectedMySqlDbType, byte[] expectedBinary)
+	{
+		var parameter = new MySqlParameter { Value = value };
+		var writer = new ByteBufferWriter();
+		parameter.AppendBinary(writer, StatementPreparerOptions.None);
+
+		Assert.Equal(parameter.MySqlDbType, expectedMySqlDbType);
+		Assert.Equal(writer.Position, expectedBinary.Length);
+		Assert.Equal(writer.ArraySegment, expectedBinary);
+	}
+}


### PR DESCRIPTION
Fixed an issue where packets were corrupted when enum was not 4 bytes

This appears to be because the column type and the actual size of data used in the SingleCommandPayloadCreator.WriteBinaryParameters function are different.

Code and screenshots to reproduce the issue are provided below

Please check

```
CREATE TABLE `test1` (
	`Id` INT NOT NULL AUTO_INCREMENT,
	`A` TINYINT NOT NULL,
	`B` INT NOT NULL,
	`C` INT NOT NULL,
	PRIMARY KEY (`Id`)
);
```

```
internal class TestLogic
{
    private readonly MySqlConnection _connection;

    public TestLogic(string connStr)
    {
        _connection = new MySqlConnection(connStr);
    }

    public async Task Run()
    {
        
        await _connection.OpenAsync();

        await InsertDummyRow();
        var list = await SelectAllRow();

        foreach (var row in list)
        {
            Console.WriteLine(row);
        }
    }

    private async Task InsertDummyRow()
    {
        using var cmd = _connection.CreateCommand();
        cmd.CommandText = @"
            INSERT INTO test1 (A, B, C) 
                   VALUES (@A, @B, @C)";

        cmd.Parameters.AddWithValue("@A", TestEnum1.X);
        cmd.Parameters.AddWithValue("@B", 0x40302010);
        cmd.Parameters.AddWithValue("@C", 0);

        await cmd.PrepareAsync();

        await cmd.ExecuteNonQueryAsync();
    }

    private async Task<List<TestTable1Model>> SelectAllRow()
    {
        using var cmd = _connection.CreateCommand();
        cmd.CommandText = @"
            SELECT Id, A, B, C
              FROM test1 LIMIT 1000";

        await cmd.PrepareAsync();

        var list = new List<TestTable1Model>();
        var reader = await cmd.ExecuteReaderAsync();

        while (await reader.ReadAsync())
        {
            var row = new TestTable1Model
            {
                Id = reader.GetInt32(0),
                A = (TestEnum1)reader.GetByte(1),
                B = reader.GetInt32(2),
                C = reader.GetInt32(3),
            };

            list.Add(row);
        }

        return list;
    }
}

internal class TestTable1Model
{
    public required int Id { get; set; }

    public required TestEnum1 A { get; set; }

    public required int B { get; set; }

    public required int C { get; set; }

    public override string ToString() => $"Id: {Id}, A: {A}, B: {B:X}, C: {C:X}";
}

internal enum TestEnum1 : sbyte
{
    None = 0,
    X = 1,
    Y = 2,
    Z = 3,
};
```

![test](https://github.com/mysql-net/MySqlConnector/assets/2503620/ec4288d8-b4c2-42b0-a8ec-21ff41b4c16e)
