### PR TITLE
Avoids SET NAMES commands if not needed

### DIFF
--- a/src/MySqlConnector/Core/ConcatenatedCommandPayloadCreator.cs
+++ b/src/MySqlConnector/Core/ConcatenatedCommandPayloadCreator.cs
@@ -17,7 +17,7 @@ internal sealed class ConcatenatedCommandPayloadCreator : ICommandPayloadCreator
 
 		// ConcatenatedCommandPayloadCreator is only used by MySqlBatch, and MySqlBatchCommand doesn't expose attributes,
 		// so just write an empty attribute set if the server needs it.
-		if (commandListPosition.CommandAt(commandListPosition.CommandIndex).Connection!.Session.SupportsQueryAttributes)
+		if (commandListPosition.CommandAt(commandListPosition.CommandIndex).Connection!.Session.Context.SupportsQueryAttributes)
 		{
 			// attribute count
 			writer.WriteLengthEncodedInteger(0);

--- a/src/MySqlConnector/Core/ConnectionPool.cs
+++ b/src/MySqlConnector/Core/ConnectionPool.cs
@@ -65,7 +65,7 @@ internal sealed class ConnectionPool : IDisposable
 				}
 				else
 				{
-					if (ConnectionSettings.ConnectionReset || session.DatabaseOverride is not null)
+					if (ConnectionSettings.ConnectionReset || !session.Context.IsInitialDatabase())
 					{
 						if (timeoutMilliseconds != 0)
 							session.SetTimeout(Math.Max(1, timeoutMilliseconds - Utility.GetElapsedMilliseconds(startingTimestamp)));

--- a/src/MySqlConnector/Core/Context.cs
+++ b/src/MySqlConnector/Core/Context.cs
@@ -1,0 +1,29 @@
+using MySqlConnector.Protocol;
+
+namespace MySqlConnector.Core;
+
+internal sealed class Context
+{
+	public Context(ProtocolCapabilities protocolCapabilities, string? database, int connectionId)
+	{
+		SupportsDeprecateEof = (protocolCapabilities & ProtocolCapabilities.DeprecateEof) != 0;
+		SupportsCachedPreparedMetadata = (protocolCapabilities & ProtocolCapabilities.MariaDbCacheMetadata) != 0;
+		SupportsQueryAttributes = (protocolCapabilities & ProtocolCapabilities.QueryAttributes) != 0;
+		SupportsSessionTrack = (protocolCapabilities & ProtocolCapabilities.SessionTrack) != 0;
+		ConnectionId = connectionId;
+		Database = database;
+		m_initialDatabase = database;
+	}
+
+	public bool SupportsDeprecateEof { get; }
+	public bool SupportsQueryAttributes { get; }
+	public bool SupportsSessionTrack { get; }
+	public bool SupportsCachedPreparedMetadata { get; }
+	public string? ClientCharset { get; set; }
+
+	public string? Database { get; set; }
+	private readonly string? m_initialDatabase;
+	public bool IsInitialDatabase() => string.Equals(m_initialDatabase, Database, StringComparison.Ordinal);
+
+	public int ConnectionId { get; set; }
+}

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -38,7 +38,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 				var firstByte = payload.HeaderByte;
 				if (firstByte == OkPayload.Signature)
 				{
-					var ok = OkPayload.Create(payload.Span, Session.SupportsDeprecateEof, Session.SupportsSessionTrack);
+					var ok = OkPayload.Create(payload.Span, Session.Context);
 
 					// if we've read a result set header then this is a SELECT statement, so we shouldn't overwrite RecordsAffected
 					// (which should be -1 for SELECT) unless the server reports a non-zero count
@@ -48,8 +48,6 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 					if (ok.LastInsertId != 0)
 						Command?.SetLastInsertedId((long) ok.LastInsertId);
 					WarningCount = ok.WarningCount;
-					if (ok.NewSchema is not null)
-						Connection.Session.DatabaseOverride = ok.NewSchema;
 					m_columnDefinitions = default;
 					State = (ok.ServerStatus & ServerStatus.MoreResultsExist) == 0
 						? ResultSetState.NoMoreData
@@ -109,7 +107,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 				}
 				else
 				{
-					var columnCountPacket = ColumnCountPayload.Create(payload.Span, Session.SupportsCachedPreparedMetadata);
+					var columnCountPacket = ColumnCountPayload.Create(payload.Span, Session.Context.SupportsCachedPreparedMetadata);
 					var columnCount = columnCountPacket.ColumnCount;
 					if (!columnCountPacket.MetadataFollows)
 					{
@@ -132,7 +130,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 						m_columnDefinitions = m_columnDefinitionPayloadCache.AsMemory(0, columnCount);
 
 						// if the server supports metadata caching but has re-sent it, something has changed since last prepare/execution and we need to update the columns
-						var preparedColumns = Session.SupportsCachedPreparedMetadata ? DataReader.LastUsedPreparedStatement?.Columns : null;
+						var preparedColumns = Session.Context.SupportsCachedPreparedMetadata ? DataReader.LastUsedPreparedStatement?.Columns : null;
 
 						for (var column = 0; column < columnCount; column++)
 						{
@@ -156,7 +154,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 						}
 					}
 
-					if (!Session.SupportsDeprecateEof)
+					if (!Session.Context.SupportsDeprecateEof)
 					{
 						payload = await Session.ReceiveReplyAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 						_ = EofPayload.Create(payload.Span);
@@ -252,13 +250,13 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 
 		if (payload.HeaderByte == EofPayload.Signature)
 		{
-			if (Session.SupportsDeprecateEof && OkPayload.IsOk(payload.Span, Session.SupportsDeprecateEof))
+			if (Session.Context.SupportsDeprecateEof && OkPayload.IsOk(payload.Span, Session.Context))
 			{
-				var ok = OkPayload.Create(payload.Span, Session.SupportsDeprecateEof, Session.SupportsSessionTrack);
+				var ok = OkPayload.Create(payload.Span, Session.Context);
 				BufferState = (ok.ServerStatus & ServerStatus.MoreResultsExist) == 0 ? ResultSetState.NoMoreData : ResultSetState.HasMoreData;
 				return null;
 			}
-			if (!Session.SupportsDeprecateEof && EofPayload.IsEof(payload))
+			if (!Session.Context.SupportsDeprecateEof && EofPayload.IsEof(payload))
 			{
 				var eof = EofPayload.Create(payload.Span);
 				BufferState = (eof.ServerStatus & ServerStatus.MoreResultsExist) == 0 ? ResultSetState.NoMoreData : ResultSetState.HasMoreData;

--- a/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
+++ b/src/MySqlConnector/Core/SingleCommandPayloadCreator.cs
@@ -24,7 +24,7 @@ internal sealed class SingleCommandPayloadCreator : ICommandPayloadCreator
 			Log.PreparingCommandPayload(command.Logger, command.Connection!.Session.Id, command.CommandText!);
 
 			writer.Write((byte) CommandKind.Query);
-			var supportsQueryAttributes = command.Connection!.Session.SupportsQueryAttributes;
+			var supportsQueryAttributes = command.Connection!.Session.Context.SupportsQueryAttributes;
 			if (supportsQueryAttributes)
 			{
 				// attribute count
@@ -83,7 +83,7 @@ internal sealed class SingleCommandPayloadCreator : ICommandPayloadCreator
 		Log.PreparingCommandPayloadWithId(command.Logger, command.Connection!.Session.Id, preparedStatement.StatementId, command.CommandText!);
 
 		var attributes = command.RawAttributes;
-		var supportsQueryAttributes = command.Connection!.Session.SupportsQueryAttributes;
+		var supportsQueryAttributes = command.Connection!.Session.Context.SupportsQueryAttributes;
 		writer.Write(preparedStatement.StatementId);
 
 		// NOTE: documentation is not updated yet, but due to bugs in MySQL Server 8.0.23-8.0.25, the PARAMETER_COUNT_AVAILABLE (0x08)

--- a/src/MySqlConnector/Logging/Log.cs
+++ b/src/MySqlConnector/Logging/Log.cs
@@ -47,7 +47,7 @@ internal static partial class Log
 	public static partial void AutoDetectedAurora57(ILogger logger, string sessionId, string hostName);
 
 	[LoggerMessage(EventIds.SessionMadeConnection, LogLevel.Debug, "Session {SessionId} made connection; server version {ServerVersion}; connection ID {ConnectionId}; supports: compression {SupportsCompression}, attributes {SupportsAttributes}, deprecate EOF {SupportsDeprecateEof}, cached metadata {SupportsCachedMetadata}, SSL {SupportsSsl}, session track {SupportsSessionTrack}, pipelining {SupportsPipelining}, query attributes {SupportsQueryAttributes}")]
-	public static partial void SessionMadeConnection(ILogger logger, string sessionId, string serverVersion, int connectionId, bool supportsCompression, bool supportsAttributes, bool supportsDeprecateEof, bool supportsCachedMetadata, bool supportsSsl, bool supportsSessionTrack, bool supportsPipelining, bool supportsQueryAttributes);
+	public static partial void SessionMadeConnection(ILogger logger, string sessionId, string serverVersion, long connectionId, bool supportsCompression, bool supportsAttributes, bool supportsDeprecateEof, bool supportsCachedMetadata, bool supportsSsl, bool supportsSessionTrack, bool supportsPipelining, bool supportsQueryAttributes);
 
 	[LoggerMessage(EventIds.ServerDoesNotSupportSsl, LogLevel.Error, "Session {SessionId} requires SSL but server doesn't support it")]
 	public static partial void ServerDoesNotSupportSsl(ILogger logger, string sessionId);
@@ -184,7 +184,7 @@ internal static partial class Log
 	public static partial void DetectedProxy(ILogger logger, string sessionId);
 
 	[LoggerMessage(EventIds.ChangingConnectionId, LogLevel.Debug, "Session {SessionId} changing connection id from {OldConnectionId} to {ConnectionId} and server version from {OldServerVersion} to {ServerVersion}")]
-	public static partial void ChangingConnectionId(ILogger logger, string sessionId, int oldConnectionId, int connectionId, string oldServerVersion, string serverVersion);
+	public static partial void ChangingConnectionId(ILogger logger, string sessionId, long oldConnectionId, long connectionId, string oldServerVersion, string serverVersion);
 
 	[LoggerMessage(EventIds.FailedToGetConnectionId, LogLevel.Information, "Session {SessionId} failed to get CONNECTION_ID(), VERSION()")]
 	public static partial void FailedToGetConnectionId(ILogger logger, Exception exception, string sessionId);

--- a/src/MySqlConnector/Protocol/Payloads/OkPayload.cs
+++ b/src/MySqlConnector/Protocol/Payloads/OkPayload.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text;
+using MySqlConnector.Core;
 using MySqlConnector.Protocol.Serialization;
 using MySqlConnector.Utilities;
 
@@ -11,7 +13,6 @@ internal sealed class OkPayload
 	public ServerStatus ServerStatus { get; }
 	public int WarningCount { get; }
 	public string? StatusInfo { get; }
-	public string? NewSchema { get; }
 
 	public const byte Signature = 0x00;
 
@@ -20,56 +21,51 @@ internal sealed class OkPayload
 	 * https://mariadb.com/kb/en/the-mariadb-library/resultset/
 	 * https://github.com/MariaDB/mariadb-connector-j/blob/5fa814ac6e1b4c9cb6d141bd221cbd5fc45c8a78/src/main/java/org/mariadb/jdbc/internal/com/read/resultset/SelectResultSet.java#L443-L444
 	 */
-	public static bool IsOk(ReadOnlySpan<byte> span, bool deprecateEof) =>
+	public static bool IsOk(ReadOnlySpan<byte> span, Context context) =>
 		span.Length > 0 &&
 			(span.Length > 6 && span[0] == Signature ||
-			 deprecateEof && span.Length < 0xFF_FFFF && span[0] == EofPayload.Signature);
+			 context.SupportsDeprecateEof && span.Length < 0xFF_FFFF && span[0] == EofPayload.Signature);
 
 	/// <summary>
 	/// Creates an <see cref="OkPayload"/> from the given <paramref name="span"/>, or throws <see cref="FormatException"/>
 	/// if the bytes do not represent a valid <see cref="OkPayload"/>.
 	/// </summary>
 	/// <param name="span">The bytes from which to read an OK packet.</param>
-	/// <param name="deprecateEof">Whether the <see cref="ProtocolCapabilities.DeprecateEof"/> flag was set on the connection.</param>
-	/// <param name="clientSessionTrack">Whether <see cref="ProtocolCapabilities.SessionTrack"/> flag was set on the connection.</param>
+	/// <param name="context">Current connection variables context</param>
 	/// <returns>A <see cref="OkPayload"/> with the contents of the OK packet.</returns>
 	/// <exception cref="FormatException">Thrown when the bytes are not a valid OK packet.</exception>
-	public static OkPayload Create(ReadOnlySpan<byte> span, bool deprecateEof, bool clientSessionTrack) =>
-		Read(span, deprecateEof, clientSessionTrack, true)!;
+	public static OkPayload Create(ReadOnlySpan<byte> span, Context context) =>
+		Read(span, context, true)!;
 
 	/// <summary>
 	/// Verifies that the bytes in the given <paramref name="span"/> form a valid <see cref="OkPayload"/>, or throws
 	/// <see cref="FormatException"/> if they do not.
 	/// </summary>
 	/// <param name="span">The bytes from which to read an OK packet.</param>
-	/// <param name="deprecateEof">Whether the <see cref="ProtocolCapabilities.DeprecateEof"/> flag was set on the connection.</param>
-	/// <param name="clientSessionTrack">Whether <see cref="ProtocolCapabilities.SessionTrack"/> flag was set on the connection.</param>
+	/// <param name="context">Current connection variables context</param>
 	/// <exception cref="FormatException">Thrown when the bytes are not a valid OK packet.</exception>
-	public static void Verify(ReadOnlySpan<byte> span, bool deprecateEof, bool clientSessionTrack) =>
-		Read(span, deprecateEof, clientSessionTrack, createPayload: false);
+	public static void Verify(ReadOnlySpan<byte> span, Context context) =>
+		Read(span, context, createPayload: false);
 
-	private static OkPayload? Read(ReadOnlySpan<byte> span, bool deprecateEof, bool clientSessionTrack, bool createPayload)
+	private static OkPayload? Read(ReadOnlySpan<byte> span, Context context, bool createPayload)
 	{
 		var reader = new ByteArrayReader(span);
 		var signature = reader.ReadByte();
-		if (signature != Signature && (!deprecateEof || signature != EofPayload.Signature))
+		if (signature != Signature && (!context.SupportsDeprecateEof || signature != EofPayload.Signature))
 			throw new FormatException($"Expected to read 0x00 or 0xFE but got 0x{signature:X2}");
 		var affectedRowCount = reader.ReadLengthEncodedInteger();
 		var lastInsertId = reader.ReadLengthEncodedInteger();
 		var serverStatus = (ServerStatus) reader.ReadUInt16();
 		var warningCount = (int) reader.ReadUInt16();
-		string? newSchema = null;
 		ReadOnlySpan<byte> statusBytes;
 
-		if (clientSessionTrack)
+		if (context.SupportsSessionTrack)
 		{
 			if (reader.BytesRemaining > 0)
 			{
 				statusBytes = reader.ReadLengthEncodedByteString(); // human-readable info
-
-				if ((serverStatus & ServerStatus.SessionStateChanged) == ServerStatus.SessionStateChanged && reader.BytesRemaining > 0)
+				while (reader.BytesRemaining > 0)
 				{
-					// implies ProtocolCapabilities.SessionTrack
 					var sessionStateChangeDataLength = checked((int) reader.ReadLengthEncodedInteger());
 					var endOffset = reader.Offset + sessionStateChangeDataLength;
 					while (reader.Offset < endOffset)
@@ -79,7 +75,28 @@ internal sealed class OkPayload
 						switch (kind)
 						{
 							case SessionTrackKind.Schema:
-								newSchema = Encoding.UTF8.GetString(reader.ReadLengthEncodedByteString());
+								context.Database = Encoding.UTF8.GetString(reader.ReadLengthEncodedByteString());
+								break;
+
+							case SessionTrackKind.SystemVariables:
+								var systemVariableOffset = reader.Offset + dataLength;
+								do
+								{
+									var variableSv = Encoding.ASCII.GetString(reader.ReadLengthEncodedByteString());
+									var lenSv = reader.ReadLengthEncodedIntegerOrNull();
+									var valueSv = lenSv == -1
+										? null
+										: Encoding.ASCII.GetString(reader.ReadByteString(lenSv));
+									switch (variableSv)
+									{
+										case "character_set_client":
+											context.ClientCharset = valueSv;
+											break;
+										case "connection_id":
+											context.ConnectionId = Convert.ToInt32(valueSv, CultureInfo.InvariantCulture);
+											break;
+									}
+								} while (reader.Offset < systemVariableOffset);
 								break;
 
 							default:
@@ -109,7 +126,7 @@ internal sealed class OkPayload
 		{
 			var statusInfo = statusBytes.Length == 0 ? null : Encoding.UTF8.GetString(statusBytes);
 
-			if (affectedRowCount == 0 && lastInsertId == 0 && warningCount == 0 && statusInfo is null && newSchema is null)
+			if (affectedRowCount == 0 && lastInsertId == 0 && warningCount == 0 && statusInfo is null)
 			{
 				if (serverStatus == ServerStatus.AutoCommit)
 					return s_autoCommitOk;
@@ -117,7 +134,7 @@ internal sealed class OkPayload
 					return s_autoCommitSessionStateChangedOk;
 			}
 
-			return new OkPayload(affectedRowCount, lastInsertId, serverStatus, warningCount, statusInfo, newSchema);
+			return new OkPayload(affectedRowCount, lastInsertId, serverStatus, warningCount, statusInfo);
 		}
 		else
 		{
@@ -125,16 +142,15 @@ internal sealed class OkPayload
 		}
 	}
 
-	private OkPayload(ulong affectedRowCount, ulong lastInsertId, ServerStatus serverStatus, int warningCount, string? statusInfo, string? newSchema)
+	private OkPayload(ulong affectedRowCount, ulong lastInsertId, ServerStatus serverStatus, int warningCount, string? statusInfo)
 	{
 		AffectedRowCount = affectedRowCount;
 		LastInsertId = lastInsertId;
 		ServerStatus = serverStatus;
 		WarningCount = warningCount;
 		StatusInfo = statusInfo;
-		NewSchema = newSchema;
 	}
 
-	private static readonly OkPayload s_autoCommitOk = new(0, 0, ServerStatus.AutoCommit, 0, null, null);
-	private static readonly OkPayload s_autoCommitSessionStateChangedOk = new(0, 0, ServerStatus.AutoCommit | ServerStatus.SessionStateChanged, 0, null, null);
+	private static readonly OkPayload s_autoCommitOk = new(0, 0, ServerStatus.AutoCommit, 0, null);
+	private static readonly OkPayload s_autoCommitSessionStateChangedOk = new(0, 0, ServerStatus.AutoCommit | ServerStatus.SessionStateChanged, 0, null);
 }


### PR DESCRIPTION
For MariaDB since 15.1 (https://jira.mariadb.org/browse/MDEV-31609) session variables tracked (session_track_system_variables) are sent in initial OK_Packet. This PR permits to avoids  initial query SET NAMES command, since charset is really know, defaulting to server corresponding default collation.