### PR TITLE
Detect connections to AWS RDS Proxy and update Server ID on connection

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1898,6 +1898,13 @@ internal sealed partial class ServerSession : IServerCapabilities
 				HostName.EndsWith(".mysql.database.chinacloudapi.cn", StringComparison.OrdinalIgnoreCase);
 		}
 
+		// detect AWS RDS Proxy, if hostname like <name>.proxy-<random-chars>.<region>.rds.amazonaws.com
+		if (HostName.EndsWith(".rds.amazonaws.com", StringComparison.OrdinalIgnoreCase) &&
+			HostName.Contains(".proxy-", StringComparison.OrdinalIgnoreCase))
+		{
+			return true;
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
Adds detection of AWS RDS Proxy upon connecting and triggers fetching the actual Connection Id.

This allows query cancellation to send the correct id when running `KILL QUERY x` commands

Fixes #1581 