### PR TITLE
Add config for enriching activity with read-result-set-header

### DIFF
--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -147,6 +147,7 @@ internal sealed class ConnectionSettings
 		UseAffectedRows = csb.UseAffectedRows;
 		UseCompression = csb.UseCompression;
 		UseXaTransactions = csb.UseXaTransactions;
+		EnrichActivityWithReadResultSetHeader = csb.EnrichActivityWithReadResultSetHeader;
 
 		static int ToSigned(uint value) => value >= int.MaxValue ? int.MaxValue : (int) value;
 	}
@@ -245,6 +246,7 @@ internal sealed class ConnectionSettings
 	public bool UseAffectedRows { get; }
 	public bool UseCompression { get; }
 	public bool UseXaTransactions { get; }
+	public bool EnrichActivityWithReadResultSetHeader { get; }
 
 	public byte[]? ConnectionAttributes { get; set; }
 

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -166,7 +166,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 						ContainsCommandParameters = true;
 					WarningCount = 0;
 					State = ResultSetState.ReadResultSetHeader;
-					if (DataReader.Activity is { IsAllDataRequested: true })
+					if (DataReader.Activity is { IsAllDataRequested: true } && Connection.EnrichActivityWithReadResultSetHeader)
 						DataReader.Activity.AddEvent(new ActivityEvent("read-result-set-header"));
 					break;
 				}

--- a/src/MySqlConnector/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlConnection.cs
@@ -1023,6 +1023,7 @@ public sealed class MySqlConnection : DbConnection, ICloneable
 	internal bool NoBackslashEscapes => GetInitializedConnectionSettings().NoBackslashEscapes;
 	internal bool TreatTinyAsBoolean => GetInitializedConnectionSettings().TreatTinyAsBoolean;
 	internal IOBehavior AsyncIOBehavior => GetConnectionSettings().ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
+	internal bool EnrichActivityWithReadResultSetHeader => GetInitializedConnectionSettings().EnrichActivityWithReadResultSetHeader;
 
 	// Defaults to IOBehavior.Synchronous if the connection hasn't been opened yet; only use if it's a no-op for a closed connection.
 	internal IOBehavior SimpleAsyncIOBehavior => (m_connectionSettings?.ForceSynchronous is true) ? IOBehavior.Synchronous : IOBehavior.Asynchronous;

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -800,6 +800,19 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 		set => MySqlConnectionStringOption.UseXaTransactions.SetValue(this, value);
 	}
 
+	/// <summary>
+	/// Enrich Activity with read-result-set-header
+	/// </summary>
+	[Category("Other")]
+	[DefaultValue(true)]
+	[Description("Enriches Activity with read-result-set-header events.")]
+	[DisplayName("Enrich Activity with read-result-set-header")]
+	public bool EnrichActivityWithReadResultSetHeader
+	{
+		get => MySqlConnectionStringOption.EnrichActivityWithReadResultSetHeader.GetValue(this);
+		set => MySqlConnectionStringOption.EnrichActivityWithReadResultSetHeader.SetValue(this, value);
+	}
+
 	// Other Methods
 
 	/// <summary>
@@ -958,6 +971,7 @@ internal abstract partial class MySqlConnectionStringOption
 	public static readonly MySqlConnectionStringValueOption<bool> UseAffectedRows;
 	public static readonly MySqlConnectionStringValueOption<bool> UseCompression;
 	public static readonly MySqlConnectionStringValueOption<bool> UseXaTransactions;
+	public static readonly MySqlConnectionStringValueOption<bool> EnrichActivityWithReadResultSetHeader;
 
 	public static MySqlConnectionStringOption? TryGetOptionForKey(string key) =>
 		s_options.TryGetValue(key, out var option) ? option : null;
@@ -1261,6 +1275,10 @@ internal abstract partial class MySqlConnectionStringOption
 
 		AddOption(options, UseXaTransactions = new(
 			keys: ["Use XA Transactions", "UseXaTransactions"],
+			defaultValue: true));
+
+		AddOption(options, EnrichActivityWithReadResultSetHeader = new(
+			keys: ["Enrich Activity with ReadResultSetHeader", "EnrichActivityWithReadResultSetHeader"],
 			defaultValue: true));
 #pragma warning restore SA1118 // Parameter should not span multiple lines
 


### PR DESCRIPTION
Thread: https://github.com/mysql-net/MySqlConnector/issues/1524
Inspiration here: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/416/files

First PR, as far as I can tell the only configuration is done via the connection string to I kept using that pattern.
All feedback is appreciated.