### PR TITLE
MySqlBulkImport

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="MySql.Data" Version="9.7.0" />
     <PackageVersion Include="NLog" Version="4.7.15" />
@@ -27,6 +27,8 @@
     <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+	<PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+	<PackageVersion Include="Testcontainers.MySql" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="xunit.v3" Version="3.2.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-	<PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-	<PackageVersion Include="Testcontainers.MySql" Version="4.10.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MySqlConnector.slnx
+++ b/MySqlConnector.slnx
@@ -9,6 +9,7 @@
   <Project Path="src/MySqlConnector.Logging.NLog/MySqlConnector.Logging.NLog.csproj" />
   <Project Path="src/MySqlConnector.Logging.Serilog/MySqlConnector.Logging.Serilog.csproj" />
   <Project Path="src/MySqlConnector/MySqlConnector.csproj" />
+  <Project Path="tests/Benchmarks/Benchmarks.csproj" Id="c6978c2d-1d1b-430a-a78d-908d80d5a5e2" />
   <Project Path="tests/Conformance.Tests/Conformance.Tests.csproj" />
   <Project Path="tests/IntegrationTests/IntegrationTests.csproj" />
   <Project Path="tests/MySqlConnector.DependencyInjection.Tests/MySqlConnector.DependencyInjection.Tests.csproj" />

--- a/MySqlConnector.slnx
+++ b/MySqlConnector.slnx
@@ -9,7 +9,9 @@
   <Project Path="src/MySqlConnector.Logging.NLog/MySqlConnector.Logging.NLog.csproj" />
   <Project Path="src/MySqlConnector.Logging.Serilog/MySqlConnector.Logging.Serilog.csproj" />
   <Project Path="src/MySqlConnector/MySqlConnector.csproj" />
-  <Project Path="tests/Benchmarks/Benchmarks.csproj" Id="c6978c2d-1d1b-430a-a78d-908d80d5a5e2" />
+  <Project Path="tests/Benchmarks/Benchmarks.csproj" Id="c6978c2d-1d1b-430a-a78d-908d80d5a5e2">
+    <Build Solution="Debug|*" Project="false" />
+  </Project>
   <Project Path="tests/Conformance.Tests/Conformance.Tests.csproj" />
   <Project Path="tests/IntegrationTests/IntegrationTests.csproj" />
   <Project Path="tests/MySqlConnector.DependencyInjection.Tests/MySqlConnector.DependencyInjection.Tests.csproj" />

--- a/MySqlConnector.slnx
+++ b/MySqlConnector.slnx
@@ -9,9 +9,7 @@
   <Project Path="src/MySqlConnector.Logging.NLog/MySqlConnector.Logging.NLog.csproj" />
   <Project Path="src/MySqlConnector.Logging.Serilog/MySqlConnector.Logging.Serilog.csproj" />
   <Project Path="src/MySqlConnector/MySqlConnector.csproj" />
-  <Project Path="tests/Benchmarks/Benchmarks.csproj" Id="c6978c2d-1d1b-430a-a78d-908d80d5a5e2">
-    <Build Solution="Debug|*" Project="false" />
-  </Project>
+  <Project Path="tests/Benchmarks/Benchmarks.csproj" Id="c6978c2d-1d1b-430a-a78d-908d80d5a5e2" />
   <Project Path="tests/Conformance.Tests/Conformance.Tests.csproj" />
   <Project Path="tests/IntegrationTests/IntegrationTests.csproj" />
   <Project Path="tests/MySqlConnector.DependencyInjection.Tests/MySqlConnector.DependencyInjection.Tests.csproj" />

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -96,7 +96,7 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 								break;
 
 #if NET6_0_OR_GREATER
-							case MySqlBulkImport2 bulkImport:
+							case MySqlBulkImport bulkImport:
 								await bulkImport.SendDataReaderAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 								break;
 #endif

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -95,6 +95,12 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 								await bulkCopy.SendDataReaderAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
 								break;
 
+#if NET6_0_OR_GREATER
+							case MySqlBulkImport2 bulkImport:
+								await bulkImport.SendDataReaderAsync(ioBehavior, CancellationToken.None).ConfigureAwait(false);
+								break;
+#endif
+
 							default:
 								throw new InvalidOperationException($"Unsupported Source type: {source.GetType().Name}");
 						}

--- a/src/MySqlConnector/Helpers/ColumnMapperHelper.cs
+++ b/src/MySqlConnector/Helpers/ColumnMapperHelper.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+using MySqlConnector.Logging;
+using MySqlConnector.Protocol.Serialization;
+
+namespace MySqlConnector.Helpers;
+
+internal static class ColumnMapperHelper
+{
+	internal static async Task FillColumnMappingsAsync(
+		string tableName,
+		int fieldCount,
+		ILogger logger,
+		IOBehavior ioBehavior,
+		MySqlBulkLoader bulkLoader,
+		List<MySqlBulkCopyColumnMapping> externalColumnMappings,
+		MySqlConnection connection,
+		MySqlTransaction? transaction,
+		CancellationToken cancellationToken)
+	{
+		// merge column mappings with the destination schema
+		var columnMappings = new List<MySqlBulkCopyColumnMapping>(externalColumnMappings);
+		var addDefaultMappings = columnMappings.Count == 0;
+		using (var cmd = new MySqlCommand("select * from " + tableName + ";", connection, transaction))
+		using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly, ioBehavior, cancellationToken).ConfigureAwait(false))
+		{
+			var schema = reader.GetColumnSchema();
+			for (var i = 0; i < schema.Count; i++)
+			{
+				var destinationColumn = reader.GetName(i);
+				var dataTypeName = schema[i].DataTypeName;
+				if (dataTypeName == "BIT")
+				{
+					AddColumnMapping(logger, columnMappings, addDefaultMappings, i, destinationColumn, $"@`\uE002\bcol{i}`", $"%COL% = CAST(%VAR% AS UNSIGNED)");
+				}
+				else
+				{
+					var type = schema[i].DataType;
+					if (type == typeof(byte[]) ||
+						dataTypeName == "VECTOR" ||
+						(type == typeof(Guid) && (connection.GuidFormat is MySqlGuidFormat.Binary16 or MySqlGuidFormat.LittleEndianBinary16 or MySqlGuidFormat.TimeSwapBinary16)))
+					{
+						AddColumnMapping(logger, columnMappings, addDefaultMappings, i, destinationColumn, $"@`\uE002\bcol{i}`", $"%COL% = UNHEX(%VAR%)");
+					}
+					else if (addDefaultMappings)
+					{
+						if (schema[i].DataTypeName == "YEAR")
+						{
+							// the current code can't distinguish between 0 = 0000 and 0 = 2000
+							throw new NotSupportedException("'YEAR' columns are not supported by MySqlBulkCopy.");
+						}
+
+						Log.AddingDefaultColumnMapping(logger, i, destinationColumn);
+						columnMappings.Add(new(i, destinationColumn));
+					}
+				}
+			}
+		}
+
+		// set columns and expressions from the column mappings
+		for (var i = 0; i < fieldCount; i++)
+		{
+			var columnMapping = columnMappings.FirstOrDefault(x => x.SourceOrdinal == i);
+			if (columnMapping is null)
+			{
+				Log.IgnoringColumn(logger, i);
+				bulkLoader.Columns.Add("@`\uE002\bignore`");
+			}
+			else
+			{
+				if (columnMapping.DestinationColumn.Length == 0)
+					throw new InvalidOperationException($"MySqlBulkCopyColumnMapping.DestinationName is not set for SourceOrdinal {columnMapping.SourceOrdinal}");
+				if (columnMapping.DestinationColumn[0] == '@' && columnMapping.Expression is not null)
+					bulkLoader.Columns.Add(columnMapping.DestinationColumn);
+				else
+					bulkLoader.Columns.Add(QuoteIdentifier(columnMapping.DestinationColumn));
+				if (columnMapping.Expression is not null)
+					bulkLoader.Expressions.Add(columnMapping.Expression);
+			}
+		}
+
+		foreach (var columnMapping in columnMappings)
+		{
+			if (columnMapping.SourceOrdinal < 0 || columnMapping.SourceOrdinal >= fieldCount)
+				throw new InvalidOperationException($"SourceOrdinal {columnMapping.SourceOrdinal} is an invalid value");
+		}
+	}
+
+	private static void AddColumnMapping(
+		ILogger logger,
+		List<MySqlBulkCopyColumnMapping> columnMappings,
+		bool addDefaultMappings,
+		int destinationOrdinal,
+		string destinationColumn,
+		string variableName,
+		string expression)
+	{
+		expression = expression.Replace("%COL%", "`" + destinationColumn + "`").Replace("%VAR%", variableName);
+		var columnMapping = columnMappings.FirstOrDefault(x => destinationColumn.Equals(x.DestinationColumn, StringComparison.OrdinalIgnoreCase));
+		if (columnMapping is not null)
+		{
+			if (columnMapping.Expression is not null)
+			{
+				Log.ColumnMappingAlreadyHasExpression(logger, columnMapping.SourceOrdinal, destinationColumn, columnMapping.Expression);
+			}
+			else
+			{
+				Log.SettingExpressionToMapColumn(logger, columnMapping.SourceOrdinal, destinationColumn, expression);
+				columnMappings.Remove(columnMapping);
+				columnMappings.Add(new(columnMapping.SourceOrdinal, variableName, expression));
+			}
+		}
+		else if (addDefaultMappings)
+		{
+			Log.AddingDefaultColumnMapping(logger, destinationOrdinal, destinationColumn);
+			columnMappings.Add(new(destinationOrdinal, variableName, expression));
+		}
+	}
+
+	private static string QuoteIdentifier(string identifier) => "`" + identifier.Replace("`", "``") + "`";
+}

--- a/src/MySqlConnector/Helpers/ValueWriteHelper.cs
+++ b/src/MySqlConnector/Helpers/ValueWriteHelper.cs
@@ -1,0 +1,333 @@
+using System.Buffers.Text;
+using System.Globalization;
+using System.Numerics;
+using System.Text;
+using MySqlConnector.Utilities;
+
+namespace MySqlConnector.Helpers;
+
+internal class ValueWriteHelper
+{
+	private static readonly char[] s_specialCharacters = ['\t', '\\', '\n'];
+	private static readonly UTF8Encoding s_utf8Encoding = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+	public static bool WriteValue<T>(MySqlConnection connection, T value, ref int inputIndex, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
+	{
+		if (output.Length == 0)
+		{
+			bytesWritten = 0;
+			return false;
+		}
+
+		switch (value)
+		{
+			case null:
+			case DBNull dbNull:
+			{
+				return WriteNull(output, out bytesWritten);
+			}
+
+			case char charValue:
+			{
+				return WriteString(charValue.ToString(), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case byte byteValue:
+			{
+				return Utf8Formatter.TryFormat(byteValue, output, out bytesWritten);
+			}
+
+			case sbyte sbyteValue:
+			{
+				return Utf8Formatter.TryFormat(sbyteValue, output, out bytesWritten);
+			}
+
+			case short shortValue:
+			{
+				return Utf8Formatter.TryFormat(shortValue, output, out bytesWritten);
+			}
+
+			case ushort ushortValue:
+			{
+				return Utf8Formatter.TryFormat(ushortValue, output, out bytesWritten);
+			}
+
+			case int intValue:
+			{
+				return Utf8Formatter.TryFormat(intValue, output, out bytesWritten);
+			}
+
+			case uint uintValue:
+			{
+				return Utf8Formatter.TryFormat(uintValue, output, out bytesWritten);
+			}
+
+			case long longValue:
+			{
+				return Utf8Formatter.TryFormat(longValue, output, out bytesWritten);
+			}
+
+			case ulong ulongValue:
+			{
+				return Utf8Formatter.TryFormat(ulongValue, output, out bytesWritten);
+			}
+
+			case decimal decimalValue:
+			{
+				return Utf8Formatter.TryFormat(decimalValue, output, out bytesWritten);
+			}
+
+			case bool boolValue:
+			{
+				if (output.Length < 1)
+				{
+					bytesWritten = 0;
+					return false;
+				}
+				output[0] = boolValue ? (byte) '1' : (byte) '0';
+				bytesWritten = 1;
+				return true;
+			}
+
+			case float floatValue:
+			{
+				// NOTE: Utf8Formatter doesn't support "R"
+				return WriteString(floatValue.ToString("R", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case double doubleValue:
+			{
+				// NOTE: Utf8Formatter doesn't support "R"
+				return WriteString(doubleValue.ToString("R", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case MySqlDateTime mySqlDateTimeValue:
+			{
+				if (mySqlDateTimeValue.IsValidDateTime)
+					return WriteString(mySqlDateTimeValue.GetDateTime().ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+				else
+					return WriteString("0000-00-00", ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case DateTime dateTimeValue:
+			{
+				if (connection.DateTimeKind == DateTimeKind.Utc && dateTimeValue.Kind == DateTimeKind.Local)
+					throw new MySqlException("DateTime.Kind must not be Local when DateTimeKind setting is Utc");
+				else if (connection.DateTimeKind == DateTimeKind.Local && dateTimeValue.Kind == DateTimeKind.Utc)
+					throw new MySqlException("DateTime.Kind must not be Utc when DateTimeKind setting is Local");
+
+				return WriteString(dateTimeValue.ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case DateTimeOffset dateTimeOffsetValue:
+			{
+				// store as UTC as it will be read as such when deserialized from a timespan column
+				return WriteString(dateTimeOffsetValue.UtcDateTime.ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case string stringValue:
+			{
+				return WriteSubstring(stringValue, ref inputIndex, ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case byte[] byteArray:
+			{
+				return WriteBytes(byteArray.AsSpan(), ref inputIndex, output, out bytesWritten);
+			}
+
+			case ReadOnlyMemory<byte> memory:
+			{
+				return WriteBytes(memory.Span, ref inputIndex, output, out bytesWritten);
+			}
+
+			case ArraySegment<byte> arraySegment:
+			{
+				return WriteBytes(arraySegment.AsSpan(), ref inputIndex, output, out bytesWritten);
+			}
+
+			case Memory<byte> memory:
+			{
+				return WriteBytes(memory.Span, ref inputIndex, output, out bytesWritten);
+			}
+
+			case MySqlGeometry geometry:
+			{
+				return WriteBytes(geometry.ValueSpan, ref inputIndex, output, out bytesWritten);
+			}
+
+			case float[] floatArray:
+			{
+				return WriteBytes(MySqlParameter.ConvertFloatsToBytes(floatArray.AsSpan()), ref inputIndex, output, out bytesWritten);
+			}
+
+			case Memory<float> memory:
+			{
+				return WriteBytes(MySqlParameter.ConvertFloatsToBytes(memory.Span), ref inputIndex, output, out bytesWritten);
+			}
+
+			case ReadOnlyMemory<float> memory:
+			{
+				return WriteBytes(MySqlParameter.ConvertFloatsToBytes(memory.Span), ref inputIndex, output, out bytesWritten);
+			}
+
+#if NET6_0_OR_GREATER
+
+			case DateOnly dateOnlyValue:
+			{
+				return WriteString(dateOnlyValue.ToString("yyyy'-'MM'-'dd", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case TimeOnly timeOnlyValue:
+			{
+				return WriteString(timeOnlyValue.ToString("HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+#endif
+			case TimeSpan ts:
+			{
+				var isNegative = false;
+				if (ts.Ticks < 0)
+				{
+					isNegative = true;
+					ts = TimeSpan.FromTicks(-ts.Ticks);
+				}
+#if NET6_0_OR_GREATER
+				var str = string.Create(CultureInfo.InvariantCulture, $"{(isNegative ? "-" : "")}{ts.Days * 24 + ts.Hours}:{ts:mm':'ss'.'ffffff}");
+#else
+				var str = FormattableString.Invariant($"{(isNegative ? "-" : "")}{ts.Days * 24 + ts.Hours}:{ts:mm':'ss'.'ffffff}");
+#endif
+				return WriteString(str, ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case Guid guidValue:
+			{
+				if (connection.GuidFormat is MySqlGuidFormat.Binary16 or MySqlGuidFormat.TimeSwapBinary16 or MySqlGuidFormat.LittleEndianBinary16)
+				{
+					var bytes = guidValue.ToByteArray();
+					if (connection.GuidFormat != MySqlGuidFormat.LittleEndianBinary16)
+					{
+						Utility.SwapBytes(bytes, 0, 3);
+						Utility.SwapBytes(bytes, 1, 2);
+						Utility.SwapBytes(bytes, 4, 5);
+						Utility.SwapBytes(bytes, 6, 7);
+
+						if (connection.GuidFormat == MySqlGuidFormat.TimeSwapBinary16)
+						{
+							Utility.SwapBytes(bytes, 0, 4);
+							Utility.SwapBytes(bytes, 1, 5);
+							Utility.SwapBytes(bytes, 2, 6);
+							Utility.SwapBytes(bytes, 3, 7);
+							Utility.SwapBytes(bytes, 0, 2);
+							Utility.SwapBytes(bytes, 1, 3);
+						}
+					}
+					return WriteBytes(bytes, ref inputIndex, output, out bytesWritten);
+				}
+				else
+				{
+					var is32Characters = connection.GuidFormat == MySqlGuidFormat.Char32;
+					return Utf8Formatter.TryFormat(guidValue, output, out bytesWritten, is32Characters ? 'N' : 'D');
+				}
+			}
+
+			case Enum enumValue:
+			{
+				return WriteString(enumValue.ToString("d"), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case BigInteger bigInteger:
+			{
+				return WriteString(bigInteger.ToString(CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			case MySqlDecimal mySqlDecimal:
+			{
+				return WriteString(mySqlDecimal.ToString(), ref utf8Encoder, output, out bytesWritten);
+			}
+
+			default:
+			{
+				throw new NotSupportedException($"Type {typeof(T).Name} not currently supported. Value: {value}");
+			}
+		}
+	}
+
+	private static bool WriteNull(Span<byte> output, out int bytesWritten)
+	{
+		ReadOnlySpan<byte> escapedNull = @"\N"u8; // a field value of \N is read as NULL for input
+		if (output.Length < escapedNull.Length)
+		{
+			bytesWritten = 0;
+			return false;
+		}
+		escapedNull.CopyTo(output);
+		bytesWritten = escapedNull.Length;
+		return true;
+	}
+
+	private static bool WriteString(string value, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
+	{
+		var inputIndex = 0;
+		if (WriteSubstring(value, ref inputIndex, ref utf8Encoder, output, out bytesWritten))
+			return true;
+		bytesWritten = 0;
+		return false;
+	}
+
+	// Writes as much of 'value' as possible, starting at 'inputIndex' and writing UTF-8-encoded bytes to 'output'.
+	// 'inputIndex' will be updated to the next character to be written, and 'bytesWritten' the number of bytes written to 'output'.
+	private static bool WriteSubstring(string value, ref int inputIndex, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
+	{
+		bytesWritten = 0;
+		while (inputIndex < value.Length)
+		{
+			if (Array.IndexOf(s_specialCharacters, value[inputIndex]) != -1)
+			{
+				if (output.Length <= 2)
+					return false;
+
+				output[0] = (byte) '\\';
+				output[1] = (byte) value[inputIndex];
+				output = output[2..];
+				bytesWritten += 2;
+				inputIndex++;
+			}
+			else
+			{
+				var nextIndex = value.IndexOfAny(s_specialCharacters, inputIndex);
+				if (nextIndex == -1)
+					nextIndex = value.Length;
+
+				utf8Encoder ??= s_utf8Encoding.GetEncoder();
+				if (output.Length < 4 && utf8Encoder.GetByteCount(value.AsSpan(inputIndex, Math.Min(2, nextIndex - inputIndex)), flush: false) > output.Length)
+					return false;
+				utf8Encoder.Convert(value.AsSpan(inputIndex, nextIndex - inputIndex), output, nextIndex == value.Length, out var charsUsed, out var bytesUsed, out var completed);
+
+				bytesWritten += bytesUsed;
+				output = output[bytesUsed..];
+				inputIndex += charsUsed;
+
+				if (!completed)
+					return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static bool WriteBytes(ReadOnlySpan<byte> value, ref int inputIndex, Span<byte> output, out int bytesWritten)
+	{
+		ReadOnlySpan<byte> hex = "0123456789ABCDEF"u8;
+		bytesWritten = 0;
+		for (; inputIndex < value.Length && output.Length > 2; inputIndex++)
+		{
+			var by = value[inputIndex];
+			output[0] = hex[(by >> 4) & 0xF];
+			output[1] = hex[by & 0xF];
+			output = output[2..];
+			bytesWritten += 2;
+		}
+
+		return inputIndex == value.Length;
+	}
+}

--- a/src/MySqlConnector/MySqlBulkCopy.cs
+++ b/src/MySqlConnector/MySqlBulkCopy.cs
@@ -1,14 +1,11 @@
 using System.Buffers;
-using System.Buffers.Text;
-using System.Globalization;
-using System.Numerics;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using MySqlConnector.Core;
+using MySqlConnector.Helpers;
 using MySqlConnector.Logging;
 using MySqlConnector.Protocol;
 using MySqlConnector.Protocol.Serialization;
-using MySqlConnector.Utilities;
 
 namespace MySqlConnector;
 
@@ -361,6 +358,9 @@ public sealed class MySqlBulkCopy
 		{
 			var values = new object[m_valuesEnumerator!.FieldCount];
 			Encoder? utf8Encoder = null;
+			const byte tabByte = (byte) '\t';
+			const byte newLineByte = (byte) '\n';
+
 			while (true)
 			{
 				var hasMore = ioBehavior == IOBehavior.Asynchronous ?
@@ -373,11 +373,11 @@ public sealed class MySqlBulkCopy
 				for (var valueIndex = 0; valueIndex < values.Length; valueIndex++)
 				{
 					if (valueIndex > 0)
-						buffer[outputIndex++] = (byte) '\t';
+						buffer[outputIndex++] = tabByte;
 
 					var inputIndex = 0;
 					var bytesWritten = 0;
-					while (outputIndex >= maxLength || !WriteValue(m_connection, values[valueIndex], ref inputIndex, ref utf8Encoder, buffer.AsSpan(0, maxLength)[outputIndex..], out bytesWritten))
+					while (outputIndex >= maxLength || !ValueWriteHelper.WriteValue(m_connection, values[valueIndex], ref inputIndex, ref utf8Encoder, buffer.AsSpan(0, maxLength)[outputIndex..], out bytesWritten))
 					{
 						var payload = new PayloadData(new ArraySegment<byte>(buffer, 0, outputIndex + bytesWritten));
 						await m_connection.Session.SendReplyAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
@@ -386,7 +386,7 @@ public sealed class MySqlBulkCopy
 					}
 					outputIndex += bytesWritten;
 				}
-				buffer[outputIndex++] = (byte) '\n';
+				buffer[outputIndex++] = newLineByte;
 
 				m_rowsCopied++;
 				if (eventArgs is not null && m_rowsCopied % NotifyAfter == 0)
@@ -409,271 +409,7 @@ public sealed class MySqlBulkCopy
 			ArrayPool<byte>.Shared.Return(buffer);
 			m_wasAborted = eventArgs?.Abort is true;
 		}
-
-		static bool WriteValue(MySqlConnection connection, object value, ref int inputIndex, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
-		{
-			if (output.Length == 0)
-			{
-				bytesWritten = 0;
-				return false;
-			}
-
-			if (value is null || value == DBNull.Value)
-			{
-				ReadOnlySpan<byte> escapedNull = @"\N"u8; // a field value of \N is read as NULL for input
-				if (output.Length < escapedNull.Length)
-				{
-					bytesWritten = 0;
-					return false;
-				}
-				escapedNull.CopyTo(output);
-				bytesWritten = escapedNull.Length;
-				return true;
-			}
-			else if (value is string stringValue)
-			{
-				return WriteSubstring(stringValue, ref inputIndex, ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is char charValue)
-			{
-				return WriteString(charValue.ToString(), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is byte byteValue)
-			{
-				return Utf8Formatter.TryFormat(byteValue, output, out bytesWritten);
-			}
-			else if (value is sbyte sbyteValue)
-			{
-				return Utf8Formatter.TryFormat(sbyteValue, output, out bytesWritten);
-			}
-			else if (value is short shortValue)
-			{
-				return Utf8Formatter.TryFormat(shortValue, output, out bytesWritten);
-			}
-			else if (value is ushort ushortValue)
-			{
-				return Utf8Formatter.TryFormat(ushortValue, output, out bytesWritten);
-			}
-			else if (value is int intValue)
-			{
-				return Utf8Formatter.TryFormat(intValue, output, out bytesWritten);
-			}
-			else if (value is uint uintValue)
-			{
-				return Utf8Formatter.TryFormat(uintValue, output, out bytesWritten);
-			}
-			else if (value is long longValue)
-			{
-				return Utf8Formatter.TryFormat(longValue, output, out bytesWritten);
-			}
-			else if (value is ulong ulongValue)
-			{
-				return Utf8Formatter.TryFormat(ulongValue, output, out bytesWritten);
-			}
-			else if (value is decimal decimalValue)
-			{
-				return Utf8Formatter.TryFormat(decimalValue, output, out bytesWritten);
-			}
-			else if (value is byte[] or ReadOnlyMemory<byte> or Memory<byte> or ArraySegment<byte> or MySqlGeometry or float[] or ReadOnlyMemory<float> or Memory<float>)
-			{
-				var inputSpan = value switch
-				{
-					byte[] byteArray => byteArray.AsSpan(),
-					ArraySegment<byte> arraySegment => arraySegment.AsSpan(),
-					Memory<byte> memory => memory.Span,
-					MySqlGeometry geometry => geometry.ValueSpan,
-					float[] floatArray => MySqlParameter.ConvertFloatsToBytes(floatArray.AsSpan()),
-					Memory<float> memory => MySqlParameter.ConvertFloatsToBytes(memory.Span),
-					ReadOnlyMemory<float> memory => MySqlParameter.ConvertFloatsToBytes(memory.Span),
-					_ => ((ReadOnlyMemory<byte>) value).Span,
-				};
-
-				return WriteBytes(inputSpan, ref inputIndex, output, out bytesWritten);
-			}
-			else if (value is bool boolValue)
-			{
-				if (output.Length < 1)
-				{
-					bytesWritten = 0;
-					return false;
-				}
-				output[0] = boolValue ? (byte) '1' : (byte) '0';
-				bytesWritten = 1;
-				return true;
-			}
-			else if (value is float floatValue)
-			{
-				// NOTE: Utf8Formatter doesn't support "R"
-				return WriteString(floatValue.ToString("R", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is double doubleValue)
-			{
-				// NOTE: Utf8Formatter doesn't support "R"
-				return WriteString(doubleValue.ToString("R", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is MySqlDateTime mySqlDateTimeValue)
-			{
-				if (mySqlDateTimeValue.IsValidDateTime)
-					return WriteString(mySqlDateTimeValue.GetDateTime().ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-				else
-					return WriteString("0000-00-00", ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is DateTime dateTimeValue)
-			{
-				if (connection.DateTimeKind == DateTimeKind.Utc && dateTimeValue.Kind == DateTimeKind.Local)
-					throw new MySqlException("DateTime.Kind must not be Local when DateTimeKind setting is Utc");
-				else if (connection.DateTimeKind == DateTimeKind.Local && dateTimeValue.Kind == DateTimeKind.Utc)
-					throw new MySqlException("DateTime.Kind must not be Utc when DateTimeKind setting is Local");
-
-				return WriteString(dateTimeValue.ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is DateTimeOffset dateTimeOffsetValue)
-			{
-				// store as UTC as it will be read as such when deserialized from a timespan column
-				return WriteString(dateTimeOffsetValue.UtcDateTime.ToString("yyyy'-'MM'-'dd' 'HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-#if NET6_0_OR_GREATER
-			else if (value is DateOnly dateOnlyValue)
-			{
-				return WriteString(dateOnlyValue.ToString("yyyy'-'MM'-'dd", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is TimeOnly timeOnlyValue)
-			{
-				return WriteString(timeOnlyValue.ToString("HH':'mm':'ss'.'ffffff", CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-#endif
-			else if (value is TimeSpan ts)
-			{
-				var isNegative = false;
-				if (ts.Ticks < 0)
-				{
-					isNegative = true;
-					ts = TimeSpan.FromTicks(-ts.Ticks);
-				}
-#if NET6_0_OR_GREATER
-				var str = string.Create(CultureInfo.InvariantCulture, $"{(isNegative ? "-" : "")}{ts.Days * 24 + ts.Hours}:{ts:mm':'ss'.'ffffff}");
-#else
-				var str = FormattableString.Invariant($"{(isNegative ? "-" : "")}{ts.Days * 24 + ts.Hours}:{ts:mm':'ss'.'ffffff}");
-#endif
-				return WriteString(str, ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is Guid guidValue)
-			{
-				if (connection.GuidFormat is MySqlGuidFormat.Binary16 or MySqlGuidFormat.TimeSwapBinary16 or MySqlGuidFormat.LittleEndianBinary16)
-				{
-					var bytes = guidValue.ToByteArray();
-					if (connection.GuidFormat != MySqlGuidFormat.LittleEndianBinary16)
-					{
-						Utility.SwapBytes(bytes, 0, 3);
-						Utility.SwapBytes(bytes, 1, 2);
-						Utility.SwapBytes(bytes, 4, 5);
-						Utility.SwapBytes(bytes, 6, 7);
-
-						if (connection.GuidFormat == MySqlGuidFormat.TimeSwapBinary16)
-						{
-							Utility.SwapBytes(bytes, 0, 4);
-							Utility.SwapBytes(bytes, 1, 5);
-							Utility.SwapBytes(bytes, 2, 6);
-							Utility.SwapBytes(bytes, 3, 7);
-							Utility.SwapBytes(bytes, 0, 2);
-							Utility.SwapBytes(bytes, 1, 3);
-						}
-					}
-					return WriteBytes(bytes, ref inputIndex, output, out bytesWritten);
-				}
-				else
-				{
-					var is32Characters = connection.GuidFormat == MySqlGuidFormat.Char32;
-					return Utf8Formatter.TryFormat(guidValue, output, out bytesWritten, is32Characters ? 'N' : 'D');
-				}
-			}
-			else if (value is Enum enumValue)
-			{
-				return WriteString(enumValue.ToString("d"), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is BigInteger bigInteger)
-			{
-				return WriteString(bigInteger.ToString(CultureInfo.InvariantCulture), ref utf8Encoder, output, out bytesWritten);
-			}
-			else if (value is MySqlDecimal mySqlDecimal)
-			{
-				return WriteString(mySqlDecimal.ToString(), ref utf8Encoder, output, out bytesWritten);
-			}
-			else
-			{
-				throw new NotSupportedException($"Type {value.GetType().Name} not currently supported. Value: {value}");
-			}
-		}
-
-		static bool WriteString(string value, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
-		{
-			var inputIndex = 0;
-			if (WriteSubstring(value, ref inputIndex, ref utf8Encoder, output, out bytesWritten))
-				return true;
-			bytesWritten = 0;
-			return false;
-		}
-
-		// Writes as much of 'value' as possible, starting at 'inputIndex' and writing UTF-8-encoded bytes to 'output'.
-		// 'inputIndex' will be updated to the next character to be written, and 'bytesWritten' the number of bytes written to 'output'.
-		static bool WriteSubstring(string value, ref int inputIndex, ref Encoder? utf8Encoder, Span<byte> output, out int bytesWritten)
-		{
-			bytesWritten = 0;
-			while (inputIndex < value.Length)
-			{
-				if (Array.IndexOf(s_specialCharacters, value[inputIndex]) != -1)
-				{
-					if (output.Length <= 2)
-						return false;
-
-					output[0] = (byte) '\\';
-					output[1] = (byte) value[inputIndex];
-					output = output[2..];
-					bytesWritten += 2;
-					inputIndex++;
-				}
-				else
-				{
-					var nextIndex = value.IndexOfAny(s_specialCharacters, inputIndex);
-					if (nextIndex == -1)
-						nextIndex = value.Length;
-
-					utf8Encoder ??= s_utf8Encoding.GetEncoder();
-					if (output.Length < 4 && utf8Encoder.GetByteCount(value.AsSpan(inputIndex, Math.Min(2, nextIndex - inputIndex)), flush: false) > output.Length)
-						return false;
-					utf8Encoder.Convert(value.AsSpan(inputIndex, nextIndex - inputIndex), output, nextIndex == value.Length, out var charsUsed, out var bytesUsed, out var completed);
-
-					bytesWritten += bytesUsed;
-					output = output[bytesUsed..];
-					inputIndex += charsUsed;
-
-					if (!completed)
-						return false;
-				}
-			}
-
-			return true;
-		}
-
-		static bool WriteBytes(ReadOnlySpan<byte> value, ref int inputIndex, Span<byte> output, out int bytesWritten)
-		{
-			ReadOnlySpan<byte> hex = "0123456789ABCDEF"u8;
-			bytesWritten = 0;
-			for (; inputIndex < value.Length && output.Length > 2; inputIndex++)
-			{
-				var by = value[inputIndex];
-				output[0] = hex[(by >> 4) & 0xF];
-				output[1] = hex[by & 0xF];
-				output = output[2..];
-				bytesWritten += 2;
-			}
-
-			return inputIndex == value.Length;
-		}
 	}
-
-	private static readonly char[] s_specialCharacters = ['\t', '\\', '\n'];
-	private static readonly UTF8Encoding s_utf8Encoding = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
 	private readonly MySqlConnection m_connection;
 	private readonly MySqlTransaction? m_transaction;

--- a/src/MySqlConnector/MySqlBulkCopy.cs
+++ b/src/MySqlConnector/MySqlBulkCopy.cs
@@ -221,72 +221,17 @@ public sealed class MySqlBulkCopy
 			closeConnection = true;
 		}
 
-		// merge column mappings with the destination schema
-		var columnMappings = new List<MySqlBulkCopyColumnMapping>(ColumnMappings);
-		var addDefaultMappings = columnMappings.Count == 0;
-		using (var cmd = new MySqlCommand("select * from " + tableName + ";", m_connection, m_transaction))
-		using (var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SchemaOnly, ioBehavior, cancellationToken).ConfigureAwait(false))
-		{
-			var schema = reader.GetColumnSchema();
-			for (var i = 0; i < schema.Count; i++)
-			{
-				var destinationColumn = reader.GetName(i);
-				var dataTypeName = schema[i].DataTypeName;
-				if (dataTypeName == "BIT")
-				{
-					AddColumnMapping(m_logger, columnMappings, addDefaultMappings, i, destinationColumn, $"@`\uE002\bcol{i}`", $"%COL% = CAST(%VAR% AS UNSIGNED)");
-				}
-				else
-				{
-					var type = schema[i].DataType;
-					if (type == typeof(byte[]) ||
-						dataTypeName == "VECTOR" ||
-						(type == typeof(Guid) && (m_connection.GuidFormat is MySqlGuidFormat.Binary16 or MySqlGuidFormat.LittleEndianBinary16 or MySqlGuidFormat.TimeSwapBinary16)))
-					{
-						AddColumnMapping(m_logger, columnMappings, addDefaultMappings, i, destinationColumn, $"@`\uE002\bcol{i}`", $"%COL% = UNHEX(%VAR%)");
-					}
-					else if (addDefaultMappings)
-					{
-						if (schema[i].DataTypeName == "YEAR")
-						{
-							// the current code can't distinguish between 0 = 0000 and 0 = 2000
-							throw new NotSupportedException("'YEAR' columns are not supported by MySqlBulkCopy.");
-						}
-
-						Log.AddingDefaultColumnMapping(m_logger, i, destinationColumn);
-						columnMappings.Add(new(i, destinationColumn));
-					}
-				}
-			}
-		}
-
-		// set columns and expressions from the column mappings
-		for (var i = 0; i < m_valuesEnumerator!.FieldCount; i++)
-		{
-			var columnMapping = columnMappings.FirstOrDefault(x => x.SourceOrdinal == i);
-			if (columnMapping is null)
-			{
-				Log.IgnoringColumn(m_logger, i);
-				bulkLoader.Columns.Add("@`\uE002\bignore`");
-			}
-			else
-			{
-				if (columnMapping.DestinationColumn.Length == 0)
-					throw new InvalidOperationException($"MySqlBulkCopyColumnMapping.DestinationName is not set for SourceOrdinal {columnMapping.SourceOrdinal}");
-				if (columnMapping.DestinationColumn[0] == '@' && columnMapping.Expression is not null)
-					bulkLoader.Columns.Add(columnMapping.DestinationColumn);
-				else
-					bulkLoader.Columns.Add(QuoteIdentifier(columnMapping.DestinationColumn));
-				if (columnMapping.Expression is not null)
-					bulkLoader.Expressions.Add(columnMapping.Expression);
-			}
-		}
-
-		foreach (var columnMapping in columnMappings)
-		{
-			if (columnMapping.SourceOrdinal < 0 || columnMapping.SourceOrdinal >= m_valuesEnumerator.FieldCount)
-				throw new InvalidOperationException($"SourceOrdinal {columnMapping.SourceOrdinal} is an invalid value");
-		}
+		await ColumnMapperHelper.FillColumnMappingsAsync(
+			tableName,
+			m_valuesEnumerator!.FieldCount,
+			m_logger,
+			ioBehavior,
+			bulkLoader,
+			ColumnMappings,
+			m_connection,
+			m_transaction,
+			cancellationToken)
+			.ConfigureAwait(false);
 
 		var errors = new List<MySqlError>();
 		MySqlInfoMessageEventHandler infoMessageHandler = (s, e) => errors.AddRange(e.Errors);
@@ -314,32 +259,6 @@ public sealed class MySqlBulkCopy
 		}
 
 		return new(errors, rowsInserted);
-
-		static string QuoteIdentifier(string identifier) => "`" + identifier.Replace("`", "``") + "`";
-
-		static void AddColumnMapping(ILogger logger, List<MySqlBulkCopyColumnMapping> columnMappings, bool addDefaultMappings, int destinationOrdinal, string destinationColumn, string variableName, string expression)
-		{
-			expression = expression.Replace("%COL%", "`" + destinationColumn + "`").Replace("%VAR%", variableName);
-			var columnMapping = columnMappings.FirstOrDefault(x => destinationColumn.Equals(x.DestinationColumn, StringComparison.OrdinalIgnoreCase));
-			if (columnMapping is not null)
-			{
-				if (columnMapping.Expression is not null)
-				{
-					Log.ColumnMappingAlreadyHasExpression(logger, columnMapping.SourceOrdinal, destinationColumn, columnMapping.Expression);
-				}
-				else
-				{
-					Log.SettingExpressionToMapColumn(logger, columnMapping.SourceOrdinal, destinationColumn, expression);
-					columnMappings.Remove(columnMapping);
-					columnMappings.Add(new(columnMapping.SourceOrdinal, variableName, expression));
-				}
-			}
-			else if (addDefaultMappings)
-			{
-				Log.AddingDefaultColumnMapping(logger, destinationOrdinal, destinationColumn);
-				columnMappings.Add(new(destinationOrdinal, variableName, expression));
-			}
-		}
 	}
 
 	internal async Task SendDataReaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)

--- a/src/MySqlConnector/MySqlBulkImport.cs
+++ b/src/MySqlConnector/MySqlBulkImport.cs
@@ -11,7 +11,7 @@ namespace MySqlConnector;
 
 public sealed class MySqlBulkImport : IAsyncDisposable
 {
-	private readonly int bufferSize;
+	private readonly int rentBufferSize;
 	private readonly MySqlConnection m_connection;
 	private readonly ArrayPool<byte> pool;
 	private Channel<BufferData> channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
@@ -30,20 +30,20 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 	/// Initializes a <see cref="MySqlBulkCopy"/> object with the specified connection, and optionally the active transaction.
 	/// </summary>
 	/// <param name="connection">The <see cref="MySqlConnection"/> to use.</param>
-	/// <param name="bufferSize">The size of the buffers requested from the pool</param>
+	/// <param name="rentBufferSize">The size of the buffers requested from the pool</param>
 	/// <param name="pool">Pool for obtaining temporary buffers for writing data</param>
 	public MySqlBulkImport(
 		MySqlConnection connection,
-		int bufferSize = 65_536,
+		int rentBufferSize = 65_536,
 		ArrayPool<byte>? pool = null)
 	{
 		ArgumentNullException.ThrowIfNull(connection);
-		if (bufferSize < 1_000)
+		if (rentBufferSize < 1_000)
 		{
-			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(bufferSize));
+			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(rentBufferSize));
 		}
 
-		this.bufferSize = bufferSize;
+		this.rentBufferSize = rentBufferSize;
 		m_connection = connection;
 		this.pool = pool ?? ArrayPool<byte>.Shared;
 	}
@@ -56,7 +56,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 	public void StartImport(
 		string destinationTableName,
 		string[] columns,
-		CancellationToken cancellationToken)
+		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(destinationTableName);
 		ArgumentNullException.ThrowIfNull(columns);
@@ -124,7 +124,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 		cancellationToken);
 	}
 
-	public async Task WaitFinishImportAsync()
+	public async ValueTask WaitFinishImportAsync()
 	{
 		if (importTask == null)
 		{
@@ -170,26 +170,25 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 	public void WriteColumnValue<T>(T value)
 	{
-		bufferData ??= new BufferData(pool.Rent(bufferSize), 0);
+		bufferData ??= new BufferData(pool.Rent(rentBufferSize), 0);
+		var buffer = bufferData.Buffer.AsSpan();
 
 		var totalBytesWritten = bufferData.TotalBytesWritten;
-		var span = bufferData.Buffer.AsSpan();
-		var inputIndex = 0;
-
-		if (totalBytesWritten >= bufferSize)
+		if (totalBytesWritten >= rentBufferSize)
 		{
 			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
 			totalBytesWritten = 0;
-			span = bufferData.Buffer.AsSpan();
+			buffer = bufferData.Buffer.AsSpan();
 		}
 
 		if (columnsCount++ > 0)
 		{
 			const byte tabByte = (byte) '\t';
-			span[..bufferSize][totalBytesWritten++] = tabByte;
+			buffer[totalBytesWritten++] = tabByte;
 		}
 
+		var inputIndex = 0;
 		while (true)
 		{
 			var completeWrite = ValueWriteHelper.WriteValue(
@@ -197,7 +196,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 				value,
 				ref inputIndex,
 				ref encoder,
-				span[..bufferSize][totalBytesWritten..],
+				buffer[totalBytesWritten..],
 				out var bytesWritten);
 
 			totalBytesWritten += bytesWritten;
@@ -205,9 +204,9 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			if (!completeWrite)
 			{
 				channel.Writer.TryWrite(bufferData);
-				bufferData = new BufferData(pool.Rent(bufferSize), 0);
+				bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
 				totalBytesWritten = 0;
-				span = bufferData.Buffer.AsSpan();
+				buffer = bufferData.Buffer.AsSpan();
 			}
 			else
 			{
@@ -223,329 +222,22 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			throw new InvalidOperationException("The row does not contain any values.");
 		}
 
-		var totalBytesWritten = bufferData!.TotalBytesWritten;
-		var span = bufferData.Buffer.AsSpan();
-
-		if (totalBytesWritten >= bufferSize)
+		int totalBytesWritten = bufferData!.TotalBytesWritten;
+		Span<byte> buffer;
+		if (totalBytesWritten >= rentBufferSize)
 		{
 			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
 			totalBytesWritten = 0;
-			span = bufferData.Buffer.AsSpan();
-		}
-
-		const byte newLineByte = (byte) '\n';
-		span[..bufferSize][totalBytesWritten++] = newLineByte;
-		bufferData!.TotalBytesWritten = totalBytesWritten;
-		columnsCount = 0;
-	}
-
-	internal async Task SendDataReaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
-	{
-		var reader = channel.Reader;
-		while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
-		{
-			while (reader.TryRead(out var bufferData))
-			{
-				try
-				{
-					var payload = new PayloadData(new ArraySegment<byte>(bufferData.Buffer, 0, bufferData.TotalBytesWritten));
-					await m_connection.Session.SendReplyAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
-				}
-				finally
-				{
-					pool.Return(bufferData.Buffer);
-				}
-			}
-		}
-	}
-
-	public async ValueTask DisposeAsync()
-	{
-		channel.Writer.TryComplete();
-		if (bufferData != null)
-		{
-			try
-			{
-				pool.Return(bufferData.Buffer);
-			}
-			catch
-			{
-				// ignore
-			}
-
-			bufferData = null;
-		}
-
-		if (importTask != null)
-		{
-			try
-			{
-				await importTask.ConfigureAwait(false);
-				importTask = null;
-			}
-			catch
-			{
-				// ignore
-			}
-		}
-
-		while (channel.Reader.TryRead(out var bufferData))
-		{
-			try
-			{
-				pool.Return(bufferData.Buffer);
-			}
-			catch
-			{
-				// ignore
-			}
-		}
-	}
-
-	private sealed class BufferData
-	{
-		public BufferData(
-			byte[] buffer,
-			int totalBytesWritten)
-		{
-			Buffer = buffer;
-			TotalBytesWritten = totalBytesWritten;
-		}
-
-		public int TotalBytesWritten { get; set; }
-
-		public byte[] Buffer { get; private set; }
-	}
-}
-
-public sealed class MySqlBulkImport2 : IAsyncDisposable
-{
-	private readonly int bufferSize;
-	private readonly MySqlConnection m_connection;
-	private readonly ArrayPool<byte> pool;
-	private Channel<BufferData> channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
-	{
-		SingleReader = true,
-		SingleWriter = true,
-		AllowSynchronousContinuations = false,
-	});
-
-	private Encoder? encoder;
-	private BufferData? bufferData;
-	private int columnsCount;
-	private Task? importTask;
-
-	/// <summary>
-	/// Initializes a <see cref="MySqlBulkCopy"/> object with the specified connection, and optionally the active transaction.
-	/// </summary>
-	/// <param name="connection">The <see cref="MySqlConnection"/> to use.</param>
-	/// <param name="bufferSize">The size of the buffers requested from the pool</param>
-	/// <param name="pool">Pool for obtaining temporary buffers for writing data</param>
-	public MySqlBulkImport2(
-		MySqlConnection connection,
-		int bufferSize = 65_536,
-		ArrayPool<byte>? pool = null)
-	{
-		ArgumentNullException.ThrowIfNull(connection);
-		if (bufferSize < 1_000)
-		{
-			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(bufferSize));
-		}
-
-		this.bufferSize = bufferSize;
-		m_connection = connection;
-		this.pool = pool ?? ArrayPool<byte>.Shared;
-	}
-
-	/// <summary>
-	/// A <see cref="MySqlBulkLoaderConflictOption"/> value that specifies how conflicts are resolved (default <see cref="MySqlBulkLoaderConflictOption.None"/>).
-	/// </summary>
-	public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
-
-	public void StartImport(
-		string destinationTableName,
-		string[] columns,
-		CancellationToken cancellationToken)
-	{
-		ArgumentNullException.ThrowIfNull(destinationTableName);
-		ArgumentNullException.ThrowIfNull(columns);
-		if (columns.Length == 0)
-		{
-			throw new ArgumentException("The column array is empty", nameof(columns));
-		}
-
-		if (importTask != null)
-		{
-			throw new InvalidOperationException($"First you need to wait for the previous import to complete by calling '{nameof(WaitFinishImportAsync)}'");
-		}
-
-		cancellationToken.ThrowIfCancellationRequested();
-		var tableName = destinationTableName ?? throw new InvalidOperationException("DestinationTableName must be set before calling WriteToServer");
-		var bulkLoader = new MySqlBulkLoader(m_connection)
-		{
-			CharacterSet = "utf8mb4",
-			EscapeCharacter = '\\',
-			FieldQuotationCharacter = '\0',
-			FieldTerminator = "\t",
-			LinePrefix = null,
-			LineTerminator = "\n",
-			Local = true,
-			NumberOfLinesToSkip = 0,
-			Source = this,
-			TableName = tableName,
-			Timeout = 0,
-			ConflictOption = ConflictOption,
-		};
-
-		bulkLoader.Columns.AddRange(columns);
-
-		var closeConnection = false;
-		if (m_connection.State != ConnectionState.Open)
-		{
-			m_connection.Open();
-			closeConnection = true;
-		}
-
-		importTask = Task.Run(async () =>
-		{
-			try
-			{
-				var errors = new List<MySqlError>();
-				MySqlInfoMessageEventHandler infoMessageHandler = (s, e) => errors.AddRange(e.Errors);
-				m_connection.InfoMessage += infoMessageHandler;
-
-				int rowsInserted;
-				try
-				{
-					rowsInserted = await bulkLoader.LoadAsync(IOBehavior.Asynchronous, cancellationToken).ConfigureAwait(false);
-				}
-				finally
-				{
-					m_connection.InfoMessage -= infoMessageHandler;
-				}
-			}
-			finally
-			{
-				if (closeConnection)
-					await m_connection.CloseAsync().ConfigureAwait(false);
-			}
-		},
-		cancellationToken);
-	}
-
-	public async Task WaitFinishImportAsync()
-	{
-		if (importTask == null)
-		{
-			return;
+			buffer = bufferData.Buffer.AsSpan();
 		}
 		else
 		{
-			if (columnsCount != 0)
-			{
-				throw new InvalidOperationException($"Before calling '{nameof(WaitFinishImportAsync)}', you must close the line write by calling '{nameof(EndRow)}'");
-			}
-
-			var writer = channel.Writer;
-			if (bufferData != null)
-			{
-				writer.TryWrite(bufferData);
-				bufferData = null;
-			}
-
-			writer.Complete();
-			columnsCount = 0;
-			encoder = null;
-
-			try
-			{
-				await importTask.ConfigureAwait(false);
-			}
-			catch (OperationCanceledException)
-			{
-				// ignore
-			}
-
-			importTask = null;
-
-			channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
-			{
-				SingleReader = true,
-				SingleWriter = true,
-				AllowSynchronousContinuations = false,
-			});
-		}
-	}
-
-	public void WriteColumnValue<T>(T value)
-	{
-		bufferData ??= new BufferData(pool.Rent(bufferSize), 0);
-
-		var totalBytesWritten = bufferData.TotalBytesWritten;
-		var span = bufferData.Buffer.AsSpan();
-		var inputIndex = 0;
-
-		if (totalBytesWritten >= bufferSize)
-		{
-			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(bufferSize), 0);
-			totalBytesWritten = 0;
-			span = bufferData.Buffer.AsSpan();
-		}
-
-		if (columnsCount++ > 0)
-		{
-			const byte tabByte = (byte) '\t';
-			span[..bufferSize][totalBytesWritten++] = tabByte;
-		}
-
-		while (true)
-		{
-			var completeWrite = ValueWriteHelper.WriteValue(
-				m_connection,
-				value,
-				ref inputIndex,
-				ref encoder,
-				span[..bufferSize][totalBytesWritten..],
-				out var bytesWritten);
-
-			totalBytesWritten += bytesWritten;
-			bufferData.TotalBytesWritten = totalBytesWritten;
-			if (!completeWrite)
-			{
-				channel.Writer.TryWrite(bufferData);
-				bufferData = new BufferData(pool.Rent(bufferSize), 0);
-				totalBytesWritten = 0;
-				span = bufferData.Buffer.AsSpan();
-			}
-			else
-			{
-				break;
-			}
-		}
-	}
-
-	public void EndRow()
-	{
-		if (columnsCount <= 0)
-		{
-			throw new InvalidOperationException("The row does not contain any values.");
-		}
-
-		var totalBytesWritten = bufferData!.TotalBytesWritten;
-		var span = bufferData.Buffer.AsSpan();
-
-		if (totalBytesWritten >= bufferSize)
-		{
-			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(bufferSize), 0);
-			totalBytesWritten = 0;
-			span = bufferData.Buffer.AsSpan();
+			buffer = bufferData.Buffer.AsSpan();
 		}
 
 		const byte newLineByte = (byte) '\n';
-		span[..bufferSize][totalBytesWritten++] = newLineByte;
+		buffer[totalBytesWritten++] = newLineByte;
 		bufferData!.TotalBytesWritten = totalBytesWritten;
 		columnsCount = 0;
 	}

--- a/src/MySqlConnector/MySqlBulkImport.cs
+++ b/src/MySqlConnector/MySqlBulkImport.cs
@@ -1,0 +1,632 @@
+#if NET6_0_OR_GREATER
+
+using System.Buffers;
+using System.Text;
+using System.Threading.Channels;
+using MySqlConnector.Helpers;
+using MySqlConnector.Protocol;
+using MySqlConnector.Protocol.Serialization;
+
+namespace MySqlConnector;
+
+public sealed class MySqlBulkImport : IAsyncDisposable
+{
+	private readonly int bufferSize;
+	private readonly MySqlConnection m_connection;
+	private readonly ArrayPool<byte> pool;
+	private Channel<BufferData> channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+	{
+		SingleReader = true,
+		SingleWriter = true,
+		AllowSynchronousContinuations = false,
+	});
+
+	private Encoder? encoder;
+	private BufferData? bufferData;
+	private int columnsCount;
+	private Task? importTask;
+
+	/// <summary>
+	/// Initializes a <see cref="MySqlBulkCopy"/> object with the specified connection, and optionally the active transaction.
+	/// </summary>
+	/// <param name="connection">The <see cref="MySqlConnection"/> to use.</param>
+	/// <param name="bufferSize">The size of the buffers requested from the pool</param>
+	/// <param name="pool">Pool for obtaining temporary buffers for writing data</param>
+	public MySqlBulkImport(
+		MySqlConnection connection,
+		int bufferSize = 65_536,
+		ArrayPool<byte>? pool = null)
+	{
+		ArgumentNullException.ThrowIfNull(connection);
+		if (bufferSize < 1_000)
+		{
+			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(bufferSize));
+		}
+
+		this.bufferSize = bufferSize;
+		m_connection = connection;
+		this.pool = pool ?? ArrayPool<byte>.Shared;
+	}
+
+	/// <summary>
+	/// A <see cref="MySqlBulkLoaderConflictOption"/> value that specifies how conflicts are resolved (default <see cref="MySqlBulkLoaderConflictOption.None"/>).
+	/// </summary>
+	public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
+
+	public void StartImport(
+		string destinationTableName,
+		string[] columns,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(destinationTableName);
+		ArgumentNullException.ThrowIfNull(columns);
+		if (columns.Length == 0)
+		{
+			throw new ArgumentException("The column array is empty", nameof(columns));
+		}
+
+		if (importTask != null)
+		{
+			throw new InvalidOperationException($"First you need to wait for the previous import to complete by calling '{nameof(WaitFinishImportAsync)}'");
+		}
+
+		cancellationToken.ThrowIfCancellationRequested();
+		var tableName = destinationTableName ?? throw new InvalidOperationException("DestinationTableName must be set before calling WriteToServer");
+		var bulkLoader = new MySqlBulkLoader(m_connection)
+		{
+			CharacterSet = "utf8mb4",
+			EscapeCharacter = '\\',
+			FieldQuotationCharacter = '\0',
+			FieldTerminator = "\t",
+			LinePrefix = null,
+			LineTerminator = "\n",
+			Local = true,
+			NumberOfLinesToSkip = 0,
+			Source = this,
+			TableName = tableName,
+			Timeout = 0,
+			ConflictOption = ConflictOption,
+		};
+
+		bulkLoader.Columns.AddRange(columns);
+
+		var closeConnection = false;
+		if (m_connection.State != ConnectionState.Open)
+		{
+			m_connection.Open();
+			closeConnection = true;
+		}
+
+		importTask = Task.Run(async () =>
+		{
+			try
+			{
+				var errors = new List<MySqlError>();
+				MySqlInfoMessageEventHandler infoMessageHandler = (s, e) => errors.AddRange(e.Errors);
+				m_connection.InfoMessage += infoMessageHandler;
+
+				int rowsInserted;
+				try
+				{
+					rowsInserted = await bulkLoader.LoadAsync(IOBehavior.Asynchronous, cancellationToken).ConfigureAwait(false);
+				}
+				finally
+				{
+					m_connection.InfoMessage -= infoMessageHandler;
+				}
+			}
+			finally
+			{
+				if (closeConnection)
+					await m_connection.CloseAsync().ConfigureAwait(false);
+			}
+		},
+		cancellationToken);
+	}
+
+	public async Task WaitFinishImportAsync()
+	{
+		if (importTask == null)
+		{
+			return;
+		}
+		else
+		{
+			if (columnsCount != 0)
+			{
+				throw new InvalidOperationException($"Before calling '{nameof(WaitFinishImportAsync)}', you must close the line write by calling '{nameof(EndRow)}'");
+			}
+
+			var writer = channel.Writer;
+			if (bufferData != null)
+			{
+				writer.TryWrite(bufferData);
+				bufferData = null;
+			}
+
+			writer.Complete();
+			columnsCount = 0;
+			encoder = null;
+
+			try
+			{
+				await importTask.ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				// ignore
+			}
+
+			importTask = null;
+
+			channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+			{
+				SingleReader = true,
+				SingleWriter = true,
+				AllowSynchronousContinuations = false,
+			});
+		}
+	}
+
+	public void WriteColumnValue<T>(T value)
+	{
+		bufferData ??= new BufferData(pool.Rent(bufferSize), 0);
+
+		var totalBytesWritten = bufferData.TotalBytesWritten;
+		var span = bufferData.Buffer.AsSpan();
+		var inputIndex = 0;
+
+		if (totalBytesWritten >= bufferSize)
+		{
+			channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			totalBytesWritten = 0;
+			span = bufferData.Buffer.AsSpan();
+		}
+
+		if (columnsCount++ > 0)
+		{
+			const byte tabByte = (byte) '\t';
+			span[..bufferSize][totalBytesWritten++] = tabByte;
+		}
+
+		while (true)
+		{
+			var completeWrite = ValueWriteHelper.WriteValue(
+				m_connection,
+				value,
+				ref inputIndex,
+				ref encoder,
+				span[..bufferSize][totalBytesWritten..],
+				out var bytesWritten);
+
+			totalBytesWritten += bytesWritten;
+			bufferData.TotalBytesWritten = totalBytesWritten;
+			if (!completeWrite)
+			{
+				channel.Writer.TryWrite(bufferData);
+				bufferData = new BufferData(pool.Rent(bufferSize), 0);
+				totalBytesWritten = 0;
+				span = bufferData.Buffer.AsSpan();
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	public void EndRow()
+	{
+		if (columnsCount <= 0)
+		{
+			throw new InvalidOperationException("The row does not contain any values.");
+		}
+
+		var totalBytesWritten = bufferData!.TotalBytesWritten;
+		var span = bufferData.Buffer.AsSpan();
+
+		if (totalBytesWritten >= bufferSize)
+		{
+			channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			totalBytesWritten = 0;
+			span = bufferData.Buffer.AsSpan();
+		}
+
+		const byte newLineByte = (byte) '\n';
+		span[..bufferSize][totalBytesWritten++] = newLineByte;
+		bufferData!.TotalBytesWritten = totalBytesWritten;
+		columnsCount = 0;
+	}
+
+	internal async Task SendDataReaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+	{
+		var reader = channel.Reader;
+		while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+		{
+			while (reader.TryRead(out var bufferData))
+			{
+				try
+				{
+					var payload = new PayloadData(new ArraySegment<byte>(bufferData.Buffer, 0, bufferData.TotalBytesWritten));
+					await m_connection.Session.SendReplyAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
+				}
+				finally
+				{
+					pool.Return(bufferData.Buffer);
+				}
+			}
+		}
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		channel.Writer.TryComplete();
+		if (bufferData != null)
+		{
+			try
+			{
+				pool.Return(bufferData.Buffer);
+			}
+			catch
+			{
+				// ignore
+			}
+
+			bufferData = null;
+		}
+
+		if (importTask != null)
+		{
+			try
+			{
+				await importTask.ConfigureAwait(false);
+				importTask = null;
+			}
+			catch
+			{
+				// ignore
+			}
+		}
+
+		while (channel.Reader.TryRead(out var bufferData))
+		{
+			try
+			{
+				pool.Return(bufferData.Buffer);
+			}
+			catch
+			{
+				// ignore
+			}
+		}
+	}
+
+	private sealed class BufferData
+	{
+		public BufferData(
+			byte[] buffer,
+			int totalBytesWritten)
+		{
+			Buffer = buffer;
+			TotalBytesWritten = totalBytesWritten;
+		}
+
+		public int TotalBytesWritten { get; set; }
+
+		public byte[] Buffer { get; private set; }
+	}
+}
+
+public sealed class MySqlBulkImport2 : IAsyncDisposable
+{
+	private readonly int bufferSize;
+	private readonly MySqlConnection m_connection;
+	private readonly ArrayPool<byte> pool;
+	private Channel<BufferData> channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+	{
+		SingleReader = true,
+		SingleWriter = true,
+		AllowSynchronousContinuations = false,
+	});
+
+	private Encoder? encoder;
+	private BufferData? bufferData;
+	private int columnsCount;
+	private Task? importTask;
+
+	/// <summary>
+	/// Initializes a <see cref="MySqlBulkCopy"/> object with the specified connection, and optionally the active transaction.
+	/// </summary>
+	/// <param name="connection">The <see cref="MySqlConnection"/> to use.</param>
+	/// <param name="bufferSize">The size of the buffers requested from the pool</param>
+	/// <param name="pool">Pool for obtaining temporary buffers for writing data</param>
+	public MySqlBulkImport2(
+		MySqlConnection connection,
+		int bufferSize = 65_536,
+		ArrayPool<byte>? pool = null)
+	{
+		ArgumentNullException.ThrowIfNull(connection);
+		if (bufferSize < 1_000)
+		{
+			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(bufferSize));
+		}
+
+		this.bufferSize = bufferSize;
+		m_connection = connection;
+		this.pool = pool ?? ArrayPool<byte>.Shared;
+	}
+
+	/// <summary>
+	/// A <see cref="MySqlBulkLoaderConflictOption"/> value that specifies how conflicts are resolved (default <see cref="MySqlBulkLoaderConflictOption.None"/>).
+	/// </summary>
+	public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
+
+	public void StartImport(
+		string destinationTableName,
+		string[] columns,
+		CancellationToken cancellationToken)
+	{
+		ArgumentNullException.ThrowIfNull(destinationTableName);
+		ArgumentNullException.ThrowIfNull(columns);
+		if (columns.Length == 0)
+		{
+			throw new ArgumentException("The column array is empty", nameof(columns));
+		}
+
+		if (importTask != null)
+		{
+			throw new InvalidOperationException($"First you need to wait for the previous import to complete by calling '{nameof(WaitFinishImportAsync)}'");
+		}
+
+		cancellationToken.ThrowIfCancellationRequested();
+		var tableName = destinationTableName ?? throw new InvalidOperationException("DestinationTableName must be set before calling WriteToServer");
+		var bulkLoader = new MySqlBulkLoader(m_connection)
+		{
+			CharacterSet = "utf8mb4",
+			EscapeCharacter = '\\',
+			FieldQuotationCharacter = '\0',
+			FieldTerminator = "\t",
+			LinePrefix = null,
+			LineTerminator = "\n",
+			Local = true,
+			NumberOfLinesToSkip = 0,
+			Source = this,
+			TableName = tableName,
+			Timeout = 0,
+			ConflictOption = ConflictOption,
+		};
+
+		bulkLoader.Columns.AddRange(columns);
+
+		var closeConnection = false;
+		if (m_connection.State != ConnectionState.Open)
+		{
+			m_connection.Open();
+			closeConnection = true;
+		}
+
+		importTask = Task.Run(async () =>
+		{
+			try
+			{
+				var errors = new List<MySqlError>();
+				MySqlInfoMessageEventHandler infoMessageHandler = (s, e) => errors.AddRange(e.Errors);
+				m_connection.InfoMessage += infoMessageHandler;
+
+				int rowsInserted;
+				try
+				{
+					rowsInserted = await bulkLoader.LoadAsync(IOBehavior.Asynchronous, cancellationToken).ConfigureAwait(false);
+				}
+				finally
+				{
+					m_connection.InfoMessage -= infoMessageHandler;
+				}
+			}
+			finally
+			{
+				if (closeConnection)
+					await m_connection.CloseAsync().ConfigureAwait(false);
+			}
+		},
+		cancellationToken);
+	}
+
+	public async Task WaitFinishImportAsync()
+	{
+		if (importTask == null)
+		{
+			return;
+		}
+		else
+		{
+			if (columnsCount != 0)
+			{
+				throw new InvalidOperationException($"Before calling '{nameof(WaitFinishImportAsync)}', you must close the line write by calling '{nameof(EndRow)}'");
+			}
+
+			var writer = channel.Writer;
+			if (bufferData != null)
+			{
+				writer.TryWrite(bufferData);
+				bufferData = null;
+			}
+
+			writer.Complete();
+			columnsCount = 0;
+			encoder = null;
+
+			try
+			{
+				await importTask.ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				// ignore
+			}
+
+			importTask = null;
+
+			channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+			{
+				SingleReader = true,
+				SingleWriter = true,
+				AllowSynchronousContinuations = false,
+			});
+		}
+	}
+
+	public void WriteColumnValue<T>(T value)
+	{
+		bufferData ??= new BufferData(pool.Rent(bufferSize), 0);
+
+		var totalBytesWritten = bufferData.TotalBytesWritten;
+		var span = bufferData.Buffer.AsSpan();
+		var inputIndex = 0;
+
+		if (totalBytesWritten >= bufferSize)
+		{
+			channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			totalBytesWritten = 0;
+			span = bufferData.Buffer.AsSpan();
+		}
+
+		if (columnsCount++ > 0)
+		{
+			const byte tabByte = (byte) '\t';
+			span[..bufferSize][totalBytesWritten++] = tabByte;
+		}
+
+		while (true)
+		{
+			var completeWrite = ValueWriteHelper.WriteValue(
+				m_connection,
+				value,
+				ref inputIndex,
+				ref encoder,
+				span[..bufferSize][totalBytesWritten..],
+				out var bytesWritten);
+
+			totalBytesWritten += bytesWritten;
+			bufferData.TotalBytesWritten = totalBytesWritten;
+			if (!completeWrite)
+			{
+				channel.Writer.TryWrite(bufferData);
+				bufferData = new BufferData(pool.Rent(bufferSize), 0);
+				totalBytesWritten = 0;
+				span = bufferData.Buffer.AsSpan();
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	public void EndRow()
+	{
+		if (columnsCount <= 0)
+		{
+			throw new InvalidOperationException("The row does not contain any values.");
+		}
+
+		var totalBytesWritten = bufferData!.TotalBytesWritten;
+		var span = bufferData.Buffer.AsSpan();
+
+		if (totalBytesWritten >= bufferSize)
+		{
+			channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(pool.Rent(bufferSize), 0);
+			totalBytesWritten = 0;
+			span = bufferData.Buffer.AsSpan();
+		}
+
+		const byte newLineByte = (byte) '\n';
+		span[..bufferSize][totalBytesWritten++] = newLineByte;
+		bufferData!.TotalBytesWritten = totalBytesWritten;
+		columnsCount = 0;
+	}
+
+	internal async Task SendDataReaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
+	{
+		var reader = channel.Reader;
+		while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+		{
+			while (reader.TryRead(out var bufferData))
+			{
+				try
+				{
+					var payload = new PayloadData(new ArraySegment<byte>(bufferData.Buffer, 0, bufferData.TotalBytesWritten));
+					await m_connection.Session.SendReplyAsync(payload, ioBehavior, cancellationToken).ConfigureAwait(false);
+				}
+				finally
+				{
+					pool.Return(bufferData.Buffer);
+				}
+			}
+		}
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		channel.Writer.TryComplete();
+		if (bufferData != null)
+		{
+			try
+			{
+				pool.Return(bufferData.Buffer);
+			}
+			catch
+			{
+				// ignore
+			}
+
+			bufferData = null;
+		}
+
+		if (importTask != null)
+		{
+			try
+			{
+				await importTask.ConfigureAwait(false);
+				importTask = null;
+			}
+			catch
+			{
+				// ignore
+			}
+		}
+
+		while (channel.Reader.TryRead(out var bufferData))
+		{
+			try
+			{
+				pool.Return(bufferData.Buffer);
+			}
+			catch
+			{
+				// ignore
+			}
+		}
+	}
+
+	private sealed class BufferData
+	{
+		public BufferData(
+			byte[] buffer,
+			int totalBytesWritten)
+		{
+			Buffer = buffer;
+			TotalBytesWritten = totalBytesWritten;
+		}
+
+		public int TotalBytesWritten { get; set; }
+
+		public byte[] Buffer { get; private set; }
+	}
+}
+
+#endif

--- a/src/MySqlConnector/MySqlBulkImport.cs
+++ b/src/MySqlConnector/MySqlBulkImport.cs
@@ -3,6 +3,7 @@
 using System.Buffers;
 using System.Text;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 using MySqlConnector.Helpers;
 using MySqlConnector.Protocol;
 using MySqlConnector.Protocol.Serialization;
@@ -11,10 +12,12 @@ namespace MySqlConnector;
 
 public sealed class MySqlBulkImport : IAsyncDisposable
 {
-	private readonly int rentBufferSize;
+	private readonly ILogger m_logger;
+	private readonly int m_rentBufferSize;
 	private readonly MySqlConnection m_connection;
-	private readonly ArrayPool<byte> pool;
-	private Channel<BufferData> channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+	private readonly MySqlTransaction? m_transaction;
+	private readonly ArrayPool<byte> m_pool;
+	private Channel<BufferData> m_channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
 	{
 		SingleReader = true,
 		SingleWriter = true,
@@ -30,10 +33,12 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 	/// Initializes a <see cref="MySqlBulkCopy"/> object with the specified connection, and optionally the active transaction.
 	/// </summary>
 	/// <param name="connection">The <see cref="MySqlConnection"/> to use.</param>
+	/// <param name="transaction">(Optional) The <see cref="MySqlTransaction"/> to use.</param>
 	/// <param name="rentBufferSize">The size of the buffers requested from the pool</param>
 	/// <param name="pool">Pool for obtaining temporary buffers for writing data</param>
 	public MySqlBulkImport(
 		MySqlConnection connection,
+		MySqlTransaction? transaction = null,
 		int rentBufferSize = 65_536,
 		ArrayPool<byte>? pool = null)
 	{
@@ -43,9 +48,12 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			throw new ArgumentException("The buffer size cannot be less than 1000 bytes.", nameof(rentBufferSize));
 		}
 
-		this.rentBufferSize = rentBufferSize;
+		m_rentBufferSize = rentBufferSize;
 		m_connection = connection;
-		this.pool = pool ?? ArrayPool<byte>.Shared;
+		m_logger = m_connection.LoggingConfiguration.BulkCopyLogger;
+		m_transaction = transaction;
+		m_pool = pool ?? ArrayPool<byte>.Shared;
+		ColumnMappings = [];
 	}
 
 	/// <summary>
@@ -53,16 +61,30 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 	/// </summary>
 	public MySqlBulkLoaderConflictOption ConflictOption { get; set; }
 
-	public void StartImport(
+	/// <summary>
+	/// A collection of <see cref="MySqlBulkCopyColumnMapping"/> objects. If the columns being copied from the
+	/// data source line up one-to-one with the columns in the destination table then populating this collection is
+	/// unnecessary. Otherwise, this should be filled with a collection of <see cref="MySqlBulkCopyColumnMapping"/> objects
+	/// specifying how source columns are to be mapped onto destination columns. If one column mapping is specified,
+	/// then all must be specified.
+	/// </summary>
+	public List<MySqlBulkCopyColumnMapping> ColumnMappings { get; }
+
+	/// <summary>
+	/// Start inserting data
+	/// </summary>
+	/// <param name="destinationTableName">The name of the table to insert rows into.</param>
+	/// <param name="fieldsCount">Specifies how many columns we will fill in each row.</param>
+	/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+	public async Task StartImportAsync(
 		string destinationTableName,
-		string[] columns,
+		int fieldsCount,
 		CancellationToken cancellationToken = default)
 	{
 		ArgumentNullException.ThrowIfNull(destinationTableName);
-		ArgumentNullException.ThrowIfNull(columns);
-		if (columns.Length == 0)
+		if (fieldsCount <= 0)
 		{
-			throw new ArgumentException("The column array is empty", nameof(columns));
+			throw new ArgumentException($"The number of columns to write cannot be less than 1. To correctly specify '{nameof(ColumnMappings)}', you need to know the number of columns to be written.", nameof(fieldsCount));
 		}
 
 		if (importTask != null)
@@ -88,14 +110,24 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			ConflictOption = ConflictOption,
 		};
 
-		bulkLoader.Columns.AddRange(columns);
-
 		var closeConnection = false;
 		if (m_connection.State != ConnectionState.Open)
 		{
 			m_connection.Open();
 			closeConnection = true;
 		}
+
+		await ColumnMapperHelper.FillColumnMappingsAsync(
+			tableName,
+			fieldsCount,
+			m_logger,
+			IOBehavior.Asynchronous,
+			bulkLoader,
+			ColumnMappings,
+			m_connection,
+			m_transaction,
+			cancellationToken)
+			.ConfigureAwait(false);
 
 		importTask = Task.Run(async () =>
 		{
@@ -137,7 +169,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 				throw new InvalidOperationException($"Before calling '{nameof(WaitFinishImportAsync)}', you must close the line write by calling '{nameof(EndRow)}'");
 			}
 
-			var writer = channel.Writer;
+			var writer = m_channel.Writer;
 			if (bufferData != null)
 			{
 				writer.TryWrite(bufferData);
@@ -159,7 +191,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 			importTask = null;
 
-			channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
+			m_channel = Channel.CreateUnbounded<BufferData>(new UnboundedChannelOptions
 			{
 				SingleReader = true,
 				SingleWriter = true,
@@ -170,14 +202,14 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 	public void WriteColumnValue<T>(T value)
 	{
-		bufferData ??= new BufferData(pool.Rent(rentBufferSize), 0);
+		bufferData ??= new BufferData(m_pool.Rent(m_rentBufferSize), 0);
 		var buffer = bufferData.Buffer.AsSpan();
 
 		var totalBytesWritten = bufferData.TotalBytesWritten;
-		if (totalBytesWritten >= rentBufferSize)
+		if (totalBytesWritten >= m_rentBufferSize)
 		{
-			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
+			m_channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(m_pool.Rent(m_rentBufferSize), 0);
 			totalBytesWritten = 0;
 			buffer = bufferData.Buffer.AsSpan();
 		}
@@ -203,8 +235,8 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			bufferData.TotalBytesWritten = totalBytesWritten;
 			if (!completeWrite)
 			{
-				channel.Writer.TryWrite(bufferData);
-				bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
+				m_channel.Writer.TryWrite(bufferData);
+				bufferData = new BufferData(m_pool.Rent(m_rentBufferSize), 0);
 				totalBytesWritten = 0;
 				buffer = bufferData.Buffer.AsSpan();
 			}
@@ -224,10 +256,10 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 		int totalBytesWritten = bufferData!.TotalBytesWritten;
 		Span<byte> buffer;
-		if (totalBytesWritten >= rentBufferSize)
+		if (totalBytesWritten >= m_rentBufferSize)
 		{
-			channel.Writer.TryWrite(bufferData);
-			bufferData = new BufferData(pool.Rent(rentBufferSize), 0);
+			m_channel.Writer.TryWrite(bufferData);
+			bufferData = new BufferData(m_pool.Rent(m_rentBufferSize), 0);
 			totalBytesWritten = 0;
 			buffer = bufferData.Buffer.AsSpan();
 		}
@@ -244,7 +276,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 	internal async Task SendDataReaderAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 	{
-		var reader = channel.Reader;
+		var reader = m_channel.Reader;
 		while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
 		{
 			while (reader.TryRead(out var bufferData))
@@ -256,7 +288,7 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 				}
 				finally
 				{
-					pool.Return(bufferData.Buffer);
+					m_pool.Return(bufferData.Buffer);
 				}
 			}
 		}
@@ -264,12 +296,12 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 
 	public async ValueTask DisposeAsync()
 	{
-		channel.Writer.TryComplete();
+		m_channel.Writer.TryComplete();
 		if (bufferData != null)
 		{
 			try
 			{
-				pool.Return(bufferData.Buffer);
+				m_pool.Return(bufferData.Buffer);
 			}
 			catch
 			{
@@ -292,11 +324,11 @@ public sealed class MySqlBulkImport : IAsyncDisposable
 			}
 		}
 
-		while (channel.Reader.TryRead(out var bufferData))
+		while (m_channel.Reader.TryRead(out var bufferData))
 		{
 			try
 			{
-				pool.Return(bufferData.Buffer);
+				m_pool.Return(bufferData.Buffer);
 			}
 			catch
 			{

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Testcontainers.MySql" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MySqlConnector\MySqlConnector.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Benchmarks/Cases/BenchmarkBase.cs
+++ b/tests/Benchmarks/Cases/BenchmarkBase.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading.Tasks;
+using Benchmarks.Helpers;
+using DotNet.Testcontainers.Builders;
+using MySqlConnector;
+using Testcontainers.MySql;
+
+namespace Benchmarks.Cases
+{
+    public abstract class BenchmarkBase
+    {
+#pragma warning disable SA1309 // Field names should not begin with underscore
+		private MySqlContainer _mysql;
+#pragma warning restore SA1309 // Field names should not begin with underscore
+
+#pragma warning disable SA1401 // Fields should be private
+		public MySqlDataSource MySqlDataSource;
+#pragma warning restore SA1401 // Fields should be private
+
+		public async Task OneTimeSetUp()
+        {
+            _mysql =
+                new MySqlBuilder("mysql:9.7.0")
+                .WithUsername("root")
+                .WithPassword("dhgvbh73j")
+                .WithPortBinding(3306, true)
+                .WithAutoRemove(true)
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(3306))
+                .Build();
+
+            await _mysql.StartAsync();
+            await _mysql.WaitContainerStateRunningAsync(TimeSpan.FromMinutes(1));
+            await _mysql.WaitResponseAsync(TimeSpan.FromMinutes(1));
+
+            await using (var masterConnection = new MySqlConnection(_mysql.GetConnectionString()))
+            {
+                await masterConnection.OpenAsync();
+                await using var createCmd = masterConnection.CreateCommand();
+                createCmd.CommandText = $@"
+CREATE DATABASE IF NOT EXISTS benchmark;
+";
+                createCmd.ExecuteNonQuery();
+            }
+
+            var builder = new MySqlConnectionStringBuilder(_mysql.GetConnectionString());
+            builder.Database = "benchmark";
+            builder.AllowLoadLocalInfile = true;
+
+            MySqlDataSource = new MySqlDataSource(builder.ConnectionString);
+
+            await using var connection = await MySqlDataSource.OpenConnectionAsync();
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = @"
+SET GLOBAL local_infile = 1;
+";
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+		protected async Task OneTimeTearDown()
+        {
+            var dataSource = MySqlDataSource;
+            if (dataSource != null)
+            {
+                try
+                {
+                    await dataSource.DisposeAsync();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
+            if (_mysql != null)
+            {
+                try
+                {
+                    await _mysql.DisposeAsync();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+        }
+    }
+}

--- a/tests/Benchmarks/Cases/BenchmarkBase.cs
+++ b/tests/Benchmarks/Cases/BenchmarkBase.cs
@@ -17,22 +17,27 @@ namespace Benchmarks.Cases
 		public MySqlDataSource MySqlDataSource;
 #pragma warning restore SA1401 // Fields should be private
 
-		public async Task OneTimeSetUp()
+		public async Task OneTimeSetUp(string connectionString = null)
         {
-            _mysql =
-                new MySqlBuilder("mysql:9.7.0")
-                .WithUsername("root")
-                .WithPassword("dhgvbh73j")
-                .WithPortBinding(3306, true)
-                .WithAutoRemove(true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(3306))
-                .Build();
+			if (connectionString == null)
+			{
+				_mysql =
+					new MySqlBuilder("mysql:9.7.0")
+					.WithUsername("root")
+					.WithPassword("dhgvbh73j")
+					.WithPortBinding(3306, true)
+					.WithAutoRemove(true)
+					.WithWaitStrategy(Wait.ForUnixContainer().UntilExternalTcpPortIsAvailable(3306))
+					.Build();
 
-            await _mysql.StartAsync();
-            await _mysql.WaitContainerStateRunningAsync(TimeSpan.FromMinutes(1));
-            await _mysql.WaitResponseAsync(TimeSpan.FromMinutes(1));
+				await _mysql.StartAsync();
+				await _mysql.WaitContainerStateRunningAsync(TimeSpan.FromMinutes(1));
+				await _mysql.WaitResponseAsync(TimeSpan.FromMinutes(1));
 
-            await using (var masterConnection = new MySqlConnection(_mysql.GetConnectionString()))
+				connectionString = _mysql.GetConnectionString();
+			}
+
+			await using (var masterConnection = new MySqlConnection(connectionString))
             {
                 await masterConnection.OpenAsync();
                 await using var createCmd = masterConnection.CreateCommand();
@@ -42,14 +47,14 @@ CREATE DATABASE IF NOT EXISTS benchmark;
                 createCmd.ExecuteNonQuery();
             }
 
-            var builder = new MySqlConnectionStringBuilder(_mysql.GetConnectionString());
-            builder.Database = "benchmark";
-            builder.AllowLoadLocalInfile = true;
+			var builder = new MySqlConnectionStringBuilder(connectionString);
+			builder.Database = "benchmark";
+			builder.AllowLoadLocalInfile = true;
 
-            MySqlDataSource = new MySqlDataSource(builder.ConnectionString);
+			MySqlDataSource = new MySqlDataSource(builder.ConnectionString);
 
-            await using var connection = await MySqlDataSource.OpenConnectionAsync();
-            {
+			await using var connection = await MySqlDataSource.OpenConnectionAsync();
+			{
                 using var cmd = connection.CreateCommand();
                 cmd.CommandText = @"
 SET GLOBAL local_infile = 1;

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -110,6 +110,8 @@ namespace Benchmarks.Cases
 				newRow["five"] = rowData.Five;
 				newRow["six"] = rowData.Six;
 				newRow["seven"] = rowData.Seven;
+
+				rows.Add(newRow);
 			}
 
 			await using var connection = MySqlDataSource.CreateConnection();
@@ -119,7 +121,7 @@ namespace Benchmarks.Cases
 				BulkCopyTimeout = 0,
 			};
 
-			await bulkCopy.WriteToServerAsync(rows, 5);
+			await bulkCopy.WriteToServerAsync(rows, 7);
 		}
 
 		[Benchmark(Description = "MySqlBulkCopy.IDataReader")]

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -121,7 +121,7 @@ namespace Benchmarks.Cases
 				BulkCopyTimeout = 0,
 			};
 
-			await bulkCopy.WriteToServerAsync(rows, 7);
+			await bulkCopy.WriteToServerAsync(rows, 9);
 		}
 
 		[Benchmark(Description = "MySqlBulkCopy.IDataReader")]

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace Benchmarks.Cases
     {
 		private RowData[] collection;
 
-		[Params(500, 5_000, 50_000, 500_000)]
+		[Params(500, 5_000, 50_000)]
 #pragma warning disable SA1401 // Fields should be private
 		public int RowsToInsert;
 #pragma warning restore SA1401 // Fields should be private
@@ -44,7 +45,9 @@ namespace Benchmarks.Cases
 				ignore_two varchar(200),
 				three varchar(200),
 				four datetime,
-				five blob
+				five int,
+				six datetime,
+				seven int
 			)
 			CHARACTER SET = UTF8;";
 
@@ -65,6 +68,9 @@ namespace Benchmarks.Cases
 					Two = $"two-{id}",
 					Three = $"three-{id}",
 					Four = startDate.AddSeconds(id),
+					Five = id + 1,
+					Six = startDate.AddSeconds(id + 1),
+					Seven = id + 2,
 				};
 			}
 		}
@@ -81,10 +87,45 @@ namespace Benchmarks.Cases
 			command.ExecuteNonQuery();
 		}
 
-		[Benchmark(Baseline = true, Description = "MySqlBulkCopy.IDataReader")]
+		[Benchmark(Baseline = true, Description = "MySqlBulkCopy.DataRows")]
+		public async Task DataRowsCase()
+		{
+			DataTable table = new();
+			table.Columns.Add("one", typeof(int));
+			table.Columns.Add("two", typeof(string));
+			table.Columns.Add("three", typeof(string));
+			table.Columns.Add("four", typeof(DateTime));
+			table.Columns.Add("five", typeof(int));
+			table.Columns.Add("six", typeof(DateTime));
+			table.Columns.Add("seven", typeof(int));
+
+			var rows = new List<DataRow>();
+			foreach (var rowData in collection)
+			{
+				var newRow = table.NewRow();
+				newRow["one"] = rowData.One;
+				newRow["two"] = rowData.Two;
+				newRow["three"] = rowData.Three;
+				newRow["four"] = rowData.Four;
+				newRow["five"] = rowData.Five;
+				newRow["six"] = rowData.Six;
+				newRow["seven"] = rowData.Seven;
+			}
+
+			await using var connection = MySqlDataSource.CreateConnection();
+			var bulkCopy = new MySqlBulkCopy(connection)
+			{
+				DestinationTableName = "mysql_bulk_import.person",
+				BulkCopyTimeout = 0,
+			};
+
+			await bulkCopy.WriteToServerAsync(rows, 5);
+		}
+
+		[Benchmark(Description = "MySqlBulkCopy.IDataReader")]
 		public async Task DataReaderCase()
 		{
-			using var connection = MySqlDataSource.CreateConnection();
+			await using var connection = MySqlDataSource.CreateConnection();
 
 			var bc = new MySqlBulkCopy(connection)
 			{
@@ -95,6 +136,9 @@ namespace Benchmarks.Cases
 					new(1, "two"),
 					new(2, "three"),
 					new(3, "four"),
+					new(4, "five"),
+					new(5, "six"),
+					new(6, "seven"),
 				},
 				BulkCopyTimeout = 0,
 			};
@@ -103,12 +147,12 @@ namespace Benchmarks.Cases
 			await bc.WriteToServerAsync(reader);
 		}
 
-		[Benchmark(Description = "MySqlBulkImport2")]
+		[Benchmark(Description = "MySqlBulkImport")]
 		public async Task MySqlBulkImportCase()
 		{
-			using var connection = MySqlDataSource.CreateConnection();
-			await using var import = new MySqlConnector.MySqlBulkImport2(connection, 1048575);
-			import.StartImport("mysql_bulk_import", ["one", "two", "three", "four"], default);
+			await using var connection = MySqlDataSource.CreateConnection();
+			await using var import = new MySqlConnector.MySqlBulkImport(connection);
+			import.StartImport("mysql_bulk_import", ["one", "two", "three", "four", "five", "six", "seven"], default);
 
 			foreach (var row in collection)
 			{
@@ -116,6 +160,10 @@ namespace Benchmarks.Cases
 				import.WriteColumnValue(row.Two);
 				import.WriteColumnValue(row.Three);
 				import.WriteColumnValue(row.Four);
+				import.WriteColumnValue(row.Five);
+				import.WriteColumnValue(row.Six);
+				import.WriteColumnValue(row.Seven);
+
 				import.EndRow();
 			}
 
@@ -131,6 +179,12 @@ namespace Benchmarks.Cases
 			public string Three { get; set; }
 
 			public DateTime Four { get; set; }
+
+			public int Five { get; set; }
+
+			public DateTime Six { get; set; }
+
+			public int Seven { get; set; }
 		}
 
 		public class DataReader : IDataReader
@@ -153,7 +207,7 @@ namespace Benchmarks.Cases
 
 			public int RecordsAffected => throw new NotImplementedException();
 
-			public int FieldCount => 4;
+			public int FieldCount => 7;
 
 			public void Close() => throw new NotImplementedException();
 			public void Dispose() => throw new NotImplementedException();
@@ -182,12 +236,17 @@ namespace Benchmarks.Cases
 
 			public int GetValues(object[] values)
 			{
-				values[0] = collection[currentIndex].One;
-				values[1] = collection[currentIndex].Two;
-				values[2] = collection[currentIndex].Three;
-				values[3] = collection[currentIndex].Four;
+				var value = collection[currentIndex];
 
-				return 4;
+				values[0] = value.One;
+				values[1] = value.Two;
+				values[2] = value.Three;
+				values[3] = value.Four;
+				values[4] = value.Five;
+				values[5] = value.Six;
+				values[6] = value.Seven;
+
+				return 7;
 			}
 
 			public bool IsDBNull(int i) => throw new NotImplementedException();

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -155,8 +155,49 @@ namespace Benchmarks.Cases
 		public async Task MySqlBulkImportCaseAsync()
 		{
 			await using var connection = MySqlDataSource.CreateConnection();
-			await using var import = new MySqlConnector.MySqlBulkImport(connection);
-			import.StartImport("mysql_bulk_import", ["one", "two", "three", "four", "five", "six", "seven"], default);
+			await using var import = new MySqlConnector.MySqlBulkImport(connection)
+			{
+				ColumnMappings =
+				{
+					new()
+					{
+						SourceOrdinal = 0,
+						DestinationColumn = "one",
+					},
+					new()
+					{
+						SourceOrdinal = 1,
+						DestinationColumn = "two",
+					},
+					new()
+					{
+						SourceOrdinal = 2,
+						DestinationColumn = "three",
+					},
+					new()
+					{
+						SourceOrdinal = 3,
+						DestinationColumn = "four",
+					},
+					new()
+					{
+						SourceOrdinal = 4,
+						DestinationColumn = "five",
+					},
+					new()
+					{
+						SourceOrdinal = 5,
+						DestinationColumn = "six",
+					},
+					new()
+					{
+						SourceOrdinal = 6,
+						DestinationColumn = "seven",
+					},
+				},
+			};
+
+			await import.StartImportAsync("mysql_bulk_import", 7);
 
 			foreach (var row in collection)
 			{

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -16,7 +16,7 @@ namespace Benchmarks.Cases
     {
 		private RowData[] collection;
 
-		[Params(500, 5_000, 50_000)]
+		[Params(500, 5_000, 50_000, 100_000)]
 #pragma warning disable SA1401 // Fields should be private
 		public int RowsToInsert;
 #pragma warning restore SA1401 // Fields should be private

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -22,13 +22,13 @@ namespace Benchmarks.Cases
 #pragma warning restore SA1401 // Fields should be private
 
 		[GlobalSetup]
-		public async Task GlobalSetup()
+		public async Task GlobalSetupAsync()
         {
             await OneTimeSetUp();
 		}
 
 		[GlobalCleanup]
-		public async Task GlobalCleanup()
+		public async Task GlobalCleanupAsync()
         {
             await OneTimeTearDown();
         }
@@ -88,11 +88,13 @@ namespace Benchmarks.Cases
 		}
 
 		[Benchmark(Baseline = true, Description = "MySqlBulkCopy.DataRows")]
-		public async Task DataRowsCase()
+		public async Task DataRowsCaseAsync()
 		{
 			DataTable table = new();
 			table.Columns.Add("one", typeof(int));
+			table.Columns.Add("ignore_one", typeof(int));
 			table.Columns.Add("two", typeof(string));
+			table.Columns.Add("ignore_two", typeof(string));
 			table.Columns.Add("three", typeof(string));
 			table.Columns.Add("four", typeof(DateTime));
 			table.Columns.Add("five", typeof(int));
@@ -125,7 +127,7 @@ namespace Benchmarks.Cases
 		}
 
 		[Benchmark(Description = "MySqlBulkCopy.IDataReader")]
-		public async Task DataReaderCase()
+		public async Task DataReaderCaseAsync()
 		{
 			await using var connection = MySqlDataSource.CreateConnection();
 
@@ -150,7 +152,7 @@ namespace Benchmarks.Cases
 		}
 
 		[Benchmark(Description = "MySqlBulkImport")]
-		public async Task MySqlBulkImportCase()
+		public async Task MySqlBulkImportCaseAsync()
 		{
 			await using var connection = MySqlDataSource.CreateConnection();
 			await using var import = new MySqlConnector.MySqlBulkImport(connection);

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -115,7 +115,7 @@ namespace Benchmarks.Cases
 			await using var connection = MySqlDataSource.CreateConnection();
 			var bulkCopy = new MySqlBulkCopy(connection)
 			{
-				DestinationTableName = "mysql_bulk_import.person",
+				DestinationTableName = "mysql_bulk_import",
 				BulkCopyTimeout = 0,
 			};
 

--- a/tests/Benchmarks/Cases/MySqlBulkImport.cs
+++ b/tests/Benchmarks/Cases/MySqlBulkImport.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using MySqlConnector;
+
+namespace Benchmarks.Cases
+{
+	[MemoryDiagnoser]
+	[ThreadingDiagnoser]
+	[SimpleJob(RuntimeMoniker.Net10_0)]
+	public class MySqlBulkImport : BenchmarkBase
+    {
+		private RowData[] collection;
+
+		[Params(500, 5_000, 50_000, 500_000)]
+#pragma warning disable SA1401 // Fields should be private
+		public int RowsToInsert;
+#pragma warning restore SA1401 // Fields should be private
+
+		[GlobalSetup]
+		public async Task GlobalSetup()
+        {
+            await OneTimeSetUp();
+		}
+
+		[GlobalCleanup]
+		public async Task GlobalCleanup()
+        {
+            await OneTimeTearDown();
+        }
+
+		[IterationSetup]
+		public void IterationSetup()
+        {
+			var sql = $@"
+			create table mysql_bulk_import
+			(
+				one int primary key,
+				ignore_one int,
+				two varchar(200),
+				ignore_two varchar(200),
+				three varchar(200),
+				four datetime,
+				five blob
+			)
+			CHARACTER SET = UTF8;";
+
+			using var connection = MySqlDataSource.OpenConnection();
+			using var command = connection.CreateCommand();
+			command.CommandText = sql;
+
+			command.ExecuteNonQuery();
+
+			collection = new RowData[RowsToInsert];
+			var startDate = DateTime.UtcNow;
+			for (var i = 0; i < collection.Length; i++)
+			{
+				var id = i + 1;
+				collection[i] = new RowData
+				{
+					One = id,
+					Two = $"two-{id}",
+					Three = $"three-{id}",
+					Four = startDate.AddSeconds(id),
+				};
+			}
+		}
+
+		[IterationCleanup]
+		public void IterationCleanup()
+        {
+			var sql = "drop table if exists mysql_bulk_import;";
+
+			using var connection = MySqlDataSource.OpenConnection();
+			using var command = connection.CreateCommand();
+			command.CommandText = sql;
+
+			command.ExecuteNonQuery();
+		}
+
+		[Benchmark(Baseline = true, Description = "MySqlBulkCopy.IDataReader")]
+		public async Task DataReaderCase()
+		{
+			using var connection = MySqlDataSource.CreateConnection();
+
+			var bc = new MySqlBulkCopy(connection)
+			{
+				DestinationTableName = "mysql_bulk_import",
+				ColumnMappings =
+				{
+					new(0, "one"),
+					new(1, "two"),
+					new(2, "three"),
+					new(3, "four"),
+				},
+				BulkCopyTimeout = 0,
+			};
+
+			var reader = new DataReader(collection);
+			await bc.WriteToServerAsync(reader);
+		}
+
+		[Benchmark(Description = "MySqlBulkImport2")]
+		public async Task MySqlBulkImportCase()
+		{
+			using var connection = MySqlDataSource.CreateConnection();
+			await using var import = new MySqlConnector.MySqlBulkImport2(connection, 1048575);
+			import.StartImport("mysql_bulk_import", ["one", "two", "three", "four"], default);
+
+			foreach (var row in collection)
+			{
+				import.WriteColumnValue(row.One);
+				import.WriteColumnValue(row.Two);
+				import.WriteColumnValue(row.Three);
+				import.WriteColumnValue(row.Four);
+				import.EndRow();
+			}
+
+			await import.WaitFinishImportAsync();
+		}
+
+		public class RowData
+		{
+			public int One { get; set; }
+
+			public string Two { get; set; }
+
+			public string Three { get; set; }
+
+			public DateTime Four { get; set; }
+		}
+
+		public class DataReader : IDataReader
+		{
+			private readonly RowData[] collection;
+			private int currentIndex;
+
+			public DataReader(RowData[] collection)
+			{
+				this.collection = collection;
+			}
+
+			public object this[int i] => throw new NotImplementedException();
+
+			public object this[string name] => throw new NotImplementedException();
+
+			public int Depth => throw new NotImplementedException();
+
+			public bool IsClosed => throw new NotImplementedException();
+
+			public int RecordsAffected => throw new NotImplementedException();
+
+			public int FieldCount => 4;
+
+			public void Close() => throw new NotImplementedException();
+			public void Dispose() => throw new NotImplementedException();
+			public bool GetBoolean(int i) => throw new NotImplementedException();
+			public byte GetByte(int i) => throw new NotImplementedException();
+			public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) => throw new NotImplementedException();
+			public char GetChar(int i) => throw new NotImplementedException();
+			public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) => throw new NotImplementedException();
+			public IDataReader GetData(int i) => throw new NotImplementedException();
+			public string GetDataTypeName(int i) => throw new NotImplementedException();
+			public DateTime GetDateTime(int i) => throw new NotImplementedException();
+			public decimal GetDecimal(int i) => throw new NotImplementedException();
+			public double GetDouble(int i) => throw new NotImplementedException();
+			[return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+			public Type GetFieldType(int i) => throw new NotImplementedException();
+			public float GetFloat(int i) => throw new NotImplementedException();
+			public Guid GetGuid(int i) => throw new NotImplementedException();
+			public short GetInt16(int i) => throw new NotImplementedException();
+			public int GetInt32(int i) => throw new NotImplementedException();
+			public long GetInt64(int i) => throw new NotImplementedException();
+			public string GetName(int i) => throw new NotImplementedException();
+			public int GetOrdinal(string name) => throw new NotImplementedException();
+			public DataTable GetSchemaTable() => throw new NotImplementedException();
+			public string GetString(int i) => throw new NotImplementedException();
+			public object GetValue(int i) => throw new NotImplementedException();
+
+			public int GetValues(object[] values)
+			{
+				values[0] = collection[currentIndex].One;
+				values[1] = collection[currentIndex].Two;
+				values[2] = collection[currentIndex].Three;
+				values[3] = collection[currentIndex].Four;
+
+				return 4;
+			}
+
+			public bool IsDBNull(int i) => throw new NotImplementedException();
+			public bool NextResult() => throw new NotImplementedException();
+
+			public bool Read()
+			{
+				if (currentIndex >= collection.Length - 1)
+				{
+					return false;
+				}
+
+				currentIndex++;
+				return true;
+			}
+		}
+	}
+}

--- a/tests/Benchmarks/Helpers/ContainerHelpers.cs
+++ b/tests/Benchmarks/Helpers/ContainerHelpers.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Containers;
+using MySqlConnector;
+using Testcontainers.MySql;
+
+namespace Benchmarks.Helpers
+{
+    internal static class ContainerHelpers
+    {
+        /// <summary>
+        /// Wait untill container start
+        /// </summary>
+        public static async ValueTask WaitContainerStateRunningAsync(this DockerContainer dockerContainer, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (true)
+            {
+                if (dockerContainer.State == TestcontainersStates.Running)
+                {
+                    break;
+                }
+
+                if (sw.Elapsed >= timeout)
+                {
+                    throw new Exception($"Container start timeout ({timeout}) exceeded, benchmark stopped, current container state is {dockerContainer.State}.");
+                }
+
+                await Task.Delay(100);
+            }
+        }
+
+        /// <summary>
+        /// Wait until the container responds to at least one request
+        /// </summary>
+        public static async ValueTask WaitResponseAsync(this MySqlContainer container, TimeSpan timeout)
+        {
+            var sw = Stopwatch.StartNew();
+            while (true)
+            {
+                if (sw.Elapsed >= timeout)
+                {
+                    throw new Exception($"MySQL has not responded to any queries in {timeout}. Container state {container.State}");
+                }
+
+                var connectionString = container.GetConnectionString();
+                try
+                {
+                    await using (var conn = new MySqlConnection(connectionString))
+                    {
+                        await conn.OpenAsync();
+                        await using var command = conn.CreateCommand();
+                        command.CommandText = "SELECT 1";
+                        var result = await command.ExecuteScalarAsync();
+
+                        if ((result is int intValue && intValue == 1) || (result is long longValue && longValue == 1))
+                        {
+                            break;
+                        }
+                    }
+                }
+                catch
+                {
+                    // игнорим
+                }
+
+                await Task.Delay(100);
+            }
+        }
+    }
+}

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using BenchmarkDotNet.Running;
+using Benchmarks.Cases;
+
+namespace Benchmarks
+{
+	internal class Program
+	{
+		private static async Task Main(string[] args)
+		{
+			BenchmarkRunner.Run<MySqlBulkImport>();
+		}
+	}
+}

--- a/tests/IntegrationTests/BulkLoaderAsync.cs
+++ b/tests/IntegrationTests/BulkLoaderAsync.cs
@@ -1,4 +1,3 @@
-using MySqlConnector.Core;
 using Xunit.Sdk;
 
 namespace IntegrationTests;

--- a/tests/IntegrationTests/BulkLoaderAsync.cs
+++ b/tests/IntegrationTests/BulkLoaderAsync.cs
@@ -678,7 +678,7 @@ create table bulk_load_data_table(id BIGINT UNIQUE NOT NULL AUTO_INCREMENT, geo_
 #if NET6_0_OR_GREATER
 
 	[Fact]
-	public async Task MySqlBulkImportDataTableWithLongData()
+	public async Task MySqlBulkImport()
 	{
 		var rows = new List<(int, string)>()
 		{
@@ -688,14 +688,14 @@ create table bulk_load_data_table(id BIGINT UNIQUE NOT NULL AUTO_INCREMENT, geo_
 
 		using var connection = new MySqlConnection(GetLocalConnectionString());
 		await connection.OpenAsync();
-		using (var cmd = new MySqlCommand(@"drop table if exists bulk_import_data_table;
-create table bulk_import_data_table(value int, name text);", connection))
+		using (var cmd = new MySqlCommand(@"drop table if exists bulk_import_table;
+create table bulk_import_table(value int, name text);", connection))
 		{
 			await cmd.ExecuteNonQueryAsync();
 		}
 
 		var bulkImport = new MySqlBulkImport(connection);
-		bulkImport.StartImport("bulk_import_data_table", ["value", "name"]);
+		bulkImport.StartImport("bulk_import_table", ["value", "name"]);
 
 		foreach (var row in rows)
 		{
@@ -706,7 +706,7 @@ create table bulk_import_data_table(value int, name text);", connection))
 
 		await bulkImport.WaitFinishImportAsync();
 
-		await using (var cmd = new MySqlCommand(@"select value, name from bulk_import_data_table", connection))
+		await using (var cmd = new MySqlCommand(@"select value, name from bulk_import_table", connection))
 		{
 			await using var reader = await cmd.ExecuteReaderAsync();
 

--- a/tests/IntegrationTests/BulkLoaderAsync.cs
+++ b/tests/IntegrationTests/BulkLoaderAsync.cs
@@ -674,6 +674,61 @@ create table bulk_load_data_table(id BIGINT UNIQUE NOT NULL AUTO_INCREMENT, geo_
 
 		await bc.WriteToServerAsync(dataTable);
 	}
+
+#if NET6_0_OR_GREATER
+
+	[Fact]
+	public async Task MySqlBulkImportDataTableWithLongData()
+	{
+		var rows = new List<(int, string)>()
+		{
+			new(1, "row 1"),
+			new(12345678, "row 12345678"),
+		};
+
+		using var connection = new MySqlConnection(GetLocalConnectionString());
+		await connection.OpenAsync();
+		using (var cmd = new MySqlCommand(@"drop table if exists bulk_import_data_table;
+create table bulk_import_data_table(value int, name text);", connection))
+		{
+			await cmd.ExecuteNonQueryAsync();
+		}
+
+		var bulkImport = new MySqlBulkImport(connection);
+		bulkImport.StartImport("bulk_import_data_table", ["value", "name"]);
+
+		foreach (var row in rows)
+		{
+			bulkImport.WriteColumnValue(row.Item1);
+			bulkImport.WriteColumnValue(row.Item2);
+			bulkImport.EndRow();
+		}
+
+		await bulkImport.WaitFinishImportAsync();
+
+		await using (var cmd = new MySqlCommand(@"select value, name from bulk_import_data_table", connection))
+		{
+			await using var reader = await cmd.ExecuteReaderAsync();
+
+			var rowsCount = 0;
+			while (reader.Read())
+			{
+				rowsCount++;
+				var a = reader.GetFieldValue<int>(0);
+				Assert.Contains(rows, wh => wh.Item1 == a);
+
+				var expect = rows.First(wh => wh.Item1 == a);
+				var b = reader.GetFieldValue<string>(1);
+
+				Assert.Equal(expect.Item2, b);
+			}
+
+			Assert.Equal(rows.Count, rowsCount);
+		}
+	}
+
+#endif
+
 #endif
 
 	private static string GetConnectionString() => BulkLoaderSync.GetConnectionString();

--- a/tests/IntegrationTests/BulkLoaderAsync.cs
+++ b/tests/IntegrationTests/BulkLoaderAsync.cs
@@ -1,3 +1,4 @@
+using MySqlConnector.Core;
 using Xunit.Sdk;
 
 namespace IntegrationTests;
@@ -678,7 +679,7 @@ create table bulk_load_data_table(id BIGINT UNIQUE NOT NULL AUTO_INCREMENT, geo_
 #if NET6_0_OR_GREATER
 
 	[Fact]
-	public async Task MySqlBulkImport()
+	public async Task MySqlBulkImportDataReader()
 	{
 		var rows = new List<(int, string)>()
 		{
@@ -695,7 +696,7 @@ create table bulk_import_table(value int, name text);", connection))
 		}
 
 		var bulkImport = new MySqlBulkImport(connection);
-		bulkImport.StartImport("bulk_import_table", ["value", "name"]);
+		await bulkImport.StartImportAsync("bulk_import_table", 2);
 
 		foreach (var row in rows)
 		{
@@ -724,6 +725,49 @@ create table bulk_import_table(value int, name text);", connection))
 			}
 
 			Assert.Equal(rows.Count, rowsCount);
+		}
+	}
+
+	[Fact]
+	public async Task MySqlBulkImportLongBlob()
+	{
+		var emptyArray = new byte[524200];
+		var rows = new List<(int, byte[])>()
+		{
+			new(1, emptyArray),
+			new(12345678, emptyArray),
+		};
+
+		using var connection = new MySqlConnection(GetLocalConnectionString());
+		await connection.OpenAsync();
+		using (var cmd = new MySqlCommand(@"drop table if exists bulk_import_table;
+create table bulk_import_table(a int, b longblob);", connection))
+		{
+			await cmd.ExecuteNonQueryAsync();
+		}
+
+		var bulkImport = new MySqlBulkImport(connection);
+		await bulkImport.StartImportAsync("bulk_import_table", 2);
+
+		foreach (var row in rows)
+		{
+			bulkImport.WriteColumnValue(row.Item1);
+			bulkImport.WriteColumnValue(row.Item2);
+			bulkImport.EndRow();
+		}
+
+		await bulkImport.WaitFinishImportAsync();
+
+		using (var cmd = new MySqlCommand(@"select b from bulk_import_table;", connection))
+		{
+			using (var reader = cmd.ExecuteReader())
+			{
+				while (reader.Read())
+				{
+					var actual = reader.GetFieldValue<byte[]>(0);
+					Assert.Equal(actual, emptyArray);
+				}
+			}
 		}
 	}
 

--- a/tests/IntegrationTests/BulkLoaderSync.cs
+++ b/tests/IntegrationTests/BulkLoaderSync.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using MySqlConnector.Helpers;
 using Xunit.Sdk;
 
 namespace IntegrationTests;
@@ -480,6 +481,85 @@ public class BulkLoaderSync : IClassFixture<DatabaseFixture>
 		connection.Open();
 		MySqlBulkLoader bl = new MySqlBulkLoader(connection);
 		using var memoryStream = new MemoryStream(m_memoryStreamBytes, false);
+#if !MYSQL_DATA
+		bl.SourceStream = memoryStream;
+#endif
+		bl.TableName = m_testTable;
+		bl.CharacterSet = "UTF8";
+		bl.Columns.AddRange(new string[] { "one", "two", "three" });
+		bl.NumberOfLinesToSkip = 0;
+		bl.FieldTerminator = ",";
+		bl.FieldQuotationCharacter = '"';
+		bl.FieldQuotationOptional = true;
+		bl.Local = true;
+#if !MYSQL_DATA
+		int rowCount = bl.Load();
+#else
+		int rowCount = bl.Load(memoryStream);
+#endif
+		Assert.Equal(5, rowCount);
+	}
+
+	[Fact]
+	public void BulkLoadLocalMemoryStreamManual()
+	{
+		using var connection = new MySqlConnection(GetLocalConnectionString());
+		connection.Open();
+		MySqlBulkLoader bl = new MySqlBulkLoader(connection);
+
+		const byte newLineByte = (byte)'\n';
+		const char qChar = '\'';
+		const char commaChar = ',';
+
+		var memory = new byte[5_000];
+		var inputIndex = 0;
+		Encoder utf8Encoder = null;
+		var span = memory.AsSpan();
+		var totalBytes = 0;
+
+		void WriteRow(int id, Span<byte> span)
+		{
+			ValueWriteHelper.WriteValue(connection, id, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out var bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+
+			ValueWriteHelper.WriteValue(connection, commaChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+
+			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			ValueWriteHelper.WriteValue(connection, $"two-{id}", ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			ValueWriteHelper.WriteValue(connection, commaChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+
+			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			ValueWriteHelper.WriteValue(connection, $"three-{id}", ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
+			totalBytes += bytesWritten;
+			inputIndex = 0;
+			span[totalBytes++] = newLineByte;
+			inputIndex = 0;
+		}
+
+		WriteRow(1, span);
+		WriteRow(2, span);
+		WriteRow(3, span);
+		WriteRow(4, span);
+		WriteRow(5, span);
+
+		using var memoryStream = new MemoryStream(memory, 0, totalBytes, false);
 #if !MYSQL_DATA
 		bl.SourceStream = memoryStream;
 #endif

--- a/tests/IntegrationTests/BulkLoaderSync.cs
+++ b/tests/IntegrationTests/BulkLoaderSync.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using MySqlConnector.Helpers;
 using Xunit.Sdk;
 
 namespace IntegrationTests;
@@ -481,85 +480,6 @@ public class BulkLoaderSync : IClassFixture<DatabaseFixture>
 		connection.Open();
 		MySqlBulkLoader bl = new MySqlBulkLoader(connection);
 		using var memoryStream = new MemoryStream(m_memoryStreamBytes, false);
-#if !MYSQL_DATA
-		bl.SourceStream = memoryStream;
-#endif
-		bl.TableName = m_testTable;
-		bl.CharacterSet = "UTF8";
-		bl.Columns.AddRange(new string[] { "one", "two", "three" });
-		bl.NumberOfLinesToSkip = 0;
-		bl.FieldTerminator = ",";
-		bl.FieldQuotationCharacter = '"';
-		bl.FieldQuotationOptional = true;
-		bl.Local = true;
-#if !MYSQL_DATA
-		int rowCount = bl.Load();
-#else
-		int rowCount = bl.Load(memoryStream);
-#endif
-		Assert.Equal(5, rowCount);
-	}
-
-	[Fact]
-	public void BulkLoadLocalMemoryStreamManual()
-	{
-		using var connection = new MySqlConnection(GetLocalConnectionString());
-		connection.Open();
-		MySqlBulkLoader bl = new MySqlBulkLoader(connection);
-
-		const byte newLineByte = (byte)'\n';
-		const char qChar = '\'';
-		const char commaChar = ',';
-
-		var memory = new byte[5_000];
-		var inputIndex = 0;
-		Encoder utf8Encoder = null;
-		var span = memory.AsSpan();
-		var totalBytes = 0;
-
-		void WriteRow(int id, Span<byte> span)
-		{
-			ValueWriteHelper.WriteValue(connection, id, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out var bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-
-			ValueWriteHelper.WriteValue(connection, commaChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-
-			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			ValueWriteHelper.WriteValue(connection, $"two-{id}", ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			ValueWriteHelper.WriteValue(connection, commaChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-
-			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			ValueWriteHelper.WriteValue(connection, $"three-{id}", ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			ValueWriteHelper.WriteValue(connection, qChar, ref inputIndex, ref utf8Encoder, span.Slice(totalBytes), out bytesWritten);
-			totalBytes += bytesWritten;
-			inputIndex = 0;
-			span[totalBytes++] = newLineByte;
-			inputIndex = 0;
-		}
-
-		WriteRow(1, span);
-		WriteRow(2, span);
-		WriteRow(3, span);
-		WriteRow(4, span);
-		WriteRow(5, span);
-
-		using var memoryStream = new MemoryStream(memory, 0, totalBytes, false);
 #if !MYSQL_DATA
 		bl.SourceStream = memoryStream;
 #endif


### PR DESCRIPTION
A new way to insert data into tables is MySqlBulkImport. MySqlBulkImport is similar to MySqlBulkCopy in its purpose, but:
- Has reduced memory consumption (over 30% savings, depending on the number of columns in a row and their type)
- Adheres to the "push" model instead of "pull"

#1644 