### PR TITLE
Support catching by DbException and checking it's ErrorCode

### DIFF
--- a/src/MySqlConnector/MySqlException.cs
+++ b/src/MySqlConnector/MySqlException.cs
@@ -113,6 +113,7 @@ public sealed class MySqlException : DbException
 		ErrorCode = errorCode;
 		Number = (int) errorCode;
 		SqlState = sqlState;
+		HResult = (int) errorCode;
 	}
 
 	internal static MySqlException CreateForTimeout() => CreateForTimeout(null);

--- a/tests/MySqlConnector.Tests/MySqlExceptionTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlExceptionTests.cs
@@ -9,4 +9,13 @@ public class MySqlExceptionTests
 		Assert.Equal(1002, exception.Data["Server Error Code"]);
 		Assert.Equal("two", exception.Data["SqlState"]);
 	}
+
+	[Fact]
+	public void DbException()
+	{
+		var exception = new MySqlException(MySqlErrorCode.CommandTimeoutExpired, "The Command Timeout expired before the operation completed.");
+		var dbException = (DbException) exception;
+		Assert.Equal((int)MySqlErrorCode.CommandTimeoutExpired, dbException.ErrorCode);
+		Assert.Equal((int)MySqlErrorCode.CommandTimeoutExpired, exception.Number);
+	}
 }


### PR DESCRIPTION
Hoping to be able to just catch the agnostic `DbException` class and get the plain integer ErrorCode of what was thrown. As `MySqlException` is already hiding the underlying `int ErrorCode` with the strongly typed `MySqlErrorCode` enum. Thankfully this can still be supported because the ErrorCode field as defined in `ExternalException` (parent of DbException) just references the HResult field in it's default implementation of ErrorCode.

```
public virtual int ErrorCode => HResult;
```

With that 1 line change to constructor a DbException (or anything higher) can be caught and at least get some useful info about what failed (still need to consult MySqlErrorCodes obviously). My real intention is to keep the mysql client implementation references as minimal as possible, so primarily just using DbProviderFactory, DbConnection, DbCommand, DbTransaction, etc. Truly only referencing MySqlConnector when setting up the DbProvider and parsing ConnectionString. With current implemtnation it is sort of impossible to get anything useful out of DbException unless I want to match exact string messages (yuch), but maybe that will be the only final recourse.

Otherwise all MySqlException objects always have the same ErrorCode (when cast upwards) because its never changed from the default value `HResults.E_FAIL`, -2147467259.

I don't know the full implications of owning the `HResult` field, since that comes all the way from plain `Exception` class itself. Which maybe is part of the reason this wasn't done already? Or some legacy behavior which rewquired never changing HResult in thrown Exceptions?

Included small test which showing `DbException.ErrorCode` now matching the same backing integral value as `MySqlException.Number`.