### PR TITLE
Ensure correct foreign key query: using join with table name

### DIFF
--- a/src/MySqlConnector/Core/SchemaProvider.cs
+++ b/src/MySqlConnector/Core/SchemaProvider.cs
@@ -446,15 +446,14 @@ internal sealed partial class SchemaProvider(MySqlConnection connection)
 			command.CommandText = """
 				SELECT rc.constraint_catalog, rc.constraint_schema, rc.constraint_name,
 					kcu.table_catalog, kcu.table_schema,
-					rc.table_name, rc.match_option, rc.update_rule, rc.delete_rule, 
-					NULL as referenced_table_catalog, kcu.referenced_table_schema, rc.referenced_table_name 
+					rc.table_name, rc.match_option, rc.update_rule, rc.delete_rule,
+					NULL as referenced_table_catalog, kcu.referenced_table_schema, rc.referenced_table_name
 				FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
-					LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ON 
-					(
-						(kcu.constraint_catalog = rc.constraint_catalog OR (kcu.constraint_catalog IS NULL AND rc.constraint_catalog IS NULL)) AND
-						(kcu.constraint_schema = rc.constraint_schema OR (kcu.constraint_schema IS NULL AND rc.constraint_schema IS NULL)) AND
-						(kcu.constraint_name = rc.constraint_name OR (kcu.constraint_name IS NULL AND rc.constraint_name IS NULL))
-					)
+				LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu
+					ON kcu.constraint_catalog = rc.constraint_catalog
+					AND kcu.constraint_schema = rc.constraint_schema
+					AND kcu.table_name = rc.table_name
+					AND kcu.constraint_name = rc.constraint_name
 				WHERE kcu.ORDINAL_POSITION = 1
 				""";
 
@@ -481,9 +480,9 @@ internal sealed partial class SchemaProvider(MySqlConnection connection)
 			command.CommandText = """
 				SELECT null AS INDEX_CATALOG, INDEX_SCHEMA,
 					INDEX_NAME, TABLE_NAME,
-					!NON_UNIQUE as `UNIQUE`, 
+					!NON_UNIQUE as `UNIQUE`,
 					INDEX_NAME='PRIMARY' as `PRIMARY`,
-					INDEX_TYPE as TYPE, COMMENT 
+					INDEX_TYPE as TYPE, COMMENT
 				FROM INFORMATION_SCHEMA.STATISTICS
 				WHERE SEQ_IN_INDEX=1
 				""";


### PR DESCRIPTION
The main reason is MariaDB 12.1 change https://jira.mariadb.org/browse/MDEV-28933

other language driver always use this : 
*  [java mysql](https://github.com/mysql/mysql-connector-j/blob/d680767849154c8e136dfc3d8a0ae4d9fefd1fb7/src/main/user-impl/java/com/mysql/cj/jdbc/DatabaseMetaDataInformationSchema.java#L65)
*  [java mariadb](https://github.com/mariadb-corporation/mariadb-connector-j/blob/5222bfb7b30f8bcb71447b03d86843e872d19ec2/src/main/java/org/mariadb/jdbc/DatabaseMetaData.java#L1252), * [mysql ODBC](https://github.com/mysql/mysql-connector-odbc/blob/3d85084e3f70b4869e64a5d0b76447011232042b/driver/catalog.cc#L1642)
* ...