### PR TITLE
Clarify EOL status for MySQL 8.0

### DIFF
--- a/docs/content/home.md
+++ b/docs/content/home.md
@@ -65,7 +65,7 @@ Amazon Aurora RDS | 2.x, 3.x | Use `Pipelining=False` [for Aurora 2.x](https://m
 Azure Database for MySQL | 5.7, 8.0 | Single Server and Flexible Server
 Google Cloud SQL for MySQL | 5.6, 5.7, 8.0 |
 MariaDB | 10.x (**10.6**, **10.11**), 11.x (**11.4**, **11.8**) |
-MySQL | 5.5, 5.6, 5.7, 8.x (**8.0**, **8.4**), 9.x (**9.4**, **9.7**) | 5.5 is EOL and has some [compatibility issues](https://github.com/mysql-net/MySqlConnector/issues/1192); 5.6 and 5.7 are EOL
+MySQL | 5.5, 5.6, 5.7, 8.x (**8.0**, **8.4**), 9.x (**9.4**, **9.7**) | 5.5 is EOL and has some [compatibility issues](https://github.com/mysql-net/MySqlConnector/issues/1192); 5.6, 5.7 and 8.0 are EOL
 Percona Server | 5.6, 5.7, 8.0 |
 PlanetScale | | See PlanetScale [MySQL compatibility notes](https://planetscale.com/docs/reference/mysql-compatibility)
 ProxySQL | 2.x | Some [compatibility issues](https://github.com/search?q=repo%3Amysql-net%2FMySqlConnector+proxysql&type=issues)


### PR DESCRIPTION
See https://dev.mysql.com/doc/relnotes/mysql/8.0/en/

Note: 9.4 is listed as still tested, although it is not a LTS release nor receiving any kind of updates anymore. It might make sense to test just 9.7 from the 9.x series?