### PR TITLE
Remove nonexistent properties from exception message

### DIFF
--- a/src/MySqlConnector/MySqlBulkLoader.cs
+++ b/src/MySqlConnector/MySqlBulkLoader.cs
@@ -183,7 +183,7 @@ public sealed class MySqlBulkLoader
 		else
 		{
 			if (!Local)
-				throw new InvalidOperationException("Local must be true to use SourceStream, SourceDataTable, or SourceDataReader.");
+				throw new InvalidOperationException("Local must be true to use SourceStream.");
 
 			FileName = GenerateSourceFileName();
 			AddSource(FileName, Source!);


### PR DESCRIPTION
This was introduced in dd853ff30cd7a894d89e473e97506c5a11cff20a but the named properties were never added.