### PR TITLE
Add ConnectionOpenedCallback

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -833,7 +833,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 			Log.IgnoringFailureInTryResetConnectionAsync(m_logger, ex, Id, "SocketException");
 		}
 
-		Conditions |= ~MySqlConnectionOpenedConditions.Reset;
+		Conditions &= ~MySqlConnectionOpenedConditions.Reset;
 		return false;
 	}
 

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -584,7 +584,10 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 				EnlistTransaction(System.Transactions.Transaction.Current);
 
 			if (ConnectionOpenedCallback is { } connectionOpenedCallback)
-				await connectionOpenedCallback(new(this, m_session.Conditions)).ConfigureAwait(false);
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				await connectionOpenedCallback(new(this, m_session.Conditions), cancellationToken).ConfigureAwait(false);
+			}
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -584,7 +584,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 				EnlistTransaction(System.Transactions.Transaction.Current);
 
 			if (ConnectionOpenedCallback is { } connectionOpenedCallback)
-				await connectionOpenedCallback(this, m_session.Conditions).ConfigureAwait(false);
+				await connectionOpenedCallback(new(this, m_session.Conditions)).ConfigureAwait(false);
 		}
 		catch (Exception ex) when (activity is { IsAllDataRequested: true })
 		{

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -551,6 +551,13 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 					ActivitySourceHelper.CopyTags(m_session!.ActivityTags, activity);
 					m_hasBeenOpened = true;
 					SetState(ConnectionState.Open);
+
+					if (ConnectionOpenedCallback is { } autoEnlistConnectionOpenedCallback)
+					{
+						cancellationToken.ThrowIfCancellationRequested();
+						await autoEnlistConnectionOpenedCallback(new(this, MySqlConnectionOpenedConditions.None), cancellationToken).ConfigureAwait(false);
+					}
+
 					return;
 				}
 			}

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -920,7 +920,11 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 
 			using var connection = CloneWith(csb.ConnectionString);
 			connection.m_connectionSettings = connectionSettings;
-			connection.ConnectionOpenedCallback = null; // clear the callback because the user doesn't need to execute any setup logic on this connection
+
+			// clear the callback because this is not intended to be a user-visible MySqlConnection that will execute setup logic; it's a
+			// non-pooled connection that will execute "KILL QUERY" then immediately be closed
+			connection.ConnectionOpenedCallback = null;
+
 			connection.Open();
 #if NET6_0_OR_GREATER
 			var killQuerySql = string.Create(CultureInfo.InvariantCulture, $"KILL QUERY {command.Connection!.ServerThread}");

--- a/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
+++ b/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
@@ -1,0 +1,31 @@
+namespace MySqlConnector;
+
+/// <summary>
+/// A callback that is invoked when a new <see cref="MySqlConnection"/> is opened.
+/// </summary>
+/// <param name="connection">The <see cref="MySqlConnection"/> that was opened.</param>
+/// <param name="conditions">Bitflags giving the conditions under which a connection was opened.</param>
+/// <returns>A <see cref="ValueTask"/> representing the result of the possibly-asynchronous operation.</returns>
+public delegate ValueTask MySqlConnectionOpenedCallback(MySqlConnection connection, MySqlConnectionOpenedConditions conditions);
+
+/// <summary>
+/// Bitflags giving the conditions under which a connection was opened.
+/// </summary>
+[Flags]
+public enum MySqlConnectionOpenedConditions
+{
+	/// <summary>
+	/// No specific conditions apply. This value may be used when an existing pooled connection is reused without being reset.
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// A new physical connection to a MySQL Server was opened. This value is mutually exclusive with <see cref="Reset"/>.
+	/// </summary>
+	New = 1,
+
+	/// <summary>
+	/// An existing pooled connection to a MySQL Server was reset. This value is mutually exclusive with <see cref="New"/>.
+	/// </summary>
+	Reset = 2,
+}

--- a/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
+++ b/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
@@ -3,10 +3,28 @@ namespace MySqlConnector;
 /// <summary>
 /// A callback that is invoked when a new <see cref="MySqlConnection"/> is opened.
 /// </summary>
-/// <param name="connection">The <see cref="MySqlConnection"/> that was opened.</param>
-/// <param name="conditions">Bitflags giving the conditions under which a connection was opened.</param>
+/// <param name="data">A <see cref="MySqlConnectionOpenedData"/> giving information about the connection being opened.</param>
 /// <returns>A <see cref="ValueTask"/> representing the result of the possibly-asynchronous operation.</returns>
-public delegate ValueTask MySqlConnectionOpenedCallback(MySqlConnection connection, MySqlConnectionOpenedConditions conditions);
+public delegate ValueTask MySqlConnectionOpenedCallback(MySqlConnectionOpenedData data);
+
+public sealed class MySqlConnectionOpenedData
+{
+	/// <summary>
+	/// The <see cref="MySqlConnection"/> that was opened.
+	/// </summary>
+	public MySqlConnection Connection { get; }
+
+	/// <summary>
+	/// Bitflags giving the conditions under which a connection was opened.
+	/// </summary>
+	public MySqlConnectionOpenedConditions Conditions { get; }
+
+	internal MySqlConnectionOpenedData(MySqlConnection connection, MySqlConnectionOpenedConditions conditions)
+	{
+		Connection = connection;
+		Conditions = conditions;
+	}
+}
 
 /// <summary>
 /// Bitflags giving the conditions under which a connection was opened.

--- a/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
+++ b/src/MySqlConnector/MySqlConnectionOpenedCallback.cs
@@ -3,47 +3,7 @@ namespace MySqlConnector;
 /// <summary>
 /// A callback that is invoked when a new <see cref="MySqlConnection"/> is opened.
 /// </summary>
-/// <param name="data">A <see cref="MySqlConnectionOpenedData"/> giving information about the connection being opened.</param>
+/// <param name="context">A <see cref="MySqlConnectionOpenedContext"/> giving information about the connection being opened.</param>
+/// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to cancel the asynchronous operation.</param>
 /// <returns>A <see cref="ValueTask"/> representing the result of the possibly-asynchronous operation.</returns>
-public delegate ValueTask MySqlConnectionOpenedCallback(MySqlConnectionOpenedData data);
-
-public sealed class MySqlConnectionOpenedData
-{
-	/// <summary>
-	/// The <see cref="MySqlConnection"/> that was opened.
-	/// </summary>
-	public MySqlConnection Connection { get; }
-
-	/// <summary>
-	/// Bitflags giving the conditions under which a connection was opened.
-	/// </summary>
-	public MySqlConnectionOpenedConditions Conditions { get; }
-
-	internal MySqlConnectionOpenedData(MySqlConnection connection, MySqlConnectionOpenedConditions conditions)
-	{
-		Connection = connection;
-		Conditions = conditions;
-	}
-}
-
-/// <summary>
-/// Bitflags giving the conditions under which a connection was opened.
-/// </summary>
-[Flags]
-public enum MySqlConnectionOpenedConditions
-{
-	/// <summary>
-	/// No specific conditions apply. This value may be used when an existing pooled connection is reused without being reset.
-	/// </summary>
-	None = 0,
-
-	/// <summary>
-	/// A new physical connection to a MySQL Server was opened. This value is mutually exclusive with <see cref="Reset"/>.
-	/// </summary>
-	New = 1,
-
-	/// <summary>
-	/// An existing pooled connection to a MySQL Server was reset. This value is mutually exclusive with <see cref="New"/>.
-	/// </summary>
-	Reset = 2,
-}
+public delegate ValueTask MySqlConnectionOpenedCallback(MySqlConnectionOpenedContext context, CancellationToken cancellationToken);

--- a/src/MySqlConnector/MySqlConnectionOpenedConditions.cs
+++ b/src/MySqlConnector/MySqlConnectionOpenedConditions.cs
@@ -1,0 +1,23 @@
+﻿namespace MySqlConnector;
+
+/// <summary>
+/// Bitflags giving the conditions under which a connection was opened.
+/// </summary>
+[Flags]
+public enum MySqlConnectionOpenedConditions
+{
+	/// <summary>
+	/// No specific conditions apply. This value may be used when an existing pooled connection is reused without being reset.
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	/// A new physical connection to a MySQL Server was opened. This value is mutually exclusive with <see cref="Reset"/>.
+	/// </summary>
+	New = 1,
+
+	/// <summary>
+	/// An existing pooled connection to a MySQL Server was reset. This value is mutually exclusive with <see cref="New"/>.
+	/// </summary>
+	Reset = 2,
+}

--- a/src/MySqlConnector/MySqlConnectionOpenedContext.cs
+++ b/src/MySqlConnector/MySqlConnectionOpenedContext.cs
@@ -1,0 +1,23 @@
+namespace MySqlConnector;
+
+/// <summary>
+/// Contains information passed to <see cref="MySqlConnectionOpenedCallback"/> when a new <see cref="MySqlConnection"/> is opened.
+/// </summary>
+public sealed class MySqlConnectionOpenedContext
+{
+	/// <summary>
+	/// The <see cref="MySqlConnection"/> that was opened.
+	/// </summary>
+	public MySqlConnection Connection { get; }
+
+	/// <summary>
+	/// Bitflags giving the conditions under which a connection was opened.
+	/// </summary>
+	public MySqlConnectionOpenedConditions Conditions { get; }
+
+	internal MySqlConnectionOpenedContext(MySqlConnection connection, MySqlConnectionOpenedConditions conditions)
+	{
+		Connection = connection;
+		Conditions = conditions;
+	}
+}

--- a/src/MySqlConnector/MySqlDataSource.cs
+++ b/src/MySqlConnector/MySqlDataSource.cs
@@ -19,7 +19,7 @@ public sealed class MySqlDataSource : DbDataSource
 	/// <param name="connectionString">The connection string for the MySQL Server. This parameter is required.</param>
 	/// <exception cref="ArgumentNullException">Thrown if <paramref name="connectionString"/> is <c>null</c>.</exception>
 	public MySqlDataSource(string connectionString)
-		: this(connectionString ?? throw new ArgumentNullException(nameof(connectionString)), MySqlConnectorLoggingConfiguration.NullConfiguration, null, null, null, null, default, default, default)
+		: this(connectionString ?? throw new ArgumentNullException(nameof(connectionString)), MySqlConnectorLoggingConfiguration.NullConfiguration, null, null, null, null, default, default, default, default)
 	{
 	}
 
@@ -31,7 +31,8 @@ public sealed class MySqlDataSource : DbDataSource
 		Func<MySqlProvidePasswordContext, CancellationToken, ValueTask<string>>? periodicPasswordProvider,
 		TimeSpan periodicPasswordProviderSuccessRefreshInterval,
 		TimeSpan periodicPasswordProviderFailureRefreshInterval,
-		ZstandardPlugin? zstandardPlugin)
+		ZstandardPlugin? zstandardPlugin,
+		MySqlConnectionOpenedCallback? connectionOpenedCallback)
 	{
 		m_connectionString = connectionString;
 		LoggingConfiguration = loggingConfiguration;
@@ -40,6 +41,7 @@ public sealed class MySqlDataSource : DbDataSource
 		m_remoteCertificateValidationCallback = remoteCertificateValidationCallback;
 		m_logger = loggingConfiguration.DataSourceLogger;
 		m_zstandardPlugin = zstandardPlugin;
+		m_connectionOpenedCallback = connectionOpenedCallback;
 
 		Pool = ConnectionPool.CreatePool(m_connectionString, LoggingConfiguration, name);
 		m_id = Interlocked.Increment(ref s_lastId);
@@ -142,6 +144,7 @@ public sealed class MySqlDataSource : DbDataSource
 			ProvideClientCertificatesCallback = m_clientCertificatesCallback,
 			ProvidePasswordCallback = m_providePasswordCallback,
 			RemoteCertificateValidationCallback = m_remoteCertificateValidationCallback,
+			ConnectionOpenedCallback = m_connectionOpenedCallback,
 		};
 	}
 
@@ -225,6 +228,7 @@ public sealed class MySqlDataSource : DbDataSource
 	private readonly TimeSpan m_periodicPasswordProviderSuccessRefreshInterval;
 	private readonly TimeSpan m_periodicPasswordProviderFailureRefreshInterval;
 	private readonly ZstandardPlugin? m_zstandardPlugin;
+	private readonly MySqlConnectionOpenedCallback? m_connectionOpenedCallback;
 	private readonly MySqlProvidePasswordContext? m_providePasswordContext;
 	private readonly CancellationTokenSource? m_passwordProviderTimerCancellationTokenSource;
 	private readonly Timer? m_passwordProviderTimer;

--- a/src/MySqlConnector/MySqlDataSourceBuilder.cs
+++ b/src/MySqlConnector/MySqlDataSourceBuilder.cs
@@ -89,6 +89,22 @@ public sealed class MySqlDataSourceBuilder
 		return this;
 	}
 
+	public MySqlDataSourceBuilder UseConnectionOpenedCallback(MySqlConnectionOpenedCallback callback)
+	{
+		m_connectionOpenedCallback = callback;
+		return this;
+	}
+
+	public MySqlDataSourceBuilder UseConnectionOpenedCallback(Action<MySqlConnection, MySqlConnectionOpenedConditions> callback)
+	{
+		m_connectionOpenedCallback = (connection, conditions) =>
+		{
+			callback(connection, conditions);
+			return default;
+		};
+		return this;
+	}
+
 	/// <summary>
 	/// Builds a <see cref="MySqlDataSource"/> which is ready for use.
 	/// </summary>
@@ -104,7 +120,8 @@ public sealed class MySqlDataSourceBuilder
 			m_periodicPasswordProvider,
 			m_periodicPasswordProviderSuccessRefreshInterval,
 			m_periodicPasswordProviderFailureRefreshInterval,
-			ZstandardPlugin
+			ZstandardPlugin,
+			m_connectionOpenedCallback
 			);
 	}
 
@@ -122,4 +139,5 @@ public sealed class MySqlDataSourceBuilder
 	private Func<MySqlProvidePasswordContext, CancellationToken, ValueTask<string>>? m_periodicPasswordProvider;
 	private TimeSpan m_periodicPasswordProviderSuccessRefreshInterval;
 	private TimeSpan m_periodicPasswordProviderFailureRefreshInterval;
+	private MySqlConnectionOpenedCallback? m_connectionOpenedCallback;
 }

--- a/src/MySqlConnector/MySqlDataSourceBuilder.cs
+++ b/src/MySqlConnector/MySqlDataSourceBuilder.cs
@@ -95,11 +95,11 @@ public sealed class MySqlDataSourceBuilder
 		return this;
 	}
 
-	public MySqlDataSourceBuilder UseConnectionOpenedCallback(Action<MySqlConnection, MySqlConnectionOpenedConditions> callback)
+	public MySqlDataSourceBuilder UseConnectionOpenedCallback(Action<MySqlConnectionOpenedData> callback)
 	{
-		m_connectionOpenedCallback = (connection, conditions) =>
+		m_connectionOpenedCallback = data =>
 		{
-			callback(connection, conditions);
+			callback(data);
 			return default;
 		};
 		return this;

--- a/src/MySqlConnector/MySqlDataSourceBuilder.cs
+++ b/src/MySqlConnector/MySqlDataSourceBuilder.cs
@@ -89,19 +89,14 @@ public sealed class MySqlDataSourceBuilder
 		return this;
 	}
 
+	/// <summary>
+	/// Adds a callback that is invoked when a new <see cref="MySqlConnection"/> is opened.
+	/// </summary>
+	/// <param name="callback">The callback to invoke.</param>
+	/// <returns>This builder, so that method calls can be chained.</returns>
 	public MySqlDataSourceBuilder UseConnectionOpenedCallback(MySqlConnectionOpenedCallback callback)
 	{
-		m_connectionOpenedCallback = callback;
-		return this;
-	}
-
-	public MySqlDataSourceBuilder UseConnectionOpenedCallback(Action<MySqlConnectionOpenedData> callback)
-	{
-		m_connectionOpenedCallback = data =>
-		{
-			callback(data);
-			return default;
-		};
+		m_connectionOpenedCallback += callback;
 		return this;
 	}
 

--- a/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
@@ -48,10 +48,10 @@ public class ConnectionOpenedCallbackTests : IDisposable
 	public void SyncCallbackIsInvoked()
 	{
 		var dataSource = new MySqlDataSourceBuilder(m_csb.ConnectionString)
-			.UseConnectionOpenedCallback((conn, cond) =>
+			.UseConnectionOpenedCallback(data =>
 			{
 				m_connectionOpenedCount++;
-				m_connectionOpenedConditions = cond;
+				m_connectionOpenedConditions = data.Conditions;
 			})
 			.Build();
 		using (var connection = dataSource.CreateConnection())
@@ -146,10 +146,10 @@ public class ConnectionOpenedCallbackTests : IDisposable
 		}
 	}
 
-	private ValueTask OnConnectionOpenedAsync(MySqlConnection connection, MySqlConnectionOpenedConditions conditions)
+	private ValueTask OnConnectionOpenedAsync(MySqlConnectionOpenedData data)
 	{
 		m_connectionOpenedCount++;
-		m_connectionOpenedConditions = conditions;
+		m_connectionOpenedConditions = data.Conditions;
 		return default;
 	}
 

--- a/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MySqlConnector.Tests;
+
+public class ConnectionOpenedCallbackTests : IDisposable
+{
+	public ConnectionOpenedCallbackTests()
+	{
+		m_server = new();
+		m_server.Start();
+
+		m_csb = new MySqlConnectionStringBuilder()
+		{
+			Server = "localhost",
+			Port = (uint) m_server.Port,
+		};
+		m_dataSource = new MySqlDataSourceBuilder(m_csb.ConnectionString)
+			.UseConnectionOpenedCallback(OnConnectionOpenedAsync)
+			.Build();
+	}
+
+	public void Dispose()
+	{
+		m_dataSource.Dispose();
+		m_server.Stop();
+	}
+
+	[Fact]
+	public void CallbackIsInvoked()
+	{
+		using (var connection = m_dataSource.CreateConnection())
+		{
+			Assert.Equal(0, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.None, m_connectionOpenedConditions);
+
+			connection.Open();
+
+			Assert.Equal(1, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+	}
+
+	[Fact]
+	public void SyncCallbackIsInvoked()
+	{
+		var dataSource = new MySqlDataSourceBuilder(m_csb.ConnectionString)
+			.UseConnectionOpenedCallback((conn, cond) =>
+			{
+				m_connectionOpenedCount++;
+				m_connectionOpenedConditions = cond;
+			})
+			.Build();
+		using (var connection = dataSource.CreateConnection())
+		{
+			Assert.Equal(0, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.None, m_connectionOpenedConditions);
+
+			connection.Open();
+
+			Assert.Equal(1, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+	}
+
+	[Fact]
+	public void CallbackIsInvokedForPooledConnection()
+	{
+		using (var connection = m_dataSource.CreateConnection())
+		{
+			Assert.Equal(0, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.None, m_connectionOpenedConditions);
+
+			connection.Open();
+
+			Assert.Equal(1, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+
+		using (var connection = m_dataSource.OpenConnection())
+		{
+			Assert.Equal(2, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.Reset, m_connectionOpenedConditions);
+		}
+
+		using (var connection = m_dataSource.OpenConnection())
+		{
+			Assert.Equal(3, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.Reset, m_connectionOpenedConditions);
+		}
+	}
+
+	[Fact]
+	public void CallbackIsInvokedForNonPooledConnection()
+	{
+		var csb = new MySqlConnectionStringBuilder(m_csb.ConnectionString)
+		{
+			Pooling = false,
+		};
+		using var dataSource = new MySqlDataSourceBuilder(csb.ConnectionString)
+			.UseConnectionOpenedCallback(OnConnectionOpenedAsync)
+			.Build();
+
+		using (var connection = dataSource.OpenConnection())
+		{
+			Assert.Equal(1, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+
+		using (var connection = dataSource.OpenConnection())
+		{
+			Assert.Equal(2, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+
+		using (var connection = dataSource.OpenConnection())
+		{
+			Assert.Equal(3, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+	}
+
+	[Fact]
+	public void ConditionsForNonResetConnection()
+	{
+		var csb = new MySqlConnectionStringBuilder(m_csb.ConnectionString)
+		{
+			ConnectionReset = false,
+		};
+		using var dataSource = new MySqlDataSourceBuilder(csb.ConnectionString)
+			.UseConnectionOpenedCallback(OnConnectionOpenedAsync)
+			.Build();
+
+		using (var connection = dataSource.OpenConnection())
+		{
+			Assert.Equal(1, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
+		}
+		using (var connection = dataSource.OpenConnection())
+		{
+			Assert.Equal(2, m_connectionOpenedCount);
+			Assert.Equal(MySqlConnectionOpenedConditions.None, m_connectionOpenedConditions);
+		}
+	}
+
+	private ValueTask OnConnectionOpenedAsync(MySqlConnection connection, MySqlConnectionOpenedConditions conditions)
+	{
+		m_connectionOpenedCount++;
+		m_connectionOpenedConditions = conditions;
+		return default;
+	}
+
+	private readonly FakeMySqlServer m_server;
+	private readonly MySqlConnectionStringBuilder m_csb;
+	private readonly MySqlDataSource m_dataSource;
+
+	private int m_connectionOpenedCount;
+	private MySqlConnectionOpenedConditions m_connectionOpenedConditions;
+}

--- a/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
@@ -124,10 +124,10 @@ public class ConnectionOpenedCallbackTests : IDisposable
 		}
 	}
 
-	private ValueTask OnConnectionOpenedAsync(MySqlConnectionOpenedContext data, CancellationToken cancellationToken)
+	private ValueTask OnConnectionOpenedAsync(MySqlConnectionOpenedContext context, CancellationToken cancellationToken)
 	{
 		m_connectionOpenedCount++;
-		m_connectionOpenedConditions = data.Conditions;
+		m_connectionOpenedConditions = context.Conditions;
 		return default;
 	}
 

--- a/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
+++ b/tests/MySqlConnector.Tests/ConnectionOpenedCallbackTests.cs
@@ -45,28 +45,6 @@ public class ConnectionOpenedCallbackTests : IDisposable
 	}
 
 	[Fact]
-	public void SyncCallbackIsInvoked()
-	{
-		var dataSource = new MySqlDataSourceBuilder(m_csb.ConnectionString)
-			.UseConnectionOpenedCallback(data =>
-			{
-				m_connectionOpenedCount++;
-				m_connectionOpenedConditions = data.Conditions;
-			})
-			.Build();
-		using (var connection = dataSource.CreateConnection())
-		{
-			Assert.Equal(0, m_connectionOpenedCount);
-			Assert.Equal(MySqlConnectionOpenedConditions.None, m_connectionOpenedConditions);
-
-			connection.Open();
-
-			Assert.Equal(1, m_connectionOpenedCount);
-			Assert.Equal(MySqlConnectionOpenedConditions.New, m_connectionOpenedConditions);
-		}
-	}
-
-	[Fact]
 	public void CallbackIsInvokedForPooledConnection()
 	{
 		using (var connection = m_dataSource.CreateConnection())
@@ -146,7 +124,7 @@ public class ConnectionOpenedCallbackTests : IDisposable
 		}
 	}
 
-	private ValueTask OnConnectionOpenedAsync(MySqlConnectionOpenedData data)
+	private ValueTask OnConnectionOpenedAsync(MySqlConnectionOpenedContext data, CancellationToken cancellationToken)
 	{
 		m_connectionOpenedCount++;
 		m_connectionOpenedConditions = data.Conditions;

--- a/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
+++ b/tests/MySqlConnector.Tests/MySqlConnector.Tests.csproj
@@ -47,7 +47,7 @@
 
   <ItemGroup Condition=" '$(Configuration)' == 'MySqlData' ">
     <PackageReference Include="MySql.Data" />
-    <Compile Remove="ByteBufferWriterTests.cs;CachedProcedureTests.cs;CancellationTests.cs;ColumnCountPayloadTests.cs;ColumnReaderTests.cs;ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;LoadBalancerTests.cs;MySqlConnectionTests.cs;MySqlDecimalTests.cs;MySqlExceptionTests.cs;MySqlParameterAppendBinaryTests.cs;MySqlParameterCollectionNameToIndexTests.cs;NormalizeTests.cs;ServerVersionTests.cs;StatementPreparerTests.cs;TypeMapperTests.cs;UtilityTests.cs" />
+    <Compile Remove="ByteBufferWriterTests.cs;CachedProcedureTests.cs;CancellationTests.cs;ColumnCountPayloadTests.cs;ColumnReaderTests.cs;ConnectionOpenedCallbackTests.cs;ConnectionTests.cs;FakeMySqlServer.cs;FakeMySqlServerConnection.cs;LoadBalancerTests.cs;MySqlConnectionTests.cs;MySqlDecimalTests.cs;MySqlExceptionTests.cs;MySqlParameterAppendBinaryTests.cs;MySqlParameterCollectionNameToIndexTests.cs;NormalizeTests.cs;ServerVersionTests.cs;StatementPreparerTests.cs;TypeMapperTests.cs;UtilityTests.cs" />
     <Compile Remove="Metrics\*.cs" />
     <Using Include="MySql.Data.MySqlClient" />
     <Using Include="MySql.Data.Types" />


### PR DESCRIPTION
Fixes #1508.

This differs from the existing `StateChanged` event in that:

- it supports an async callback
- it's only invoked when a connection is opened
- it provides information about new vs existing and whether the connection was reset

Opening for API review. Needs tests before it can be merged.