### PR TITLE
Add SkipCertificateRevocationCheck connection string option

### DIFF
--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -176,6 +176,14 @@ These are the options that need to be used in order to configure a connection to
       <p>To provide a custom callback to validate the remote certificate, leave this option empty and set <code>SslMode</code> to <code>Required</code> (or <code>Preferred</code>), then set <a href="/api/mysqlconnector/mysqlconnection/remotecertificatevalidationcallback/"><code>MySqlConnection.RemoteCertificateValidationCallback</code></a> before calling <a href="/api/mysqlconnector/mysqlconnection/open/"><code>MySqlConnection.Open</code></a>. The property should be set to a delegate that will validate the remote certificate, as per <a href="https://docs.microsoft.com/en-us/dotnet/api/system.net.security.remotecertificatevalidationcallback" title="RemoteCertificateValidationCallback Delegate (MSDN)">the documentation</a>.</p>
     </td>
   </tr>
+  <tr id="AllowUnknownCertificateRevocation">
+    <td>Allow Unknown Certificate Revocation, AllowUnknownCertificateRevocation</td>
+    <td>false</td>
+    <td>
+      <p>Allows a connection using <code>SslMode=VerifyFull</code> to succeed even if revocation checking fails because certificate revocation status can't be determined. All other <code>VerifyFull</code> checks are still performed, including CA and hostname validation.</p>
+      <p>This option is only supported on .NET 7.0 or later, and it may only be used with <code>SslMode=VerifyFull</code>.</p>
+    </td>
+  </tr>
   <tr id="TlsVersion">
     <td>TLS Version, TlsVersion, Tls-Version</td>
     <td></td>

--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -181,7 +181,7 @@ These are the options that need to be used in order to configure a connection to
     <td>false</td>
     <td>
       <p>Bypasses the TLS certificate revocation check when using <code>SslMode=VerifyFull</code>. This allows a connection to be made even when revocation status can't be determined. All other <code>VerifyFull</code> checks are still performed, including CA and hostname validation.</p>
-      <p>This option is only supported on .NET 7.0 or later, and it may only be used with <code>SslMode=VerifyFull</code>.</p>
+      <p>This option may only be used with <code>SslMode=VerifyFull</code>.</p>
     </td>
   </tr>
   <tr id="TlsVersion">

--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -176,11 +176,11 @@ These are the options that need to be used in order to configure a connection to
       <p>To provide a custom callback to validate the remote certificate, leave this option empty and set <code>SslMode</code> to <code>Required</code> (or <code>Preferred</code>), then set <a href="/api/mysqlconnector/mysqlconnection/remotecertificatevalidationcallback/"><code>MySqlConnection.RemoteCertificateValidationCallback</code></a> before calling <a href="/api/mysqlconnector/mysqlconnection/open/"><code>MySqlConnection.Open</code></a>. The property should be set to a delegate that will validate the remote certificate, as per <a href="https://docs.microsoft.com/en-us/dotnet/api/system.net.security.remotecertificatevalidationcallback" title="RemoteCertificateValidationCallback Delegate (MSDN)">the documentation</a>.</p>
     </td>
   </tr>
-  <tr id="AllowUnknownCertificateRevocation">
-    <td>Allow Unknown Certificate Revocation, AllowUnknownCertificateRevocation</td>
+  <tr id="SkipCertificateRevocationCheck">
+    <td>Skip Certificate Revocation Check, SkipCertificateRevocationCheck</td>
     <td>false</td>
     <td>
-      <p>Allows a connection using <code>SslMode=VerifyFull</code> to succeed even if revocation checking fails because certificate revocation status can't be determined. All other <code>VerifyFull</code> checks are still performed, including CA and hostname validation.</p>
+      <p>Bypasses the TLS certificate revocation check when using <code>SslMode=VerifyFull</code>. This allows a connection to be made even when revocation status can't be determined. All other <code>VerifyFull</code> checks are still performed, including CA and hostname validation.</p>
       <p>This option is only supported on .NET 7.0 or later, and it may only be used with <code>SslMode=VerifyFull</code>.</p>
     </td>
   </tr>

--- a/docs/content/connection-options.md
+++ b/docs/content/connection-options.md
@@ -180,7 +180,7 @@ These are the options that need to be used in order to configure a connection to
     <td>Skip Certificate Revocation Check, SkipCertificateRevocationCheck</td>
     <td>false</td>
     <td>
-      <p>Bypasses the TLS certificate revocation check when using <code>SslMode=VerifyFull</code>. This allows a connection to be made even when revocation status can't be determined. All other <code>VerifyFull</code> checks are still performed, including CA and hostname validation.</p>
+      <p>Turns off the TLS certificate revocation check when using <code>SslMode=VerifyFull</code>. This allows a connection to be made even when revocation status can't be determined, but it also means revoked certificates may not be detected. All other checks are still performed. Intended for private clouds that don't use revocation.</p>
       <p>This option may only be used with <code>SslMode=VerifyFull</code>.</p>
     </td>
   </tr>

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -56,6 +56,7 @@ internal sealed class ConnectionSettings
 		SslCertificateFile = csb.SslCert;
 		SslKeyFile = csb.SslKey;
 		CACertificateFile = csb.SslCa;
+		AllowUnknownCertificateRevocation = csb.AllowUnknownCertificateRevocation;
 		CertificateStoreLocation = csb.CertificateStoreLocation;
 		CertificateThumbprint = csb.CertificateThumbprint;
 
@@ -201,6 +202,7 @@ internal sealed class ConnectionSettings
 	public string CACertificateFile { get; }
 	public string SslCertificateFile { get; }
 	public string SslKeyFile { get; }
+	public bool AllowUnknownCertificateRevocation { get; }
 	public MySqlCertificateStoreLocation CertificateStoreLocation { get; }
 	public string CertificateThumbprint { get; }
 	public SslProtocols TlsVersions { get; }
@@ -298,6 +300,7 @@ internal sealed class ConnectionSettings
 		SslCertificateFile = other.SslCertificateFile;
 		SslKeyFile = other.SslKeyFile;
 		CACertificateFile = other.CACertificateFile;
+		AllowUnknownCertificateRevocation = other.AllowUnknownCertificateRevocation;
 		CertificateStoreLocation = other.CertificateStoreLocation;
 		CertificateThumbprint = other.CertificateThumbprint;
 

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -56,7 +56,7 @@ internal sealed class ConnectionSettings
 		SslCertificateFile = csb.SslCert;
 		SslKeyFile = csb.SslKey;
 		CACertificateFile = csb.SslCa;
-		AllowUnknownCertificateRevocation = csb.AllowUnknownCertificateRevocation;
+		SkipCertificateRevocationCheck = csb.SkipCertificateRevocationCheck;
 		CertificateStoreLocation = csb.CertificateStoreLocation;
 		CertificateThumbprint = csb.CertificateThumbprint;
 
@@ -202,7 +202,7 @@ internal sealed class ConnectionSettings
 	public string CACertificateFile { get; }
 	public string SslCertificateFile { get; }
 	public string SslKeyFile { get; }
-	public bool AllowUnknownCertificateRevocation { get; }
+	public bool SkipCertificateRevocationCheck	 { get; }
 	public MySqlCertificateStoreLocation CertificateStoreLocation { get; }
 	public string CertificateThumbprint { get; }
 	public SslProtocols TlsVersions { get; }
@@ -300,7 +300,7 @@ internal sealed class ConnectionSettings
 		SslCertificateFile = other.SslCertificateFile;
 		SslKeyFile = other.SslKeyFile;
 		CACertificateFile = other.CACertificateFile;
-		AllowUnknownCertificateRevocation = other.AllowUnknownCertificateRevocation;
+		SkipCertificateRevocationCheck = other.SkipCertificateRevocationCheck;
 		CertificateStoreLocation = other.CertificateStoreLocation;
 		CertificateThumbprint = other.CertificateThumbprint;
 

--- a/src/MySqlConnector/Core/ConnectionSettings.cs
+++ b/src/MySqlConnector/Core/ConnectionSettings.cs
@@ -202,7 +202,7 @@ internal sealed class ConnectionSettings
 	public string CACertificateFile { get; }
 	public string SslCertificateFile { get; }
 	public string SslKeyFile { get; }
-	public bool SkipCertificateRevocationCheck	 { get; }
+	public bool SkipCertificateRevocationCheck { get; }
 	public MySqlCertificateStoreLocation CertificateStoreLocation { get; }
 	public string CertificateThumbprint { get; }
 	public SslProtocols TlsVersions { get; }

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1746,7 +1746,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 		X509Certificate ValidateLocalCertificate(object lcbSender, string lcbTargetHost, X509CertificateCollection lcbLocalCertificates, X509Certificate? lcbRemoteCertificate, string[] lcbAcceptableIssuers) => lcbLocalCertificates[0];
 
 		bool ValidateRemoteCertificate(object rcbSender, X509Certificate? rcbCertificate, X509Chain? rcbChain, SslPolicyErrors rcbPolicyErrors)
-        {
+		{
 			if (rcbPolicyErrors != SslPolicyErrors.None && rcbChain is not null && m_logger.IsEnabled(LogLevel.Trace))
 			{
 				var builder = new StringBuilder();

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1849,20 +1849,9 @@ internal sealed partial class ServerSession : IServerCapabilities
 			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
 		};
 
-		if (cs.SkipCertificateRevocationCheck)
+		if (cs.SkipCertificateRevocationCheck && cs.SslMode != MySqlSslMode.VerifyFull)
 		{
-			if (cs.SslMode != MySqlSslMode.VerifyFull)
-				throw new MySqlException("SkipCertificateRevocationCheck may only be used with SslMode=VerifyFull");
-#if NET7_0_OR_GREATER
-			clientAuthenticationOptions.CertificateChainPolicy ??= new();
-			clientAuthenticationOptions.CertificateChainPolicy.VerificationFlags =
-				X509VerificationFlags.IgnoreEndRevocationUnknown |
-				X509VerificationFlags.IgnoreCtlSignerRevocationUnknown |
-				X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
-				X509VerificationFlags.IgnoreRootRevocationUnknown;
-#else
-			throw new PlatformNotSupportedException("The SkipCertificateRevocationCheck connection string option is only supported on .NET 7.0 (or later).");
-#endif
+			throw new MySqlException("SkipCertificateRevocationCheck may only be used with SslMode=VerifyFull");
 		}
 
 #if NETCOREAPP3_0_OR_GREATER

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1747,25 +1747,21 @@ internal sealed partial class ServerSession : IServerCapabilities
 
 		bool ValidateRemoteCertificate(object rcbSender, X509Certificate? rcbCertificate, X509Chain? rcbChain, SslPolicyErrors rcbPolicyErrors)
         {
-            if (rcbPolicyErrors != SslPolicyErrors.None && rcbChain != null && m_logger.IsEnabled(LogLevel.Trace))
-            {
-                var builder = new StringBuilder();
-                builder.AppendLine($"Entering {nameof(ValidateRemoteCertificate)} with errors: {rcbPolicyErrors}");
+			if (rcbPolicyErrors != SslPolicyErrors.None && rcbChain is not null && m_logger.IsEnabled(LogLevel.Trace))
+			{
+				var builder = new StringBuilder();
 
-                for (int index = 0; index < rcbChain.ChainElements.Count; index++)
-                {
-                    X509ChainElement? element = rcbChain.ChainElements[index];
-                    builder.AppendLine($"Element {index}: {element.Certificate.GetNameInfo(X509NameType.SimpleName, false)}");
-                    builder.AppendLine("  Status:");
+				for (var index = 0; index < rcbChain.ChainElements.Count; index++)
+				{
+					var element = rcbChain.ChainElements[index];
+					builder.AppendLine(CultureInfo.InvariantCulture, $"Element {index}: {element.Certificate.GetNameInfo(X509NameType.SimpleName, false)}");
+					builder.AppendLine("  Status:");
+					foreach (var status in element.ChainElementStatus)
+						builder.AppendLine(CultureInfo.InvariantCulture, $"  {status.Status}: {status.StatusInformation}");
+				}
 
-                    foreach (X509ChainStatus status in element.ChainElementStatus)
-                    {
-                        builder.AppendLine($"  {status.Status}: {status.StatusInformation}");
-                    }
-                }
-
-                Log.RemoteCertificateValidationTrace(m_logger, builder.ToString());
-            }
+				Log.ValidateRemoteCertificateErrorDetails(m_logger, Id, rcbPolicyErrors, builder.ToString());
+			}
 
 			// if no CA verification is required, then we trust any remote certificate
 			if (cs.SslMode is MySqlSslMode.Preferred or MySqlSslMode.Required)

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1746,7 +1746,27 @@ internal sealed partial class ServerSession : IServerCapabilities
 		X509Certificate ValidateLocalCertificate(object lcbSender, string lcbTargetHost, X509CertificateCollection lcbLocalCertificates, X509Certificate? lcbRemoteCertificate, string[] lcbAcceptableIssuers) => lcbLocalCertificates[0];
 
 		bool ValidateRemoteCertificate(object rcbSender, X509Certificate? rcbCertificate, X509Chain? rcbChain, SslPolicyErrors rcbPolicyErrors)
-		{
+        {
+            if (rcbPolicyErrors != SslPolicyErrors.None && rcbChain != null && m_logger.IsEnabled(LogLevel.Trace))
+            {
+                var builder = new StringBuilder();
+                builder.AppendLine($"Entering {nameof(ValidateRemoteCertificate)} with errors: {rcbPolicyErrors}");
+
+                for (int index = 0; index < rcbChain.ChainElements.Count; index++)
+                {
+                    X509ChainElement? element = rcbChain.ChainElements[index];
+                    builder.AppendLine($"Element {index}: {element.Certificate.GetNameInfo(X509NameType.SimpleName, false)}");
+                    builder.AppendLine("  Status:");
+
+                    foreach (X509ChainStatus status in element.ChainElementStatus)
+                    {
+                        builder.AppendLine($"  {status.Status}: {status.StatusInformation}");
+                    }
+                }
+
+                Log.RemoteCertificateValidationTrace(m_logger, builder.ToString());
+            }
+
 			// if no CA verification is required, then we trust any remote certificate
 			if (cs.SslMode is MySqlSslMode.Preferred or MySqlSslMode.Required)
 				return true;
@@ -1820,7 +1840,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 		var sslStream = clientCertificates is null ? new SslStream(m_stream!, false, validateRemoteCertificate) :
 			new SslStream(m_stream!, false, validateRemoteCertificate, ValidateLocalCertificate);
 
-		var checkCertificateRevocation = cs.SslMode == MySqlSslMode.VerifyFull;
+		var checkCertificateRevocation = cs.SslMode == MySqlSslMode.VerifyFull && !cs.AllowUnknownCertificateRevocation;
 
 		using (var initSsl = HandshakeResponse41Payload.CreateWithSsl(serverCapabilities, cs, m_compressionMethod, m_characterSet))
 			await SendReplyAsync(initSsl, ioBehavior, cancellationToken).ConfigureAwait(false);

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1840,7 +1840,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 		var sslStream = clientCertificates is null ? new SslStream(m_stream!, false, validateRemoteCertificate) :
 			new SslStream(m_stream!, false, validateRemoteCertificate, ValidateLocalCertificate);
 
-		var checkCertificateRevocation = cs.SslMode == MySqlSslMode.VerifyFull && !cs.AllowUnknownCertificateRevocation;
+		var checkCertificateRevocation = cs.SslMode == MySqlSslMode.VerifyFull && !cs.SkipCertificateRevocationCheck;
 
 		using (var initSsl = HandshakeResponse41Payload.CreateWithSsl(serverCapabilities, cs, m_compressionMethod, m_characterSet))
 			await SendReplyAsync(initSsl, ioBehavior, cancellationToken).ConfigureAwait(false);
@@ -1853,10 +1853,10 @@ internal sealed partial class ServerSession : IServerCapabilities
 			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
 		};
 
-		if (cs.AllowUnknownCertificateRevocation)
+		if (cs.SkipCertificateRevocationCheck)
 		{
 			if (cs.SslMode != MySqlSslMode.VerifyFull)
-				throw new MySqlException("AllowUnknownCertificateRevocation may only be used with SslMode=VerifyFull");
+				throw new MySqlException("SkipCertificateRevocationCheck may only be used with SslMode=VerifyFull");
 #if NET7_0_OR_GREATER
 			clientAuthenticationOptions.CertificateChainPolicy ??= new();
 			clientAuthenticationOptions.CertificateChainPolicy.VerificationFlags =
@@ -1865,7 +1865,7 @@ internal sealed partial class ServerSession : IServerCapabilities
 				X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
 				X509VerificationFlags.IgnoreRootRevocationUnknown;
 #else
-			throw new PlatformNotSupportedException("The AllowUnknownCertificateRevocation connection string option is only supported on .NET 7.0 (or later).");
+			throw new PlatformNotSupportedException("The SkipCertificateRevocationCheck connection string option is only supported on .NET 7.0 (or later).");
 #endif
 		}
 

--- a/src/MySqlConnector/Core/ServerSession.cs
+++ b/src/MySqlConnector/Core/ServerSession.cs
@@ -1833,6 +1833,22 @@ internal sealed partial class ServerSession : IServerCapabilities
 			CertificateRevocationCheckMode = checkCertificateRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck,
 		};
 
+		if (cs.AllowUnknownCertificateRevocation)
+		{
+			if (cs.SslMode != MySqlSslMode.VerifyFull)
+				throw new MySqlException("AllowUnknownCertificateRevocation may only be used with SslMode=VerifyFull");
+#if NET7_0_OR_GREATER
+			clientAuthenticationOptions.CertificateChainPolicy ??= new();
+			clientAuthenticationOptions.CertificateChainPolicy.VerificationFlags =
+				X509VerificationFlags.IgnoreEndRevocationUnknown |
+				X509VerificationFlags.IgnoreCtlSignerRevocationUnknown |
+				X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
+				X509VerificationFlags.IgnoreRootRevocationUnknown;
+#else
+			throw new PlatformNotSupportedException("The AllowUnknownCertificateRevocation connection string option is only supported on .NET 7.0 (or later).");
+#endif
+		}
+
 #if NETCOREAPP3_0_OR_GREATER
 #pragma warning disable CA1416 // Validate platform compatibility
 		if (cs.TlsCipherSuites is { Count: > 0 })

--- a/src/MySqlConnector/Logging/EventIds.cs
+++ b/src/MySqlConnector/Logging/EventIds.cs
@@ -88,6 +88,7 @@ internal static class EventIds
 	public const int CertificateErrorUnixSocket = 2158;
 	public const int CertificateErrorNoPassword = 2159;
 	public const int CertificateErrorValidThumbprint = 2160;
+	public const int ValidateRemoteCertificateErrorDetails = 2161;
 
 	// Command execution events, 2200-2299
 	public const int CannotExecuteNewCommandInState = 2200;

--- a/src/MySqlConnector/Logging/Log.cs
+++ b/src/MySqlConnector/Logging/Log.cs
@@ -463,4 +463,7 @@ internal static partial class Log
 
 	[LoggerMessage(EventIds.ClearingPoolDueToDnsChanges, LogLevel.Information, "Pool {PoolId} clearing pool due to DNS changes")]
 	public static partial void ClearingPoolDueToDnsChanges(ILogger logger, int poolId);
+
+    [LoggerMessage(LogLevel.Trace, "{Message}", SkipEnabledCheck = true)]
+    public static partial void RemoteCertificateValidationTrace(ILogger logger, string message);
 }

--- a/src/MySqlConnector/Logging/Log.cs
+++ b/src/MySqlConnector/Logging/Log.cs
@@ -224,6 +224,9 @@ internal static partial class Log
 	[LoggerMessage(EventIds.CertificateErrorValidThumbprint, LogLevel.Trace, "Session {SessionId} ignoring remote certificate error {SslPolicyErrors} due to valid signature in OK packet")]
 	public static partial void CertificateErrorValidThumbprint(ILogger logger, string sessionId, SslPolicyErrors sslPolicyErrors);
 
+	[LoggerMessage(EventIds.ValidateRemoteCertificateErrorDetails, LogLevel.Trace, "Session {SessionId} entering ValidateRemoteCertificate with errors: {PolicyErrors}\n{Details}", SkipEnabledCheck = true)]
+	public static partial void ValidateRemoteCertificateErrorDetails(ILogger logger, string sessionId, SslPolicyErrors policyErrors, string details);
+
 	[LoggerMessage(EventIds.IgnoringCancellationForCommand, LogLevel.Trace, "Ignoring cancellation for closed connection or invalid command {CommandId}")]
 	public static partial void IgnoringCancellationForCommand(ILogger logger, int commandId);
 
@@ -463,7 +466,4 @@ internal static partial class Log
 
 	[LoggerMessage(EventIds.ClearingPoolDueToDnsChanges, LogLevel.Information, "Pool {PoolId} clearing pool due to DNS changes")]
 	public static partial void ClearingPoolDueToDnsChanges(ILogger logger, int poolId);
-
-    [LoggerMessage(LogLevel.Trace, "{Message}", SkipEnabledCheck = true)]
-    public static partial void RemoteCertificateValidationTrace(ILogger logger, string message);
 }

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -275,6 +275,19 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
+	/// Allows a connection using <see cref="MySqlSslMode.VerifyFull"/> to succeed even if certificate revocation checking fails because revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed. This option is only supported on .NET 7.0 or later.
+	/// </summary>
+	[Category("TLS")]
+	[DefaultValue(false)]
+	[Description("Allows a connection using VerifyFull to succeed even if revocation checking fails because revocation status can't be determined.")]
+	[DisplayName("Allow Unknown Certificate Revocation")]
+	public bool AllowUnknownCertificateRevocation
+	{
+		get => MySqlConnectionStringOption.AllowUnknownCertificateRevocation.GetValue(this);
+		set => MySqlConnectionStringOption.AllowUnknownCertificateRevocation.SetValue(this, value);
+	}
+
+	/// <summary>
 	/// The TLS versions which may be used during TLS negotiation, or empty to use OS defaults.
 	/// </summary>
 	[AllowNull]
@@ -919,6 +932,7 @@ internal abstract partial class MySqlConnectionStringOption
 	public static readonly MySqlConnectionStringReferenceOption<string> SslCert;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslKey;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslCa;
+	public static readonly MySqlConnectionStringValueOption<bool> AllowUnknownCertificateRevocation;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsVersion;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsCipherSuites;
 
@@ -1060,6 +1074,10 @@ internal abstract partial class MySqlConnectionStringOption
 		AddOption(options, SslCa = new(
 			keys: ["SSL CA", "CACertificateFile", "CA Certificate File", "SslCa", "Ssl-Ca"],
 			defaultValue: ""));
+
+		AddOption(options, AllowUnknownCertificateRevocation = new(
+			keys: ["Allow Unknown Certificate Revocation", "AllowUnknownCertificateRevocation"],
+			defaultValue: false));
 
 		AddOption(options, TlsVersion = new(
 			keys: ["TLS Version", "TlsVersion", "Tls-Version"],

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -275,11 +275,11 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
-	/// Bypasses the TLS certificate revocation check when using <see cref="MySqlSslMode.VerifyFull"/>. This allows a connection to be made even when revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed.
+	/// Turns off the TLS certificate revocation check when using <see cref="MySqlSslMode.VerifyFull"/>. This allows a connection to be made even when revocation status can't be determined, but it also means revoked certificates may not be detected. All other checks are still performed. Intended for private clouds that don't use revocation.
 	/// </summary>
 	[Category("TLS")]
 	[DefaultValue(false)]
-	[Description("Bypasses the TLS certificate revocation check when using VerifyFull. This allows a connection to be made even when revocation status can't be determined.")]
+	[Description("Turns off the TLS certificate revocation check when using VerifyFull. This allows a connection to be made even when revocation status can't be determined, but it also means revoked certificates may not be detected. All other checks are still performed. Intended for private clouds that don't use revocation.")]
 	[DisplayName("Skip Certificate Revocation Check")]
 	public bool SkipCertificateRevocationCheck
 	{

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -275,7 +275,7 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
-	/// Bypasses the TLS certificate revocation check when using <see cref="MySqlSslMode.VerifyFull"/>. This allows a connection to be made even when revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed. This option is only supported on .NET 7.0 or later.
+	/// Bypasses the TLS certificate revocation check when using <see cref="MySqlSslMode.VerifyFull"/>. This allows a connection to be made even when revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed.
 	/// </summary>
 	[Category("TLS")]
 	[DefaultValue(false)]

--- a/src/MySqlConnector/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlConnectionStringBuilder.cs
@@ -275,16 +275,16 @@ public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	}
 
 	/// <summary>
-	/// Allows a connection using <see cref="MySqlSslMode.VerifyFull"/> to succeed even if certificate revocation checking fails because revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed. This option is only supported on .NET 7.0 or later.
+	/// Bypasses the TLS certificate revocation check when using <see cref="MySqlSslMode.VerifyFull"/>. This allows a connection to be made even when revocation status can't be determined. All other <see cref="MySqlSslMode.VerifyFull"/> checks are still performed. This option is only supported on .NET 7.0 or later.
 	/// </summary>
 	[Category("TLS")]
 	[DefaultValue(false)]
-	[Description("Allows a connection using VerifyFull to succeed even if revocation checking fails because revocation status can't be determined.")]
-	[DisplayName("Allow Unknown Certificate Revocation")]
-	public bool AllowUnknownCertificateRevocation
+	[Description("Bypasses the TLS certificate revocation check when using VerifyFull. This allows a connection to be made even when revocation status can't be determined.")]
+	[DisplayName("Skip Certificate Revocation Check")]
+	public bool SkipCertificateRevocationCheck
 	{
-		get => MySqlConnectionStringOption.AllowUnknownCertificateRevocation.GetValue(this);
-		set => MySqlConnectionStringOption.AllowUnknownCertificateRevocation.SetValue(this, value);
+		get => MySqlConnectionStringOption.SkipCertificateRevocationCheck.GetValue(this);
+		set => MySqlConnectionStringOption.SkipCertificateRevocationCheck.SetValue(this, value);
 	}
 
 	/// <summary>
@@ -932,7 +932,7 @@ internal abstract partial class MySqlConnectionStringOption
 	public static readonly MySqlConnectionStringReferenceOption<string> SslCert;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslKey;
 	public static readonly MySqlConnectionStringReferenceOption<string> SslCa;
-	public static readonly MySqlConnectionStringValueOption<bool> AllowUnknownCertificateRevocation;
+	public static readonly MySqlConnectionStringValueOption<bool> SkipCertificateRevocationCheck;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsVersion;
 	public static readonly MySqlConnectionStringReferenceOption<string> TlsCipherSuites;
 
@@ -1075,8 +1075,8 @@ internal abstract partial class MySqlConnectionStringOption
 			keys: ["SSL CA", "CACertificateFile", "CA Certificate File", "SslCa", "Ssl-Ca"],
 			defaultValue: ""));
 
-		AddOption(options, AllowUnknownCertificateRevocation = new(
-			keys: ["Allow Unknown Certificate Revocation", "AllowUnknownCertificateRevocation"],
+		AddOption(options, SkipCertificateRevocationCheck = new(
+			keys: ["Skip Certificate Revocation Check", "SkipCertificateRevocationCheck"],
 			defaultValue: false));
 
 		AddOption(options, TlsVersion = new(

--- a/src/MySqlConnector/Utilities/Utility.cs
+++ b/src/MySqlConnector/Utilities/Utility.cs
@@ -4,6 +4,8 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
 #if NET462
 using System.Net;
 using System.Reflection;
@@ -86,6 +88,11 @@ internal static class Utility
 			return encoder.GetByteCount(charsPtr, chars.Length, flush);
 		}
 	}
+#endif
+
+#if !NET6_0_OR_GREATER
+	public static StringBuilder AppendLine(this StringBuilder stringBuilder, IFormatProvider formatProvider, FormattableString message) =>
+		stringBuilder.AppendLine(message.ToString(formatProvider));
 #endif
 
 #if NET5_0_OR_GREATER

--- a/src/MySqlConnector/Utilities/Utility.cs
+++ b/src/MySqlConnector/Utilities/Utility.cs
@@ -4,8 +4,6 @@ using System.Buffers;
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-
 #if NET462
 using System.Net;
 using System.Reflection;

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -19,6 +19,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Null(csb.CertificatePassword);
 		Assert.Null(csb.CertificateThumbprint);
 #else
+		Assert.False(csb.AllowUnknownCertificateRevocation);
 		Assert.Equal(2, csb.CancellationTimeout);
 		Assert.Equal("", csb.CertificateFile);
 		Assert.Equal("", csb.CertificatePassword);
@@ -122,6 +123,7 @@ public class MySqlConnectionStringBuilderTests
 #endif
 				"default command timeout=123;" +
 #if !MYSQL_DATA
+				"allow unknown certificate revocation=true;" +
 				"application name=My Test Application;" +
 				"cancellation timeout = -1;" +
 				"connectionidletimeout=30;" +
@@ -155,7 +157,7 @@ public class MySqlConnectionStringBuilderTests
 				"ssl-ca=ca.pem;" +
 				"ssl-cert=client-cert.pem;" +
 				"ssl-key=client-key.pem;" +
-				"ssl mode=verifyca;" +
+				"ssl mode=verifyfull;" +
 				"tls version=Tls12, TLS v1.3;" +
 				"Uid=username;" +
 				"useaffectedrows=true",
@@ -185,6 +187,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Equal("schema_name", csb.Database);
 		Assert.Equal(123u, csb.DefaultCommandTimeout);
 #if !MYSQL_DATA
+		Assert.True(csb.AllowUnknownCertificateRevocation);
 		Assert.Equal("My Test Application", csb.ApplicationName);
 		Assert.Equal(30u, csb.ConnectionIdleTimeout);
 #pragma warning disable 618
@@ -219,7 +222,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Equal("ca.pem", csb.SslCa);
 		Assert.Equal("client-cert.pem", csb.SslCert);
 		Assert.Equal("client-key.pem", csb.SslKey);
-		Assert.Equal(MySqlSslMode.VerifyCA, csb.SslMode);
+		Assert.Equal(MySqlSslMode.VerifyFull, csb.SslMode);
 #if MYSQL_DATA
 		Assert.Equal("Tls12, Tls13", csb.TlsVersion);
 #else
@@ -231,9 +234,9 @@ public class MySqlConnectionStringBuilderTests
 
 #if !MYSQL_DATA
 		Assert.Equal("Server=db-server;Port=1234;User ID=username;Password=Pass1234;Database=schema_name;Load Balance=Random;" +
-			"Connection Protocol=Pipe;Pipe Name=MyPipe;SSL Mode=VerifyCA;Certificate File=file.pfx;Certificate Password=Pass2345;" +
+			"Connection Protocol=Pipe;Pipe Name=MyPipe;SSL Mode=VerifyFull;Certificate File=file.pfx;Certificate Password=Pass2345;" +
 			"Certificate Store Location=CurrentUser;Certificate Thumbprint=thumbprint123;SSL Cert=client-cert.pem;SSL Key=client-key.pem;" +
-			"SSL CA=ca.pem;TLS Version=\"TLS 1.2, TLS 1.3\";TLS Cipher Suites=TLS_AES_128_CCM_8_SHA256,TLS_RSA_WITH_RC4_128_MD5;" +
+			"SSL CA=ca.pem;Allow Unknown Certificate Revocation=True;TLS Version=\"TLS 1.2, TLS 1.3\";TLS Cipher Suites=TLS_AES_128_CCM_8_SHA256,TLS_RSA_WITH_RC4_128_MD5;" +
 			"Pooling=False;Connection Lifetime=15;Connection Reset=False;Defer Connection Reset=True;Connection Idle Timeout=30;" +
 			"Minimum Pool Size=5;Maximum Pool Size=15;DNS Check Interval=15;" +
 			"Allow Load Local Infile=True;Allow Public Key Retrieval=True;Allow User Variables=True;" +
@@ -518,6 +521,7 @@ public class MySqlConnectionStringBuilderTests
 	[InlineData("SSL Key", "C:\\key.pem")]
 
 	// not supported
+	[InlineData("Allow Unknown Certificate Revocation", true)]
 	[InlineData("Application Name", "MyApp")]
 	[InlineData("Cancellation Timeout", 5)]
 	[InlineData("Connection Idle Timeout", 10u)]

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -19,7 +19,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Null(csb.CertificatePassword);
 		Assert.Null(csb.CertificateThumbprint);
 #else
-		Assert.False(csb.AllowUnknownCertificateRevocation);
+		Assert.False(csb.SkipCertificateRevocationCheck);
 		Assert.Equal(2, csb.CancellationTimeout);
 		Assert.Equal("", csb.CertificateFile);
 		Assert.Equal("", csb.CertificatePassword);
@@ -123,7 +123,7 @@ public class MySqlConnectionStringBuilderTests
 #endif
 				"default command timeout=123;" +
 #if !MYSQL_DATA
-				"allow unknown certificate revocation=true;" +
+				"skip certificate revocation check=true;" +
 				"application name=My Test Application;" +
 				"cancellation timeout = -1;" +
 				"connectionidletimeout=30;" +
@@ -187,7 +187,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Equal("schema_name", csb.Database);
 		Assert.Equal(123u, csb.DefaultCommandTimeout);
 #if !MYSQL_DATA
-		Assert.True(csb.AllowUnknownCertificateRevocation);
+		Assert.True(csb.SkipCertificateRevocationCheck);
 		Assert.Equal("My Test Application", csb.ApplicationName);
 		Assert.Equal(30u, csb.ConnectionIdleTimeout);
 #pragma warning disable 618
@@ -236,7 +236,7 @@ public class MySqlConnectionStringBuilderTests
 		Assert.Equal("Server=db-server;Port=1234;User ID=username;Password=Pass1234;Database=schema_name;Load Balance=Random;" +
 			"Connection Protocol=Pipe;Pipe Name=MyPipe;SSL Mode=VerifyFull;Certificate File=file.pfx;Certificate Password=Pass2345;" +
 			"Certificate Store Location=CurrentUser;Certificate Thumbprint=thumbprint123;SSL Cert=client-cert.pem;SSL Key=client-key.pem;" +
-			"SSL CA=ca.pem;Allow Unknown Certificate Revocation=True;TLS Version=\"TLS 1.2, TLS 1.3\";TLS Cipher Suites=TLS_AES_128_CCM_8_SHA256,TLS_RSA_WITH_RC4_128_MD5;" +
+			"SSL CA=ca.pem;Skip Certificate Revocation Check=True;TLS Version=\"TLS 1.2, TLS 1.3\";TLS Cipher Suites=TLS_AES_128_CCM_8_SHA256,TLS_RSA_WITH_RC4_128_MD5;" +
 			"Pooling=False;Connection Lifetime=15;Connection Reset=False;Defer Connection Reset=True;Connection Idle Timeout=30;" +
 			"Minimum Pool Size=5;Maximum Pool Size=15;DNS Check Interval=15;" +
 			"Allow Load Local Infile=True;Allow Public Key Retrieval=True;Allow User Variables=True;" +
@@ -521,7 +521,7 @@ public class MySqlConnectionStringBuilderTests
 	[InlineData("SSL Key", "C:\\key.pem")]
 
 	// not supported
-	[InlineData("Allow Unknown Certificate Revocation", true)]
+	[InlineData("Skip Certificate Revocation Check", true)]
 	[InlineData("Application Name", "MyApp")]
 	[InlineData("Cancellation Timeout", 5)]
 	[InlineData("Connection Idle Timeout", 10u)]

--- a/tests/SkipCrl/Client.Dockerfile
+++ b/tests/SkipCrl/Client.Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+WORKDIR /src
+COPY . .
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && cp /src/tests/SkipCrl/generated/ca-cert.pem /usr/local/share/ca-certificates/mysqlconnector-skipcrl-ca.crt \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+ENV CRL_CA_CERT=/src/tests/SkipCrl/generated/ca-cert.pem
+ENV CRL_SERVER_CERT=/src/tests/SkipCrl/generated/server-cert.pem
+ENV CRL_USE_TRUST_STORE=true
+CMD ["dotnet", "./tests/SkipCrl/SkipCrl.cs"]

--- a/tests/SkipCrl/MySql.Dockerfile
+++ b/tests/SkipCrl/MySql.Dockerfile
@@ -1,0 +1,8 @@
+FROM mysql:9.7
+COPY generated/ca-cert.pem /etc/mysql/certs/ca-cert.pem
+COPY generated/server-cert.pem /etc/mysql/certs/server-cert.pem
+COPY generated/server-key.pem /etc/mysql/certs/server-key.pem
+RUN chown mysql:mysql /etc/mysql/certs/ca-cert.pem /etc/mysql/certs/server-cert.pem /etc/mysql/certs/server-key.pem \
+ && chmod 600 /etc/mysql/certs/server-key.pem \
+ && chmod 644 /etc/mysql/certs/ca-cert.pem /etc/mysql/certs/server-cert.pem
+CMD ["mysqld", "--ssl-ca=/etc/mysql/certs/ca-cert.pem", "--ssl-cert=/etc/mysql/certs/server-cert.pem", "--ssl-key=/etc/mysql/certs/server-key.pem", "--require_secure_transport=ON"]

--- a/tests/SkipCrl/README.md
+++ b/tests/SkipCrl/README.md
@@ -1,0 +1,9 @@
+# Skip CRL repro
+
+From the repo root, run:
+
+```powershell
+.\tests\SkipCrl\setup.ps1
+.\tests\SkipCrl\repro.ps1
+.\tests\SkipCrl\teardown.ps1
+```

--- a/tests/SkipCrl/SkipCrl.cs
+++ b/tests/SkipCrl/SkipCrl.cs
@@ -1,0 +1,127 @@
+#:property TargetFramework=net10.0
+#:property ManagePackageVersionsCentrally=false
+#:property PackAsTool=false
+#:property PublishAot=false
+#:project ../../src/MySqlConnector/MySqlConnector.csproj
+
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using MySqlConnector;
+
+var configuredConnectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION_STRING");
+var caCertificatePath = Environment.GetEnvironmentVariable("CRL_CA_CERT") ??
+	Path.Combine(Environment.CurrentDirectory, "tests", "SkipCrl", "generated", "ca-cert.pem");
+var serverCertificatePath = Environment.GetEnvironmentVariable("CRL_SERVER_CERT") ??
+	Path.Combine(Environment.CurrentDirectory, "tests", "SkipCrl", "generated", "server-cert.pem");
+var useTrustStore = string.Equals(Environment.GetEnvironmentVariable("CRL_USE_TRUST_STORE"), "true", StringComparison.OrdinalIgnoreCase);
+
+var baseConnectionStringBuilder = string.IsNullOrWhiteSpace(configuredConnectionString) ?
+	new MySqlConnectionStringBuilder
+	{
+		Server = "localhost",
+		Port = 3308,
+		UserID = "root",
+		Password = "pass",
+		Database = "mysql",
+		Pooling = false,
+		ConnectionTimeout = 10,
+	} :
+	new MySqlConnectionStringBuilder(configuredConnectionString);
+
+if (!useTrustStore && string.IsNullOrWhiteSpace(baseConnectionStringBuilder.SslCa))
+	baseConnectionStringBuilder.SslCa = caCertificatePath;
+
+Console.WriteLine($"Using trust store: {useTrustStore}");
+Console.WriteLine($"CA certificate: {caCertificatePath}");
+Console.WriteLine($"CA certificate exists: {File.Exists(caCertificatePath)}");
+Console.WriteLine($"Server certificate: {serverCertificatePath}");
+Console.WriteLine($"Server certificate exists: {File.Exists(serverCertificatePath)}");
+Console.WriteLine($"Base connection string: {baseConnectionStringBuilder.ConnectionString}");
+Console.WriteLine();
+
+var onlineChainSucceeded = RunChainCheck(caCertificatePath, serverCertificatePath, X509RevocationMode.Online);
+Console.WriteLine();
+var noCheckChainSucceeded = RunChainCheck(caCertificatePath, serverCertificatePath, X509RevocationMode.NoCheck);
+Console.WriteLine();
+
+var verifyCaSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyCA);
+Console.WriteLine();
+var verifyFullSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull);
+
+Console.WriteLine();
+Console.WriteLine($"VerifyFull succeeded on this runtime: {verifyFullSucceeded}");
+Environment.ExitCode = !onlineChainSucceeded && noCheckChainSucceeded && verifyCaSucceeded ? 0 : 1;
+
+static bool RunChainCheck(string caCertificatePath, string serverCertificatePath, X509RevocationMode revocationMode)
+{
+	Console.WriteLine($"=== X509Chain ({revocationMode}) ===");
+
+#if NET9_0_OR_GREATER
+	using var caCertificate = X509CertificateLoader.LoadCertificateFromFile(caCertificatePath);
+	using var serverCertificate = X509CertificateLoader.LoadCertificateFromFile(serverCertificatePath);
+#else
+	using var caCertificate = new X509Certificate2(caCertificatePath);
+	using var serverCertificate = new X509Certificate2(serverCertificatePath);
+#endif
+
+	using var chain = new X509Chain();
+	chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+	chain.ChainPolicy.CustomTrustStore.Add(caCertificate);
+	chain.ChainPolicy.RevocationMode = revocationMode;
+
+	var success = chain.Build(serverCertificate);
+	Console.WriteLine($"Build succeeded: {success}");
+
+	for (var index = 0; index < chain.ChainElements.Count; index++)
+	{
+		var element = chain.ChainElements[index];
+		Console.WriteLine($"Element {index}: {element.Certificate.Subject}");
+		foreach (var status in element.ChainElementStatus)
+			Console.WriteLine($"  {status.Status}: {status.StatusInformation.Trim()}");
+	}
+
+	return success;
+}
+
+static async Task<bool> TryOpenAsync(MySqlConnectionStringBuilder baseConnectionStringBuilder, MySqlSslMode sslMode)
+{
+	var connectionStringBuilder = new MySqlConnectionStringBuilder(baseConnectionStringBuilder.ConnectionString)
+	{
+		SslMode = sslMode,
+	};
+
+	Console.WriteLine($"=== {sslMode} ===");
+	Console.WriteLine(connectionStringBuilder.ConnectionString);
+
+	await using var connection = new MySqlConnection(connectionStringBuilder.ConnectionString);
+	try
+	{
+		await connection.OpenAsync();
+		await using var command = new MySqlCommand("SELECT VERSION();", connection);
+		var serverVersion = (string) (await command.ExecuteScalarAsync())!;
+		Console.WriteLine($"Connected successfully. Version={serverVersion}");
+		return true;
+	}
+	catch (Exception ex)
+	{
+		Console.WriteLine("Connection failed:");
+		WriteException(ex, 0);
+		return false;
+	}
+}
+
+static void WriteException(Exception ex, int depth)
+{
+	var indent = new string(' ', depth * 2);
+	Console.WriteLine($"{indent}{ex.GetType().FullName}: {ex.Message}");
+
+	if (ex is AuthenticationException authenticationException &&
+		authenticationException.InnerException is not null)
+	{
+		WriteException(authenticationException.InnerException, depth + 1);
+		return;
+	}
+
+	if (ex.InnerException is not null)
+		WriteException(ex.InnerException, depth + 1);
+}

--- a/tests/SkipCrl/SkipCrl.cs
+++ b/tests/SkipCrl/SkipCrl.cs
@@ -46,11 +46,18 @@ Console.WriteLine();
 
 var verifyCaSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyCA);
 Console.WriteLine();
-var verifyFullSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull);
+var verifyFullWithoutOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, allowUnknownCertificateRevocation: false);
+Console.WriteLine();
+var verifyFullWithOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, allowUnknownCertificateRevocation: true);
 
 Console.WriteLine();
-Console.WriteLine($"VerifyFull succeeded on this runtime: {verifyFullSucceeded}");
-Environment.ExitCode = !onlineChainSucceeded && noCheckChainSucceeded && verifyCaSucceeded ? 0 : 1;
+Console.WriteLine($"VerifyFull without AllowUnknownCertificateRevocation succeeded: {verifyFullWithoutOverrideSucceeded}");
+Console.WriteLine($"VerifyFull with AllowUnknownCertificateRevocation succeeded: {verifyFullWithOverrideSucceeded}");
+Environment.ExitCode = !onlineChainSucceeded &&
+	noCheckChainSucceeded &&
+	verifyCaSucceeded &&
+	!verifyFullWithoutOverrideSucceeded &&
+	verifyFullWithOverrideSucceeded ? 0 : 1;
 
 static bool RunChainCheck(string caCertificatePath, string serverCertificatePath, X509RevocationMode revocationMode)
 {
@@ -83,14 +90,15 @@ static bool RunChainCheck(string caCertificatePath, string serverCertificatePath
 	return success;
 }
 
-static async Task<bool> TryOpenAsync(MySqlConnectionStringBuilder baseConnectionStringBuilder, MySqlSslMode sslMode)
+static async Task<bool> TryOpenAsync(MySqlConnectionStringBuilder baseConnectionStringBuilder, MySqlSslMode sslMode, bool allowUnknownCertificateRevocation = false)
 {
 	var connectionStringBuilder = new MySqlConnectionStringBuilder(baseConnectionStringBuilder.ConnectionString)
 	{
 		SslMode = sslMode,
+		AllowUnknownCertificateRevocation = allowUnknownCertificateRevocation,
 	};
 
-	Console.WriteLine($"=== {sslMode} ===");
+	Console.WriteLine($"=== {sslMode} (AllowUnknownCertificateRevocation={allowUnknownCertificateRevocation}) ===");
 	Console.WriteLine(connectionStringBuilder.ConnectionString);
 
 	await using var connection = new MySqlConnection(connectionStringBuilder.ConnectionString);

--- a/tests/SkipCrl/SkipCrl.cs
+++ b/tests/SkipCrl/SkipCrl.cs
@@ -46,13 +46,13 @@ Console.WriteLine();
 
 var verifyCaSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyCA);
 Console.WriteLine();
-var verifyFullWithoutOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, allowUnknownCertificateRevocation: false);
+var verifyFullWithoutOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, skipCertificateRevocationCheck: false);
 Console.WriteLine();
-var verifyFullWithOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, allowUnknownCertificateRevocation: true);
+var verifyFullWithOverrideSucceeded = await TryOpenAsync(baseConnectionStringBuilder, MySqlSslMode.VerifyFull, skipCertificateRevocationCheck: true);
 
 Console.WriteLine();
-Console.WriteLine($"VerifyFull without AllowUnknownCertificateRevocation succeeded: {verifyFullWithoutOverrideSucceeded}");
-Console.WriteLine($"VerifyFull with AllowUnknownCertificateRevocation succeeded: {verifyFullWithOverrideSucceeded}");
+Console.WriteLine($"VerifyFull without SkipCertificateRevocationCheck succeeded: {verifyFullWithoutOverrideSucceeded}");
+Console.WriteLine($"VerifyFull with SkipCertificateRevocationCheck succeeded: {verifyFullWithOverrideSucceeded}");
 Environment.ExitCode = !onlineChainSucceeded &&
 	noCheckChainSucceeded &&
 	verifyCaSucceeded &&
@@ -90,15 +90,15 @@ static bool RunChainCheck(string caCertificatePath, string serverCertificatePath
 	return success;
 }
 
-static async Task<bool> TryOpenAsync(MySqlConnectionStringBuilder baseConnectionStringBuilder, MySqlSslMode sslMode, bool allowUnknownCertificateRevocation = false)
+static async Task<bool> TryOpenAsync(MySqlConnectionStringBuilder baseConnectionStringBuilder, MySqlSslMode sslMode, bool skipCertificateRevocationCheck = false)
 {
 	var connectionStringBuilder = new MySqlConnectionStringBuilder(baseConnectionStringBuilder.ConnectionString)
 	{
 		SslMode = sslMode,
-		AllowUnknownCertificateRevocation = allowUnknownCertificateRevocation,
+		SkipCertificateRevocationCheck = skipCertificateRevocationCheck,
 	};
 
-	Console.WriteLine($"=== {sslMode} (AllowUnknownCertificateRevocation={allowUnknownCertificateRevocation}) ===");
+	Console.WriteLine($"=== {sslMode} (SkipCertificateRevocationCheck={skipCertificateRevocationCheck}) ===");
 	Console.WriteLine(connectionStringBuilder.ConnectionString);
 
 	await using var connection = new MySqlConnection(connectionStringBuilder.ConnectionString);

--- a/tests/SkipCrl/repro.ps1
+++ b/tests/SkipCrl/repro.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent (Split-Path -Parent $scriptRoot)
+$generatedDir = Join-Path $scriptRoot 'generated'
+$containerName = 'mysqlconnector-skipcrl'
+$imageName = 'mysqlconnector-skipcrl-client'
+
+if (-not (Test-Path (Join-Path $generatedDir 'ca-cert.pem')))
+{
+	throw 'Run .\tests\SkipCrl\setup.ps1 first.'
+}
+
+$containerStatus = docker ps --filter "name=^$containerName$" --format '{{.Names}}'
+if (@($containerStatus | Where-Object { $_ -eq $containerName }).Count -ne 1)
+{
+	throw 'MySQL container is not running. Run .\tests\SkipCrl\setup.ps1 first.'
+}
+
+docker image rm $imageName 2>$null | Out-Null
+docker build --quiet -f (Join-Path $scriptRoot 'Client.Dockerfile') -t $imageName $repoRoot | Out-Null
+docker run --rm `
+	-e "MYSQL_CONNECTION_STRING=Server=host.docker.internal;Port=3308;User ID=root;Password=pass;Database=mysql;Pooling=false;Connection Timeout=10" `
+	$imageName

--- a/tests/SkipCrl/server-cert.cnf
+++ b/tests/SkipCrl/server-cert.cnf
@@ -1,0 +1,18 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = localhost
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment, digitalSignature
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = host.docker.internal
+DNS.3 = mysqlconnector-skipcrl
+IP.1 = 127.0.0.1

--- a/tests/SkipCrl/setup.ps1
+++ b/tests/SkipCrl/setup.ps1
@@ -1,0 +1,101 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$generatedDir = Join-Path $scriptRoot 'generated'
+$containerName = 'mysqlconnector-skipcrl'
+$imageName = 'mysqlconnector-skipcrl-server'
+$port = 3308
+
+function Get-OpenSslPath
+{
+	$command = Get-Command openssl -ErrorAction SilentlyContinue
+	if ($command)
+	{
+		return $command.Source
+	}
+
+	$gitOpenSsl = 'C:\Program Files\Git\usr\bin\openssl.exe'
+	if (Test-Path $gitOpenSsl)
+	{
+		return $gitOpenSsl
+	}
+
+	throw 'OpenSSL was not found. Install it or use Git for Windows.'
+}
+
+function Wait-ForMySql
+{
+	param(
+		[string] $ContainerName,
+		[int] $Attempts = 60
+	)
+
+	for ($attempt = 0; $attempt -lt $Attempts; $attempt++)
+	{
+		$logs = docker logs $ContainerName 2>&1 | Out-String
+		if ($logs -match 'Channel mysql_main configured to support TLS' -and
+			$logs -match 'ready for connections')
+		{
+			return
+		}
+
+		Start-Sleep -Seconds 1
+	}
+
+	throw "MySQL container '$ContainerName' did not become ready."
+}
+
+$openSsl = Get-OpenSslPath
+
+New-Item -ItemType Directory -Force -Path $generatedDir | Out-Null
+Remove-Item -Force `
+	(Join-Path $generatedDir 'ca-key.pem'), `
+	(Join-Path $generatedDir 'ca-cert.pem'), `
+	(Join-Path $generatedDir 'ca-cert.srl'), `
+	(Join-Path $generatedDir 'server-key.pem'), `
+	(Join-Path $generatedDir 'server.csr'), `
+	(Join-Path $generatedDir 'server-cert.pem') `
+	-ErrorAction SilentlyContinue
+
+& $openSsl genrsa -out (Join-Path $generatedDir 'ca-key.pem') 4096
+& $openSsl req -x509 -new -nodes `
+	-key (Join-Path $generatedDir 'ca-key.pem') `
+	-sha256 -days 3650 `
+	-out (Join-Path $generatedDir 'ca-cert.pem') `
+	-subj '/C=US/ST=WA/L=Seattle/O=MySqlConnector/CN=MySqlConnector Skip CRL Test CA'
+& $openSsl genrsa -out (Join-Path $generatedDir 'server-key.pem') 2048
+& $openSsl req -new `
+	-key (Join-Path $generatedDir 'server-key.pem') `
+	-out (Join-Path $generatedDir 'server.csr') `
+	-config (Join-Path $scriptRoot 'server-cert.cnf')
+& $openSsl x509 -req `
+	-in (Join-Path $generatedDir 'server.csr') `
+	-CA (Join-Path $generatedDir 'ca-cert.pem') `
+	-CAkey (Join-Path $generatedDir 'ca-key.pem') `
+	-CAcreateserial `
+	-out (Join-Path $generatedDir 'server-cert.pem') `
+	-days 365 `
+	-sha256 `
+	-extensions v3_req `
+	-extfile (Join-Path $scriptRoot 'server-cert.cnf')
+
+& $openSsl verify `
+	-CAfile (Join-Path $generatedDir 'ca-cert.pem') `
+	(Join-Path $generatedDir 'server-cert.pem')
+
+docker rm -f $containerName 2>$null | Out-Null
+docker image rm $imageName 2>$null | Out-Null
+
+docker build --quiet -f (Join-Path $scriptRoot 'MySql.Dockerfile') -t $imageName $scriptRoot | Out-Null
+docker run --rm -d `
+	--name $containerName `
+	-e MYSQL_ROOT_PASSWORD=pass `
+	-e MYSQL_ROOT_HOST=% `
+	-p "${port}:3306" `
+	$imageName | Out-Null
+
+Wait-ForMySql -ContainerName $containerName
+
+Write-Host ''
+Write-Host "Skip CRL server is ready on port $port."
+Write-Host "Next: .\\tests\\SkipCrl\\repro.ps1"

--- a/tests/SkipCrl/teardown.ps1
+++ b/tests/SkipCrl/teardown.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$generatedDir = Join-Path $scriptRoot 'generated'
+
+docker rm -f mysqlconnector-skipcrl 2>$null | Out-Null
+docker image rm mysqlconnector-skipcrl-server mysqlconnector-skipcrl-client 2>$null | Out-Null
+
+if (Test-Path $generatedDir)
+{
+	Remove-Item -Recurse -Force $generatedDir
+}
+
+Write-Host 'Skip CRL repro cleaned up.'


### PR DESCRIPTION
Contains the changes from #1638, rebased on the latest master branch.

This PR adds an additional commit that logs the full error chain at Trace level, which is pretty critical to fully see what `SslStream` returns.
Also addressed the concern at https://github.com/mysql-net/MySqlConnector/pull/1638#discussion_r3185718034, which I believe is valid.

Compared to #1637, this PR _doesn't_ include changes for client certificates (mutual TLS). Our cloud broker [doesn't support it](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-mysql-tanzu-platform/10-4/mysql-tp/using-tls.html), so I'm unable to test that part.

Fixes #1615.