### PR TITLE
Cache prepared statement metadata received at execution time

### DIFF
--- a/.ci/config/config.compression+ssl.json
+++ b/.ci/config/config.compression+ssl.json
@@ -4,7 +4,7 @@
       "SocketPath": "./../../../../.ci/run/mysql/mysqld.sock",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "CachingSha2Password,Redirection,RsaEncryption,Tls12,Tls13,TlsFingerprintValidation,UuidToBin,Vector",
+      "UnsupportedFeatures": "CachingSha2Password,InsertReturning,Redirection,RsaEncryption,Tls12,Tls13,TlsFingerprintValidation,UuidToBin,Vector",
       "MySqlBulkLoaderLocalCsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.TSV",
       "CertificatesPath": "../../../../.ci/server/certs"

--- a/.ci/config/config.compression.json
+++ b/.ci/config/config.compression.json
@@ -4,7 +4,7 @@
       "SocketPath": "./../../../../.ci/run/mysql/mysqld.sock",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "Ed25519,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
+      "UnsupportedFeatures": "Ed25519,InsertReturning,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
       "MySqlBulkLoaderLocalCsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.json
+++ b/.ci/config/config.json
@@ -4,7 +4,7 @@
       "SocketPath": "./../../../../.ci/run/mysql/mysqld.sock",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "Ed25519,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
+      "UnsupportedFeatures": "Ed25519,InsertReturning,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
       "MySqlBulkLoaderLocalCsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.ci/config/config.ssl.json
+++ b/.ci/config/config.ssl.json
@@ -4,7 +4,7 @@
       "SocketPath": "./../../../../.ci/run/mysql/mysqld.sock",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "CachingSha2Password,Redirection,RsaEncryption,Tls12,Tls13,TlsFingerprintValidation,UuidToBin,Vector",
+      "UnsupportedFeatures": "CachingSha2Password,InsertReturning,Redirection,RsaEncryption,Tls12,Tls13,TlsFingerprintValidation,UuidToBin,Vector",
       "MySqlBulkLoaderLocalCsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../../tests/TestData/LoadData_UTF8_BOM_Unix.TSV",
       "CertificatesPath": "../../../../.ci/server/certs"

--- a/.ci/config/config.uds+ssl.json
+++ b/.ci/config/config.uds+ssl.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../.ci/mysqld/mysqld.sock;user id=ssltest;password=test;database=mysqltest;ssl mode=required;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "None",
+      "UnsupportedFeatures": "InsertReturning",
       "MySqlBulkLoaderLocalCsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.TSV",
       "CertificatesPath": "../../../../.ci/server/certs"

--- a/.ci/config/config.uds.json
+++ b/.ci/config/config.uds.json
@@ -3,7 +3,7 @@
       "ConnectionString": "server=./../../../../.ci/run/mysql/mysqld.sock;user id=mysqltest;password=test;database=mysqltest;ssl mode=disabled;DefaultCommandTimeout=3600",
       "PasswordlessUser": "no_password",
       "SecondaryDatabase": "testdb2",
-      "UnsupportedFeatures": "None",
+      "UnsupportedFeatures": "InsertReturning",
       "MySqlBulkLoaderLocalCsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.CSV",
       "MySqlBulkLoaderLocalTsvFile": "../../../TestData/LoadData_UTF8_BOM_Unix.TSV"
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   },
   "containerEnv": {
     "Data__ConnectionString": "server=db;port=3306;user id=mysqltest;password=test;database=mysqltest;ssl mode=disabled;DefaultCommandTimeout=3600;AllowPublicKeyRetrieval=True",
-    "Data__UnsupportedFeatures": "Ed25519,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
+    "Data__UnsupportedFeatures": "Ed25519,InsertReturning,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector,ZeroDateTime",
     "Data__CertificatesPath": "/workspace/.ci/server/certs"
   },
   "customizations": {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,19 +171,19 @@ jobs:
       'MySQL 8.0':
         image: 'mysql:8.0'
         connectionStringExtra: 'AllowPublicKeyRetrieval=True'
-        unsupportedFeatures: 'Ed25519,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
+        unsupportedFeatures: 'Ed25519,InsertReturning,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
       'MySQL 8.4':
         image: 'mysql:8.4'
         connectionStringExtra: 'AllowPublicKeyRetrieval=True'
-        unsupportedFeatures: 'Ed25519,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
+        unsupportedFeatures: 'Ed25519,InsertReturning,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
       'MySQL 9.4':
         image: 'mysql:9.4'
         connectionStringExtra: 'AllowPublicKeyRetrieval=True'
-        unsupportedFeatures: 'Ed25519,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
+        unsupportedFeatures: 'Ed25519,InsertReturning,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
       'MySQL 9.7':
         image: 'mysql:9.7'
         connectionStringExtra: 'AllowPublicKeyRetrieval=True'
-        unsupportedFeatures: 'Ed25519,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
+        unsupportedFeatures: 'Ed25519,InsertReturning,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,Vector,ZeroDateTime'
       'MariaDB 10.6':
         image: 'mariadb:10.6'
         connectionStringExtra: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ jobs:
       arguments: 'tests\IntegrationTests\IntegrationTests.csproj -c MySqlData'
       testRunTitle: 'MySql.Data integration tests'
     env:
-      DATA__UNSUPPORTEDFEATURES: 'Ed25519,QueryAttributes,ParsecAuthentication,StreamingResults,TlsFingerprintValidation,UnixDomainSocket,Vector'
+      DATA__UNSUPPORTEDFEATURES: 'Ed25519,InsertReturning,QueryAttributes,ParsecAuthentication,StreamingResults,TlsFingerprintValidation,UnixDomainSocket,Vector'
       DATA__CONNECTIONSTRING: 'server=localhost;port=3306;user id=root;password=test;database=mysqltest;ssl mode=disabled;DefaultCommandTimeout=3600'
       DATA__CERTIFICATESPATH: '$(Build.Repository.LocalPath)\.ci\server\certs\'
       DATA__MYSQLBULKLOADERLOCALCSVFILE: '$(Build.Repository.LocalPath)\tests\TestData\LoadData_UTF8_BOM_Unix.CSV'
@@ -120,7 +120,7 @@ jobs:
       arguments: '-c Release --no-restore -p:TestTfmsInParallel=false'
       testRunTitle: ${{ format('{0}, $(Agent.OS), {1}, {2}', 'mysql:8.0', 'net481/net10.0', 'No SSL') }}
     env:
-      DATA__UNSUPPORTEDFEATURES: 'Ed25519,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector'
+      DATA__UNSUPPORTEDFEATURES: 'Ed25519,InsertReturning,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector'
       DATA__CONNECTIONSTRING: 'server=localhost;port=3306;user id=mysqltest;password=test;database=mysqltest;ssl mode=disabled;DefaultCommandTimeout=3600;AllowPublicKeyRetrieval=True;UseCompression=True'
 
 - job: windows_integration_tests_2
@@ -158,7 +158,7 @@ jobs:
       arguments: '-c Release --no-restore -p:TestTfmsInParallel=false'
       testRunTitle: ${{ format('{0}, $(Agent.OS), {1}, {2}', 'mysql:8.0', 'net8.0', 'No SSL') }}
     env:
-      DATA__UNSUPPORTEDFEATURES: 'Ed25519,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector'
+      DATA__UNSUPPORTEDFEATURES: 'Ed25519,InsertReturning,QueryAttributes,ParsecAuthentication,Redirection,StreamingResults,Tls11,TlsFingerprintValidation,UnixDomainSocket,Vector'
       DATA__CONNECTIONSTRING: 'server=localhost;port=3306;user id=mysqltest;password=test;database=mysqltest;ssl mode=disabled;DefaultCommandTimeout=3600;AllowPublicKeyRetrieval=True'
 
 - job: linux_integration_tests

--- a/src/MySqlConnector/Core/ResultSet.cs
+++ b/src/MySqlConnector/Core/ResultSet.cs
@@ -132,7 +132,17 @@ internal sealed class ResultSet(MySqlDataReader dataReader)
 						m_columnDefinitions = m_columnDefinitionPayloadCache.AsMemory(0, columnCount);
 
 						// if the server supports metadata caching but has re-sent it, something has changed since last prepare/execution and we need to update the columns
-						var preparedColumns = Session.SupportsCachedPreparedMetadata ? DataReader.LastUsedPreparedStatement?.Columns : null;
+						ColumnDefinitionPayload[]? preparedColumns = null;
+						if (Session.SupportsCachedPreparedMetadata && DataReader.LastUsedPreparedStatement is { } lastUsedPreparedStatement)
+						{
+							// the prepared statement may have no cached metadata (e.g., 'INSERT ... RETURNING' reports zero columns when prepared on MariaDB), or the column count may have changed
+							preparedColumns = lastUsedPreparedStatement.Columns;
+							if (preparedColumns?.Length != columnCount)
+							{
+								preparedColumns = new ColumnDefinitionPayload[columnCount];
+								lastUsedPreparedStatement.Columns = preparedColumns;
+							}
+						}
 
 						for (var column = 0; column < columnCount; column++)
 						{

--- a/tests/IntegrationTests/PreparedCommandTests.cs
+++ b/tests/IntegrationTests/PreparedCommandTests.cs
@@ -248,6 +248,34 @@ SELECT data FROM prepared_command_test ORDER BY rowid;", connection);
 		}
 	}
 
+	[SkippableFact(ServerFeatures.InsertReturning)]
+	public void InsertReturningPreparedStatement()
+	{
+		using var connection = CreateConnection();
+
+		connection.Execute("""
+			DROP TABLE IF EXISTS insert_returning_test;
+			CREATE TABLE insert_returning_test(rowid INTEGER NOT NULL PRIMARY KEY AUTO_INCREMENT, data TEXT NOT NULL);
+			""");
+
+		using var command = new MySqlCommand("INSERT INTO insert_returning_test(data) VALUES(@data) RETURNING rowid;", connection);
+		var parameter = command.Parameters.AddWithValue("@data", "");
+		command.Prepare();
+
+		// the statement is prepared with no result set metadata; verify that multiple executions return the metadata and rows correctly (#1652)
+		var expectedRowId = 1;
+		foreach (var value in new[] { "one", "two", "three" })
+		{
+			parameter.Value = value;
+			using var reader = command.ExecuteReader();
+			Assert.True(reader.Read());
+			Assert.Equal("rowid", reader.GetName(0));
+			Assert.Equal(expectedRowId, reader.GetInt32(0));
+			Assert.False(reader.Read());
+			expectedRowId++;
+		}
+	}
+
 	[Fact]
 	public void ThrowsIfNamedParameterUsedButNoParametersDefined()
 	{

--- a/tests/IntegrationTests/ServerFeatures.cs
+++ b/tests/IntegrationTests/ServerFeatures.cs
@@ -145,4 +145,9 @@ public enum ServerFeatures
 	/// Server has a dedicated type on the wire for <c>VECTOR</c>.
 	/// </summary>
 	VectorType = 0x800_0000,
+
+	/// <summary>
+	/// Server supports <c>INSERT ... RETURNING</c> (MariaDB 10.5 and later).
+	/// </summary>
+	InsertReturning = 0x1000_0000,
 }


### PR DESCRIPTION
Fixes #1652

MariaDB reports zero result set columns when preparing INSERT...RETURNING; the metadata is only known at execution time. When the server re-sends metadata for a prepared statement, store it in PreparedStatement.Columns so that a subsequent execution that skips metadata (MARIADB_CLIENT_CACHE_METADATA) can use the cached column definitions.