### PR TITLE
[Experimental] Turn off CRL checks

### DIFF
--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1575,7 +1575,11 @@ internal sealed partial class ServerSession : IServerCapabilities
 				ChainPolicy =
 				{
 					RevocationMode = X509RevocationMode.NoCheck,
-					VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority,
+					VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority |
+					                    X509VerificationFlags.IgnoreEndRevocationUnknown |
+					                    X509VerificationFlags.IgnoreCtlSignerRevocationUnknown |
+					                    X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
+					                    X509VerificationFlags.IgnoreRootRevocationUnknown,
 				},
 			};
 
@@ -1738,6 +1742,15 @@ internal sealed partial class ServerSession : IServerCapabilities
 			TargetHost = HostName,
 			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Offline : X509RevocationMode.NoCheck,
 		};
+
+#if NET7_0_OR_GREATER
+		clientAuthenticationOptions.CertificateChainPolicy ??= new();
+		clientAuthenticationOptions.CertificateChainPolicy.VerificationFlags =
+			X509VerificationFlags.IgnoreEndRevocationUnknown |
+			X509VerificationFlags.IgnoreCtlSignerRevocationUnknown |
+			X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
+			X509VerificationFlags.IgnoreRootRevocationUnknown;
+#endif
 
 #if NETCOREAPP3_0_OR_GREATER
 #pragma warning disable CA1416 // Validate platform compatibility

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1603,7 +1603,6 @@ internal sealed partial class ServerSession : IServerCapabilities
 					try
 					{
 						// load the certificate at this index; note that 'new X509Certificate' stops at the end of the first certificate it loads
-						Log.LoadingCaCertificate(m_logger, Id, index);
 #if NET9_0_OR_GREATER
 						var caCertificate = X509CertificateLoader.LoadCertificate(certificateBytes.AsSpan(index, (nextIndex == -1 ? certificateBytes.Length : nextIndex) - index));
 #elif NET5_0_OR_GREATER

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1635,6 +1635,25 @@ internal sealed partial class ServerSession : IServerCapabilities
 
 		bool ValidateRemoteCertificate(object rcbSender, X509Certificate? rcbCertificate, X509Chain? rcbChain, SslPolicyErrors rcbPolicyErrors)
 		{
+			if (rcbPolicyErrors != SslPolicyErrors.None && rcbChain != null)
+			{
+				var builder = new StringBuilder($"Found errors in remote certificate validation: {rcbPolicyErrors}");
+
+				for (var index = 0; index < rcbChain.ChainElements.Count; index++)
+				{
+					var element = rcbChain.ChainElements[index];
+					builder.AppendLine($"Element {index}: {element.Certificate.GetNameInfo(X509NameType.SimpleName, false)}");
+					builder.AppendLine("  Status:");
+
+					foreach (var status in element.ChainElementStatus)
+					{
+						builder.AppendLine($"  {status.Status}: {status.StatusInformation}");
+					}
+				}
+
+				Log.RemoteCertificateValidationTrace(m_logger, builder.ToString());
+			}
+
 			// if no CA verification is required, then we trust any remote certificate
 			if (cs.SslMode is MySqlSslMode.Preferred or MySqlSslMode.Required)
 				return true;

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1718,7 +1718,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 			EnabledSslProtocols = sslProtocols,
 			ClientCertificates = clientCertificates,
 			TargetHost = HostName,
-			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
+			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Offline : X509RevocationMode.NoCheck,
 		};
 
 #if NETCOREAPP3_0_OR_GREATER

--- a/src/MySqlConnector/Logging/Log.cs
+++ b/src/MySqlConnector/Logging/Log.cs
@@ -463,4 +463,7 @@ internal static partial class Log
 
 	[LoggerMessage(EventIds.ClearingPoolDueToDnsChanges, LogLevel.Information, "Pool {PoolId} clearing pool due to DNS changes")]
 	public static partial void ClearingPoolDueToDnsChanges(ILogger logger, int poolId);
+
+	[LoggerMessage(LogLevel.Trace, "{Message}")]
+	public static partial void RemoteCertificateValidationTrace(ILogger logger, string message);
 }


### PR DESCRIPTION
Here's what I tried locally. It just hacks in CRL-off without a connection string parameter. Please discard the first commit; it doesn't help. I've added extra logging to analyze what happens, which should probably be left out. The code works for VerifyFull, but I haven't tested mutual-TLS yet. Note that it requires .NET 7.0 or higher, so it should probably log a warning when used with netstandard.