### PR TITLE
Mention MariaDB prominently in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![NuGet](https://img.shields.io/nuget/vpre/MySqlConnector.svg)](https://www.nuget.org/packages/MySqlConnector/)
 
 This is an [ADO.NET](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/) data
-provider for [MySQL](https://www.mysql.com/). It provides implementations of
+provider for [MySQL](https://www.mysql.com/) and other compatible servers including [MariaDB](https://www.mariadb.org).
+It provides implementations of
 `DbConnection`, `DbCommand`, `DbDataReader`, `DbTransaction`—the classes
 needed to query and update databases from managed code.
 
@@ -21,7 +22,7 @@ This library outperforms MySQL Connector/NET (`MySql.Data`) on benchmarks:
 
 ### Server Compatibility
 
-This library is compatible with [many MySQL-compatible servers](https://mysqlconnector.net/#server-compatibility).
+This library is compatible with [many MySQL-compatible servers](https://mysqlconnector.net/#server-compatibility), including MySQL 5.5 and newer and MariaDB 10.x and newer.
 MySql.Data [only supports MySQL Server](https://bugs.mysql.com/bug.php?id=109331).
 
 ### Bug Fixes


### PR DESCRIPTION
While several of the detailed documentation pages _do_ mention MariaDB, the `README` does not mention it explicitly.  

This might cause MariaDB users to overlook this package as a good solution for connecting to their databases from .NET applications.