### PR TITLE
Document available server features for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,16 @@ Otherwise, set the following options appropriately:
   * `TlsFingerprintValidation`: server provides a hash of the TLS certificate fingerprint in the first OK packet
   * `UnixDomainSocket`: server is accessible via a Unix domain socket
   * `UuidToBin`: server supports `UUID_TO_BIN` (MySQL 8.0 and later)
+  * `CancelSleepSuccessfully`: A `SLEEP` command produces a result set when it is cancelled, not an error payload.
+  * `GlobalLog`: The server `general_log` is global.
+  * `KnownCertificateAuthority`: The certificates used by the database server are trusted by the client.
+  * `ParsecAuthentication`: Server supports the 'parsec' authentication plugin.
+  * `QueryAttributes`: Server supports query attributes (MySQL 8.4 and later).
+  * `ResetConnection`: Server supports the `COM_RESET_CONNECTION` command.
+  * `StreamingResults`: The MySQL server can start streaming rows back as soon as they are available, as opposed to buffering the entire result set in memory.
+  * `Vector`: Server supports the `VECTOR` SQL type.
+  * `VectorType`: Server has a dedicated type on the wire for `VECTOR`.
+  * `ZeroDateTime`: Server does not support a zero `DATE` or `DATETIME` value.
 
 ## Running Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Otherwise, set the following options appropriately:
   * `UnixDomainSocket`: server is accessible via a Unix domain socket
   * `UuidToBin`: server supports `UUID_TO_BIN` (MySQL 8.0 and later)
   * `CancelSleepSuccessfully`: A `SLEEP` command produces a result set when it is cancelled, not an error payload.
-  * `GlobalLog`: The server `general_log` is global.
+  * `GlobalLog`: Server supports `set global general_log`.
   * `KnownCertificateAuthority`: The certificates used by the database server are trusted by the client.
   * `ParsecAuthentication`: Server supports the 'parsec' authentication plugin.
   * `QueryAttributes`: Server supports query attributes (MySQL 8.4 and later).

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,7 @@ Otherwise, set the following options appropriately:
   * `StreamingResults`: The MySQL server can start streaming rows back as soon as they are available, as opposed to buffering the entire result set in memory.
   * `Vector`: Server supports the `VECTOR` SQL type.
   * `VectorType`: Server has a dedicated type on the wire for `VECTOR`.
-  * `ZeroDateTime`: Server does not support a zero `DATE` or `DATETIME` value.
+  * `ZeroDateTime`: Server allows `0000-00-00` to be stored as `DATE` or `DATETIME`; i.e., it does _not_ have the `NO_ZERO_DATE` [SQL mode](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_no_zero_date) or strict mode enabled.
 
 ## Running Tests
 


### PR DESCRIPTION
There were a handful of test server features that weren't documented in the README. Since some of these are quite useful (e.g. lack of `VECTOR` datatype) for testing with older versions, documenting them would be beneficial.

I'd welcome feedback on the descriptions of `GlobalLog`, `KnownCertificateAuthority` and `ZeroDateTime`. I mostly deduced these from the git log as well as seeing how they were used in the test cases.